### PR TITLE
Drop Aspid.Internal.Unity refs and bump README badge to Unity 6

### DIFF
--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/README.md
@@ -14,8 +14,7 @@
 Install Aspid.FastTools using one of the following methods:
 
 - **Download .unitypackage** — Visit the [Release page on GitHub](https://github.com/VPDPersonal/Aspid.FastTools/releases) and download the latest version, `Aspid.FastTools.X.X.X.unitypackage`. Import it into your project.
-- **Via UPM** (Unity Package Manager) integrate the following packages:
-  - `https://github.com/VPDPersonal/Aspid.Internal.Unity.git`
+- **Via UPM** (Unity Package Manager) integrate the following package:
   - `https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Plugins/Aspid/FastTools`
 
 ---

--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/RU/README.md
@@ -14,8 +14,7 @@
 Установите Aspid.FastTools одним из следующих способов:
 
 - **Скачать .unitypackage** — Перейдите на [страницу релизов GitHub](https://github.com/VPDPersonal/Aspid.FastTools/releases) и скачайте последнюю версию `Aspid.FastTools.X.X.X.unitypackage`. Импортируйте его в проект.
-- **Через UPM** (Unity Package Manager) подключите следующие пакеты:
-  - `https://github.com/VPDPersonal/Aspid.Internal.Unity.git`
+- **Через UPM** (Unity Package Manager) подключите следующий пакет:
   - `https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Plugins/Aspid/FastTools`
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,10 +168,6 @@ All palette variables in `Aspid-FastTools-Default-Dark.uss` already follow this 
 - **Project skills** (`.claude/skills/`): `build-generator` (manual generator build + DLL deploy), `sync-readmes` (verify README EN/RU + root/Documentation copies against the codebase), `open-pr` (project conventions for opening pull requests — see *Pull request conventions* below).
 - **Project subagents** (`.claude/agents/`): `code-reviewer` (Unity/Editor boundary + generator + package convention review), `uss-bem-checker` (validates USS class names + `--aspid-*` variables against the BEM/positional grammars above).
 
-### Submodule
-
-`Aspid.Internal.Unity` is a git submodule providing internal Unity helpers. It is referenced but not part of the main package distribution.
-
 ## Pull request conventions
 
 When opening a PR — manually or via `@claude` — invoke the `open-pr` skill (`.claude/skills/open-pr/SKILL.md`) for the full procedure. Quick reference:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aspid.FastTools
 
-[![Unity 2022.3+](https://img.shields.io/badge/2022.3%2B-000000?style=flat&logo=unity&logoColor=white&color=4fa35d)](https://unity.com/)
+[![Unity 6](https://img.shields.io/badge/Unity_6-000000?style=flat&logo=unity&logoColor=white&color=4fa35d)](https://unity.com/)
 [![Releases](https://img.shields.io/github/v/release/VPDPersonal/Aspid.FastTools?label=Release&labelColor=254d2c&color=4fa35d)](https://github.com/VPDPersonal/Aspid.FastTools/releases)
 [![License](https://img.shields.io/github/license/VPDPersonal/Aspid.FastTools?label=License&labelColor=254d2c&color=4fa35d)](LICENSE)
 
@@ -13,8 +13,7 @@
 Install Aspid.FastTools using one of the following methods:
 
 - **Download .unitypackage** — Visit the [Release page on GitHub](https://github.com/VPDPersonal/Aspid.FastTools/releases) and download the latest version, `Aspid.FastTools.X.X.X.unitypackage`. Import it into your project.
-- **Via UPM** (Unity Package Manager) integrate the following packages:
-  - `https://github.com/VPDPersonal/Aspid.Internal.Unity.git`
+- **Via UPM** (Unity Package Manager) integrate the following package:
   - `https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Plugins/Aspid/FastTools`
 
 ---

--- a/README_RU.md
+++ b/README_RU.md
@@ -9,8 +9,7 @@
 Установите Aspid.FastTools одним из следующих способов:
 
 - **Скачать .unitypackage** — Перейдите на [страницу релизов GitHub](https://github.com/VPDPersonal/Aspid.FastTools/releases) и скачайте последнюю версию `Aspid.FastTools.X.X.X.unitypackage`. Импортируйте его в проект.
-- **Через UPM** (Unity Package Manager) подключите следующие пакеты:
-  - `https://github.com/VPDPersonal/Aspid.Internal.Unity.git`
+- **Через UPM** (Unity Package Manager) подключите следующий пакет:
   - `https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Plugins/Aspid/FastTools`
 
 ---


### PR DESCRIPTION
## Summary

- Remove the stale `https://github.com/VPDPersonal/Aspid.Internal.Unity.git` UPM bullet from all four README copies (root EN/RU and `Documentation/EN/RU`); the package no longer ships with that submodule, so users were being told to install a repo that is irrelevant to integration.
- Drop the matching `### Submodule` paragraph from `CLAUDE.md` for the same reason — the `.gitmodules` only references `Aspid.FastTools.Claude` now.
- Update the Unity badge in the root `README.md` from `2022.3+` to `Unity 6` per the new minimum supported editor version.

## Notes for review

- `Preview/Announcements-v1.0.md` intentionally still mentions the old URL — that file is a draft of the historical 1.0 release announcement and stays as-is.
- `package.json` still pins `"unity": "2022.3"`. Only the README badge was requested to change; bumping the package manifest can ride a separate PR if that minimum is being raised in practice.