### PR TITLE
Rename gradient-button USS custom properties to use underscore separator

### DIFF
--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Unity/Editor/Resources/UI/Components/Aspid-FastTools-AspidGradientButton.uss
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Unity/Editor/Resources/UI/Components/Aspid-FastTools-AspidGradientButton.uss
@@ -11,8 +11,8 @@
     -unity-font-style:                                  bold;
     -unity-text-align:                                  middle-left;
 
-    --aspid-fasttools-colors-gradient-button-bg:        var(--aspid-colors-bg-darkness);
-    --aspid-fasttools-colors-gradient-button-accent:    var(--aspid-colors-status-success-text-dark);
+    --aspid-fasttools-colors-gradient_button-bg:        var(--aspid-colors-bg-darkness);
+    --aspid-fasttools-colors-gradient_button-accent:    var(--aspid-colors-status-success-text-dark);
 }
 
 .aspid-fasttools-gradient-button__trailing-label {

--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/Styles/AspidGradientButtonColorsStyle.cs
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/Styles/AspidGradientButtonColorsStyle.cs
@@ -15,12 +15,12 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         /// <summary>
         /// Custom USS property for overriding the gradient background color via USS.
         /// </summary>
-        public static readonly CustomStyleProperty<Color> GradientProperty = new("--aspid-fasttools-colors-gradient-button-bg");
+        public static readonly CustomStyleProperty<Color> GradientProperty = new("--aspid-fasttools-colors-gradient_button-bg");
 
         /// <summary>
         /// Custom USS property for overriding the accent (hover) color via USS.
         /// </summary>
-        public static readonly CustomStyleProperty<Color> AccentProperty = new("--aspid-fasttools-colors-gradient-button-accent");
+        public static readonly CustomStyleProperty<Color> AccentProperty = new("--aspid-fasttools-colors-gradient_button-accent");
 
         private readonly InlineStyle<Color> _gradient;
         private readonly InlineStyle<Color> _accent;


### PR DESCRIPTION
## Summary

- Rename USS custom properties `--aspid-fasttools-colors-gradient-button-{bg,accent}` to `--aspid-fasttools-colors-gradient_button-{bg,accent}` so the compound `gradient_button` role uses `_` as the intra-slot separator (matches the positional grammar in CLAUDE.md → "USS variable naming").
- Update the matching `CustomStyleProperty<Color>` registrations in `AspidGradientButtonColorsStyle.cs` so USS resolution still binds to the renamed properties.
