### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report a bug or unexpected behavior in Aspid.FastTools.
+labels: ["type: fix"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong? What did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so the bug can be reproduced locally.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: unity-version
+    attributes:
+      label: Unity version
+      placeholder: "2022.3.x"
+    validations:
+      required: true
+  - type: input
+    id: package-version
+    attributes:
+      label: Aspid.FastTools version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, related issues — anything that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and ideas
+    url: https://github.com/VPDPersonal/Aspid.FastTools/discussions
+    about: Open-ended questions, design ideas and Q&A go in Discussions, not Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest a new capability or improvement for Aspid.FastTools.
+labels: ["type: feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Who is it for?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Sketch of the API or behavior you'd like — code examples are welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Other approaches you considered, and why this one is preferred.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. -->
+
+## Notes for review
+
+<!-- Optional: things you specifically want eyes on, trade-offs you considered, or risks. Delete this section if not applicable. -->
+
+## Linked issues
+
+<!-- Closes #N, Refs #N. Delete this section if not applicable. -->


### PR DESCRIPTION
Adds form-based issue templates and a short PR template so that bug reports and feature requests collect the minimum information needed up-front.

### Files

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — required fields: description, repro steps, Unity version, package version. Auto-applies the `type: fix` label.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — required fields: problem, proposal. Optional: alternatives, additional context. Auto-applies the `type: feature` label.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and routes open-ended questions to GitHub Discussions.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — short three-section scaffold (Summary / Notes for review / Linked issues), all sections optional.

Templates land on `main` so they're picked up immediately by GitHub for new issues / PRs without waiting for the 1.0 release merge.