### PR TITLE
Fix IdStruct generator crash on unrecognised TypeKind values

### DIFF
--- a/Aspid.FastTools.Generators/Aspid.FastTools.Generators/Generators/IdStruct/Data/IdStructData.cs
+++ b/Aspid.FastTools.Generators/Aspid.FastTools.Generators/Generators/IdStruct/Data/IdStructData.cs
@@ -64,7 +64,7 @@ internal readonly struct IdStructData : IEquatable<IdStructData>
             TypeKind.Class => "class",
             TypeKind.Struct => "struct",
             TypeKind.Interface => "interface",
-            _ => throw new InvalidOperationException($"Unsupported containing type kind: {symbol.TypeKind}"),
+            _ => "class",
         };
     }
 


### PR DESCRIPTION
## Summary

- Replace the `throw new InvalidOperationException(...)` in `IdStructData.GetKeyword`'s switch expression with a safe `"class"` fallback so the generator no longer crashes with an unhandled exception when a containing type's `TypeKind` is not `Class`, `Struct`, or `Interface` (e.g. `TypeKind.Module`, `TypeKind.Submission`, or unknown values from future Roslyn versions).
- The fallback matches the natural choice for an unidentified containing type — emitting a `partial class` wrapper is correct for any non-struct/interface reference type and degrades gracefully instead of failing the build.

```csharp
return symbol.TypeKind switch
{
    TypeKind.Class => "class",
    TypeKind.Struct => "struct",
    TypeKind.Interface => "interface",
    _ => "class",
};
```

## Notes for review

- I rebased `claude/fix-getkeyword-fallback-ofRvm` onto `Develop` because `IdStructData.cs` only exists on `Develop`; the branch was originally cut from `main`, which doesn't contain the generator solution.
- I couldn't run `dotnet build` / `dotnet test` locally (no dotnet in this sandbox), so generator-side verification is left to CI.