### PR TITLE
Extend open-pr skill and add commit-and-open-pr skill

### DIFF
--- a/.claude/skills/commit-and-open-pr/SKILL.md
+++ b/.claude/skills/commit-and-open-pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: commit-and-open-pr
+description: Aspid.FastTools-specific overrides for `/commit-and-open-pr` — Samples~ caveats, generator-DLL handling, README-sync prompt, base-branch default `Develop`, English-only PR/commit content, and SSH-key persistence per branch. Inherits the universal recipe from `~/.claude/skills/commit-and-open-pr/SKILL.md`. Use whenever the user asks to "commit and open PR", "закоммить и открой пр", `/commit-and-open-pr`, or otherwise wants the one-shot commit-push-PR flow inside this repo.
+user-invocable: true
+---
+
+# commit-and-open-pr (Aspid.FastTools overrides)
+
+This is the project-scoped variant. The full universal procedure lives in `~/.claude/skills/commit-and-open-pr/SKILL.md`. Follow it, then apply the project-specific rules below — they take precedence on any conflict.
+
+## Pre-flight
+
+In addition to the universal pre-flight (`git status --porcelain`, `git diff --stat`, `git diff --staged --stat`):
+
+- **Samples~/.** Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely appear / disappear because Unity Package Manager imports samples into the working tree. They are local artefacts. The `commit` skill already filters them out unless the user said the commit is about samples — trust that filter; do not pre-stage `Samples~/*` here.
+- **Generator DLL.** If `git status` shows changes to `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Aspid.FastTools.Generators.dll` but **no** `*.cs` change under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/`, that means a previous unrelated generator edit deployed the DLL. Surface this to the user before committing — usually the right call is to leave the DLL out of this PR.
+- **README sync.** If the diff touches a feature that has a page in `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/` or `…/RU/` (e.g. namespace rename, public API change, new `CreateAssetMenu` path) and the four README files are unchanged, run `AskUserQuestion` offering "запустить /sync-readmes сейчас?". If the user agrees, invoke the `sync-readmes` skill before continuing.
+
+## Commit
+
+Delegate to the project-scoped `commit` skill — title style "short bare imperatives, no Conventional Commits prefix", **English-only** content (even when chat is in Russian, per `feedback_github_content_english`), Samples~ caveat, no Claude/Anthropic Co-Authored-By.
+
+## Push
+
+Universal push step. Persisted `branch.<name>.sshCommand` for this repo is typically `ssh -i ~/.ssh/vpd_personal_my_macbook -o IdentitiesOnly=yes` (matches `~/.ssh/config` `IdentityFile` for `github.com`). If recovery picks a different key for a specific branch (e.g. a fork or co-authored remote), persist it per the universal flow — do not change the global `~/.ssh/config`.
+
+## Open PR
+
+Delegate to the project-scoped `open-pr` skill:
+
+- Base defaults to `Develop` (or `main` for release-cut PRs).
+- Required labels: exactly one `type: *`, ≥1 `area: *` (`runtime` / `editor` / `generator` / `samples`), one `status: *` (default `work-in-progress`).
+- Default is `--draft` + `status: work-in-progress` unless the user said the PR is ready.
+- Missing-label flow: propose creating new labels via `gh label create`, but only after user confirmation of name + colour + description. Reuse the palette listed in the project `open-pr` skill.
+
+## Report
+
+In addition to the universal report fields, include:
+
+- Whether the generator DLL was part of the commit (`yes` / `no — kept out`).
+- Whether the README sync prompt was offered and what the user picked.
+- The persisted `branch.<name>.sshCommand` if any new value was written.
+
+## Hard rules (project additions)
+
+- **English on GitHub.** Commit messages, PR title, PR body, PR labels — all English. The chat may be in Russian; persisted GitHub content is not.
+- **Never include `Samples~/` paths in a feature PR** unless the user explicitly opted in.
+- **Never run `dotnet build` manually here.** The PostToolUse hook `.claude/hooks/rebuild-generators-on-change.sh` already rebuilds the generator DLL on every Edit/Write to `*.cs` under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/`. If a generator-source edit happened in this session, the DLL deploy is already done — verify with `git status`, do not duplicate it.
+- **README sync** is a separate skill (`sync-readmes`). Do not inline README updates into this skill.

--- a/.claude/skills/commit-and-open-pr/SKILL.md
+++ b/.claude/skills/commit-and-open-pr/SKILL.md
@@ -1,49 +1,147 @@
 ---
 name: commit-and-open-pr
-description: Aspid.FastTools-specific overrides for `/commit-and-open-pr` — Samples~ caveats, generator-DLL handling, README-sync prompt, base-branch default `Develop`, English-only PR/commit content, and SSH-key persistence per branch. Inherits the universal recipe from `~/.claude/skills/commit-and-open-pr/SKILL.md`. Use whenever the user asks to "commit and open PR", "закоммить и открой пр", `/commit-and-open-pr`, or otherwise wants the one-shot commit-push-PR flow inside this repo.
+description: One-shot orchestrator that commits the current session's changes and then opens a pull request in the Aspid.FastTools repo. Delegates the commit step to the project `commit` skill (Samples~ caveats, generator-DLL handling, English-only content, short bare imperative titles) and the PR step to the project `open-pr` skill (base `Develop`, draft + `status: work-in-progress` default, required `type:`/`area:`/`status:` labels, SSH recovery per branch). Use whenever the user asks to "commit and open PR", "закоммить и открой пр", "commit + PR", `/commit-and-open-pr`, or otherwise wants a single command that goes from working tree to published PR.
 user-invocable: true
 ---
 
-# commit-and-open-pr (Aspid.FastTools overrides)
+# commit-and-open-pr
 
-This is the project-scoped variant. The full universal procedure lives in `~/.claude/skills/commit-and-open-pr/SKILL.md`. Follow it, then apply the project-specific rules below — they take precedence on any conflict.
+This is a **composite** skill. It does not re-implement commit-message logic or PR-creation logic — it sequences the project's `commit` and `open-pr` skills with one consistent push step in between.
 
-## Pre-flight
+## When to use
 
-In addition to the universal pre-flight (`git status --porcelain`, `git diff --stat`, `git diff --staged --stat`):
+- The user types `/commit-and-open-pr`.
+- The user says "commit and open a PR", "закоммить и открой пр", "commit + push + PR", or any natural-language equivalent.
+- Do **not** invoke when the user only said "commit" (use `commit`) or only "open a PR" (use `open-pr`).
+- Do **not** confuse with the built-in `commit-commands:commit-push-pr` plugin skill — that one has its own contract; this orchestrator follows the project conventions (no Co-Authored-By trailer, per-branch SSH, draft-by-default, English-only GitHub content, base `Develop`, etc.).
 
-- **Samples~/.** Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely appear / disappear because Unity Package Manager imports samples into the working tree. They are local artefacts. The `commit` skill already filters them out unless the user said the commit is about samples — trust that filter; do not pre-stage `Samples~/*` here.
+## Process
+
+Run the steps in order. Stop at the first hard failure; do not press on.
+
+### 1. Pre-flight
+
+```sh
+git status --porcelain
+git diff --stat
+git diff --staged --stat
+git rev-parse --abbrev-ref HEAD
+```
+
+- If the working tree is **completely** clean (no staged, no unstaged, no untracked in the session's `IN_CONTEXT`) and the branch is already pushed and a PR already exists, ask the user what they wanted — probably an `open-pr` update or `gh pr ready`.
+- If there is **no** staged content but there are unstaged session-edits, `commit` will pick them up automatically (it inspects both index and working tree). Do not pre-`git add` anything yourself.
+- If the diff mixes several unrelated logical changes (e.g. a fix + an unrelated refactor + a docs tweak), surface it the same way `commit` would — ask the user via `AskUserQuestion` whether to combine, split into several PRs, or commit only one group. Splitting "commit one logical change → push → open PR" repeatedly across multiple PRs is acceptable in a single invocation when the user says so.
+
+Project-specific pre-flight checks (on top of the universal ones):
+
+- **`Samples~/`.** Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely appear / disappear because Unity Package Manager imports samples into the working tree. They are local artefacts. The `commit` skill already filters them out unless the user said the commit is about samples — trust that filter; do not pre-stage `Samples~/*` here.
 - **Generator DLL.** If `git status` shows changes to `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Aspid.FastTools.Generators.dll` but **no** `*.cs` change under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/`, that means a previous unrelated generator edit deployed the DLL. Surface this to the user before committing — usually the right call is to leave the DLL out of this PR.
-- **README sync.** If the diff touches a feature that has a page in `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/` or `…/RU/` (e.g. namespace rename, public API change, new `CreateAssetMenu` path) and the four README files are unchanged, run `AskUserQuestion` offering "запустить /sync-readmes сейчас?". If the user agrees, invoke the `sync-readmes` skill before continuing.
+- **README sync.** If the diff touches a feature that has a page in `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/` or `…/RU/` (e.g. namespace rename, public API change, new `CreateAssetMenu` path) and the four README files (`README.md`, `README_RU.md`, `Documentation/EN/README.md`, `Documentation/RU/README.md`) are unchanged, run `AskUserQuestion` offering "запустить /sync-readmes сейчас?". If the user agrees, invoke the `sync-readmes` skill before continuing.
 
-## Commit
+### 2. Commit
 
-Delegate to the project-scoped `commit` skill — title style "short bare imperatives, no Conventional Commits prefix", **English-only** content (even when chat is in Russian, per `feedback_github_content_english`), Samples~ caveat, no Claude/Anthropic Co-Authored-By.
+Delegate to the project `commit` skill (`.claude/skills/commit/SKILL.md`). Pass through the user's session context. The composite skill does **not**:
 
-## Push
+- compose its own commit title/body;
+- bypass `commit`'s "ask before mixing logical groups" gate;
+- `git add -A` or `git add .`.
 
-Universal push step. Persisted `branch.<name>.sshCommand` for this repo is typically `ssh -i ~/.ssh/vpd_personal_my_macbook -o IdentitiesOnly=yes` (matches `~/.ssh/config` `IdentityFile` for `github.com`). If recovery picks a different key for a specific branch (e.g. a fork or co-authored remote), persist it per the universal flow — do not change the global `~/.ssh/config`.
+Project-specific reminders that `commit` already enforces but worth repeating here:
 
-## Open PR
+- Title style: short bare imperative, no Conventional Commits prefix, under 70 characters.
+- Content language: English, even when the chat is in Russian.
+- No `Samples~/` paths and no orphan generator-DLL deploy in the commit.
+- No `Co-Authored-By: Claude …` / `Anthropic …` trailers.
 
-Delegate to the project-scoped `open-pr` skill:
+After `commit` returns, capture the new SHA: `git rev-parse HEAD`.
+
+### 3. Push
+
+This is the only step the composite skill performs itself.
+
+```sh
+current=$(git rev-parse --abbrev-ref HEAD)
+sshcmd=$(git config --get "branch.${current}.sshCommand" 2>/dev/null)
+
+if [ -n "$sshcmd" ]; then
+    GIT_SSH_COMMAND="$sshcmd" git push --set-upstream origin "$current"
+else
+    git push --set-upstream origin "$current"
+fi
+```
+
+Persisted `branch.<name>.sshCommand` for this repo is typically `ssh -i ~/.ssh/vpd_personal_my_macbook -o IdentitiesOnly=yes` (matches `~/.ssh/config` `IdentityFile` for `github.com`). If recovery picks a different key for a specific branch (e.g. a fork or co-authored remote), persist it per the recovery flow — do not change the global `~/.ssh/config`.
+
+On failure with an SSH error (`Permission denied (publickey)`, `Could not read from remote repository`, `Repository not found.` on an SSH remote), run the SSH recovery flow:
+
+1. Enumerate available keys:
+   ```sh
+   ls -1 ~/.ssh/*.pub 2>/dev/null
+   awk '/IdentityFile/{print $2}' ~/.ssh/config 2>/dev/null | sort -u
+   ```
+   For each `.pub` file, read the trailing comment so option labels are recognisable.
+2. `AskUserQuestion` — which key to use.
+3. Build `ssh_cmd="ssh -i ~/.ssh/<chosen-private-key> -o IdentitiesOnly=yes"` (`IdentitiesOnly=yes` is mandatory).
+4. Retry: `GIT_SSH_COMMAND="$ssh_cmd" git push --set-upstream origin "$current"`.
+5. On success, persist: `git config "branch.${current}.sshCommand" "$ssh_cmd"`.
+
+On any non-SSH push failure (rejected, non-fast-forward, hook failure), surface the raw stderr and stop. Do not auto-`--force` / `--force-with-lease`.
+
+### 4. Open PR
+
+Delegate to the project `open-pr` skill (`.claude/skills/open-pr/SKILL.md`). The composite skill does **not**:
+
+- guess a base branch — `open-pr` runs its own merge-base detection;
+- decide draft / non-draft — `open-pr` defaults to draft + `status: work-in-progress` unless the user said the PR is ready for review;
+- pick or invent labels — `open-pr` runs the partial-label and missing-label-creation flows.
+
+Pass through any signals the user gave in the original message (e.g. "ready for review" → tells `open-pr` to skip `--draft` and use `status: needs-review`).
+
+Project-specific reminders that `open-pr` already enforces:
 
 - Base defaults to `Develop` (or `main` for release-cut PRs).
 - Required labels: exactly one `type: *`, ≥1 `area: *` (`runtime` / `editor` / `generator` / `samples`), one `status: *` (default `work-in-progress`).
 - Default is `--draft` + `status: work-in-progress` unless the user said the PR is ready.
 - Missing-label flow: propose creating new labels via `gh label create`, but only after user confirmation of name + colour + description. Reuse the palette listed in the project `open-pr` skill.
 
-## Report
+### 5. Report
 
-In addition to the universal report fields, include:
+One final summary suitable for skim:
 
+- New commit SHA(s) and titles.
+- PR URL.
+- Base branch the PR targets.
+- Draft state (`draft` / `ready`).
+- Final label list as shown by `gh pr view <N> --json labels`.
+- Any group still missing a label (because the user declined the missing-label flow).
+- SSH key used, if recovery happened (so the user knows what got persisted to `branch.<name>.sshCommand`).
 - Whether the generator DLL was part of the commit (`yes` / `no — kept out`).
 - Whether the README sync prompt was offered and what the user picked.
-- The persisted `branch.<name>.sshCommand` if any new value was written.
 
-## Hard rules (project additions)
+## Hard rules
 
+Inherit and respect:
+
+- All hard rules from the project `commit` skill (no `-A` staging, no `--amend`, no `--no-verify`, no Claude/Anthropic Co-Authored-By trailer, no secret-file commits, no `Samples~/` paths, no orphan generator-DLL deploy).
+- All hard rules from the project `open-pr` skill (HEREDOC body, no auto-generated titles, no invented labels without confirmation, correct base via merge-base or persisted `branch.<name>.aspidBase`).
+
+Plus this composite's own:
+
+- **Never push before `commit` has finished cleanly.** A failed commit aborts the pipeline; do not try to "push what's already there" as a recovery.
+- **Never open a PR before `git push` has succeeded.** `gh pr create` against an unpushed branch fails confusingly.
+- **Never `--force` push** as part of this skill. If the push is rejected, stop and ask.
+- **Never bypass either delegated skill's "ask" gates** by inlining the answer yourself. If `commit` would ask "which group?" let it ask.
 - **English on GitHub.** Commit messages, PR title, PR body, PR labels — all English. The chat may be in Russian; persisted GitHub content is not.
 - **Never include `Samples~/` paths in a feature PR** unless the user explicitly opted in.
 - **Never run `dotnet build` manually here.** The PostToolUse hook `.claude/hooks/rebuild-generators-on-change.sh` already rebuilds the generator DLL on every Edit/Write to `*.cs` under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/`. If a generator-source edit happened in this session, the DLL deploy is already done — verify with `git status`, do not duplicate it.
 - **README sync** is a separate skill (`sync-readmes`). Do not inline README updates into this skill.
+
+## Common failure modes to avoid
+
+- Composing the commit message inside this skill instead of delegating to `commit`.
+- Pushing before the commit lands (especially on a fresh `commit` failure).
+- Opening the PR against the repo default branch (`main`) when the head branch was forked from `Develop`.
+- Forgetting to apply the persisted `branch.<name>.sshCommand` and getting a `Permission denied` on the second invocation.
+- Treating a partial label set as "good enough" and closing out without asking the user about the missing groups.
+- Reporting "PR opened" when only `gh pr create` ran but the post-creation label/draft fix-ups never happened.
+- Writing PR title / body / commit message in Russian instead of English.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -40,8 +40,6 @@ Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely
 - Do **not** stage anything under `Samples~/` unless the user explicitly said the commit is about samples.
 - Even if a `Samples~/*` file is in `IN_CONTEXT` because the agent touched it as part of an unrelated experiment, treat it as out-of-context for the commit and mention it in the skipped list.
 
-(At the time of writing, the working tree on `docs/profiler-markers-screenshot` carries dozens of deleted `Samples~/EnumValues/...` and `Samples~/Ids/...` entries that must stay out of commits on this branch.)
-
 ## Generators DLL
 
 Editing `*.cs` under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/` triggers `.claude/hooks/rebuild-generators-on-change.sh`, which rebuilds the Roslyn generator and redeploys the DLL to `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Aspid.FastTools.Generators.dll`.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,21 +1,104 @@
 ---
 name: commit
 description: >
-  Aspid.FastTools-specific overrides for the /commit skill — title style
-  matching this repo's git log, Samples~ caveats, generator-DLL rebuild
-  note, and English-only commit content. Inherits the universal recipe
-  from `~/.claude/skills/commit/SKILL.md`. Use whenever the user types
-  `/commit`, asks to "commit changes", or "закоммить" inside this repo.
+  Context-aware git commit for the Aspid.FastTools repo. Inspects BOTH staged
+  and unstaged changes, filters them by the current session's edits and
+  discussions, and commits only what belongs to the task at hand. Asks the
+  user when session context is missing or when several unrelated logical
+  changes are mixed in the working tree. Title style matches the existing
+  git log (short bare imperatives, no Conventional Commits prefix), commit
+  content is English-only, and `Samples~/` / generator-DLL artefacts are
+  filtered out. Never adds a Claude/Anthropic Co-Authored-By trailer. Use
+  whenever the user types `/commit`, asks to "commit changes", or
+  "закоммить".
 user-invocable: true
 ---
 
-# commit (Aspid.FastTools overrides)
+# commit
 
-This is the project-scoped variant of the `/commit` skill. The full procedure lives in `~/.claude/skills/commit/SKILL.md`. Follow it, then apply the project-specific rules below — they take precedence on any conflict.
+Smarter alternative to the built-in `/commit-commands:commit`. The built-in only commits what is already in the index; this skill looks at **both** the index and the working tree, and decides what belongs to the current task using the current session's context.
 
-## Title style
+## When to use
 
-Match `git log --oneline -10`. Aspid.FastTools uses **short bare imperatives** with **no Conventional Commits prefix**. Examples from the current log:
+- The user types `/commit`.
+- The user says "commit the changes", "закоммить", or any natural-language equivalent.
+- Do **not** use this skill for `/commit-commands:commit`, `/commit-push-pr`, or any other explicit slash command — those have their own contracts.
+
+## Process
+
+Run the steps below in order. Treat the user's session as the source of truth for "what is the current task".
+
+### 1. Snapshot the working tree
+
+Run in parallel:
+- `git status --porcelain`
+- `git diff --stat`
+- `git diff --staged --stat`
+- `git log --oneline -10` (to learn the project's title style)
+
+If everything is clean, report `nothing to commit` and stop.
+
+### 2. Identify session context
+
+Build a set `IN_CONTEXT` of files that the current session has touched or explicitly discussed:
+- Files the agent edited via `Edit` / `Write` / `NotebookEdit` in this session.
+- Files the user pointed at by path or by symbol.
+- Generated/derived files for the above (e.g. the Roslyn-generator DLL deploy target when the generator's `.cs` was edited).
+
+If the session is fresh (post-`/clear`, brand-new session) or the agent has not modified any tracked file, mark context as **missing**.
+
+### 3. Classify working-tree changes
+
+For every path appearing in `git status --porcelain` (staged or unstaged, modified / added / deleted / renamed / untracked):
+- **In-context** if it is in `IN_CONTEXT`.
+- **Out-of-context** otherwise.
+
+#### `Samples~/` caveat (project-specific)
+
+Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely appear or disappear in `git status` because Unity's Package Manager imports/removes samples into the working tree. They are **local artefacts**, not feature changes.
+
+- Do **not** stage anything under `Samples~/` unless the user explicitly said the commit is about samples.
+- Even if a `Samples~/*` file is in `IN_CONTEXT` because the agent touched it as part of an unrelated experiment, treat it as out-of-context for the commit and mention it in the skipped list.
+
+#### Generator DLL (project-specific)
+
+Editing `*.cs` under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/` triggers `.claude/hooks/rebuild-generators-on-change.sh`, which rebuilds the Roslyn generator and redeploys the DLL to `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Aspid.FastTools.Generators.dll`.
+
+- Do **not** run `dotnet build` manually before committing — the hook already did it.
+- Include the deployed `Aspid.FastTools.Generators.dll` in the commit **only** when the commit actually changes the generator's source. For Unity-only edits, the DLL must not be in the diff; if it is, that means a previous unrelated generator edit deployed it — keep it out of this commit and mention it in the skipped list.
+
+### 4. Decide what to commit
+
+Apply these branches in order:
+
+| Situation | Action |
+|---|---|
+| Working tree empty | Report `nothing to commit`, stop. |
+| Context **missing** | Use `AskUserQuestion` with a summary of `git status -s` grouped by area; ask which group(s) to commit. Do **not** commit on no answer. |
+| All changes ⊂ `IN_CONTEXT`, one logical group | Proceed to staging. |
+| Context exists, but some files are out-of-context | Commit only the in-context subset. Leave out-of-context files **exactly as they are** — do not `git add` them, do not unstage them. Mention skipped paths in the final report. |
+| Multiple logical groups inside `IN_CONTEXT` (e.g. fix + refactor + docs) | Use `AskUserQuestion`: one combined commit, several separate commits, or commit only one specific group. |
+| User said "commit everything" / "коммить всё" / similar override | Treat the whole working tree as in-context, but still respect the hard rules below and the `Samples~/` / generator-DLL filters. |
+
+### 5. Stage
+
+Stage files **by name**, one `git add` call with the explicit path list:
+
+```sh
+git add path/to/file1 path/to/file2 ...
+```
+
+**Never** use `git add -A`, `git add .`, `git add -u`, or any wildcard that may pick up unrelated changes. Untracked files are staged only when they were created in this session (i.e. already in `IN_CONTEXT`).
+
+### 6. Compose the commit message
+
+**Language**
+
+Commit titles and bodies are **in English**, even when the chat is in Russian. This matches the project convention that all GitHub-visible content (PR titles, PR bodies, commit messages, review comments) is English.
+
+**Title style**
+
+Aspid.FastTools uses **short bare imperatives** with **no Conventional Commits prefix**. Match `git log --oneline -10`. Examples from the log:
 
 - `Restyle ProfilerMarkers screenshot, rename to snake_case`
 - `Bump Unity badge to 6.0+ and mirror badges in RU README`
@@ -28,29 +111,66 @@ Rules for this repo:
 - Verbs that show up in the log: `Add`, `Fix`, `Update`, `Drop`, `Bump`, `Restyle`, `Rename`, `Group`, `Migrate`, `Mirror`. Reuse them when they fit.
 - Title under 70 characters.
 - One sentence, no trailing period.
+- Title alone must make clear what happened — no "various changes", "misc", "updates".
 
-## Language
+**Description (body)**
 
-Commit titles and bodies are **in English**, even when the chat is in Russian. This matches `feedback_github_content_english` for everything that lands on GitHub (PR titles, PR bodies, commit messages, review comments).
+Add a body when any of these are true:
+- More than 5 files changed.
+- More than ~100 lines of diff total.
+- Several distinct concepts in one commit (e.g. moved files **and** changed an API).
+- A non-obvious "why" that future reviewers would want.
 
-## `Samples~/` caveat
+Body format: 2–4 short bullets, focused on **what changed and why**, not "what the agent did". Plain markdown bullets.
 
-Files under `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Samples~/` routinely appear or disappear in `git status` because Unity's Package Manager imports/removes samples into the working tree. They are **local artefacts**, not feature changes.
+Pass the message via HEREDOC to preserve newlines:
 
-- Do **not** stage anything under `Samples~/` unless the user explicitly said the commit is about samples.
-- Even if a `Samples~/*` file is in `IN_CONTEXT` because the agent touched it as part of an unrelated experiment, treat it as out-of-context for the commit and mention it in the skipped list.
+```sh
+git commit -m "$(cat <<'EOF'
+<title>
 
-## Generators DLL
+- <bullet 1>
+- <bullet 2>
+EOF
+)"
+```
 
-Editing `*.cs` under `Aspid.FastTools.Generators/Aspid.FastTools.Generators/` triggers `.claude/hooks/rebuild-generators-on-change.sh`, which rebuilds the Roslyn generator and redeploys the DLL to `Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Aspid.FastTools.Generators.dll`.
+**Forbidden in the message:**
+- `Co-Authored-By: Claude …`
+- `Co-Authored-By: Anthropic …`
+- Any "Generated with Claude Code" / "🤖" attribution footer.
 
-- Do **not** run `dotnet build` manually before committing — the hook already did it.
-- Include the deployed `Aspid.FastTools.Generators.dll` in the commit **only** when the commit actually changes the generator's source. For Unity-only edits, the DLL must not be in the diff; if it is, that means a previous unrelated generator edit deployed it — keep it out of this commit.
+This rule is global (see `~/.claude/CLAUDE.md`) and overrides any default template from `commit-commands:commit`, `commit-commands:commit-push-pr`, etc. It only relaxes if the user **explicitly** asks for the trailer in the current session.
 
-## Co-Authored-By
+### 7. Verify
 
-Do not append `Co-Authored-By: Claude …` or any other Claude/Anthropic attribution to commit messages. This is a global rule (`~/.claude/CLAUDE.md`) but it is critical for this project and repeated here for emphasis.
+Run `git status` after the commit. If the commit fails because of a pre-commit hook:
+- **Investigate and fix** the underlying issue.
+- Do **not** retry with `--no-verify`.
+- Do **not** use `--amend` to retry — create a **new** commit after the fix.
 
-## Pre-commit hook
+Report to the user: title used, files included, files skipped (if any — especially `Samples~/` paths or an orphan generator-DLL deploy), and the resulting commit SHA.
 
-If a pre-commit hook fails, fix the underlying issue and create a **new** commit. Do not retry with `--amend` or `--no-verify`.
+## Hard rules (do not break)
+
+- Never `git add -A` / `git add .` / `git add -u`.
+- Never `--amend` without explicit user request — the pre-commit hook may have nuked the previous commit context.
+- Never `--no-verify` / `--no-gpg-sign` / similar bypass flags.
+- Never any Claude/Anthropic Co-Authored-By or attribution trailer.
+- Never commit obvious secrets (`.env`, `*.pem`, `credentials.*`). If they appear in the diff, stop and warn the user.
+- Never use interactive flags (`git add -i`, `git rebase -i`).
+- Untracked files are staged only when they are in `IN_CONTEXT`.
+- Never include `Samples~/` paths unless the user explicitly opted in.
+- Never include the generator DLL when the commit has no generator source change.
+- Commit content (title + body) is in **English**, even when the chat is in Russian.
+
+## Common failure modes to avoid
+
+- "Misc updates" / "Various fixes" titles — always be specific.
+- Mixing unrelated noise from a base-branch merge with the actual feature work.
+- Committing local artefacts (build output, IDE caches, sample imports) that the user did not touch in this session.
+- Inlining backticks inside `-m "$(...)"` — they get eaten by the shell as command substitution. Always HEREDOC.
+- Forgetting to verify post-commit `git status` (silent partial commits).
+- Auto-staging untracked files just because they exist.
+- Adding a Conventional Commits prefix (`feat:`, `fix:`, …) — this repo does not use them.
+- Writing the commit message in Russian.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -4,15 +4,15 @@ description: Open a pull request following Aspid.FastTools project conventions �
 user-invocable: true
 ---
 
-# open-pr (Aspid.FastTools overrides)
+# open-pr
 
-This skill is the project-scoped variant of `/open-pr`. The full universal procedure lives in `~/.claude/skills/open-pr/SKILL.md`. Follow it, then apply the project-specific rules below — they take precedence on any conflict.
+Use this skill any time a pull request is being opened in this repository. It encodes both the universal preferences and the Aspid.FastTools project conventions in one place — no external skill is required.
 
-## Title
+## When to use
 
-- Short imperative sentence describing the change. Aim for under 70 characters.
-- No auto-generated branch-name strings. `claude/add-onenable-idregistry-IBkJl` is **not** acceptable; rewrite it before reporting "PR opened".
-- Examples that pass: `Mark IdRegistry cache dirty on OnEnable`, `Fix this.Marker() generator for explicit interfaces, generics and field naming`, `Document PR conventions in CLAUDE.md`.
+- The user asks to open / create / draft a PR.
+- An `@claude` automation is about to push a PR.
+- Before invoking `gh pr create` directly.
 
 ## Base branch
 
@@ -20,12 +20,54 @@ The active integration branch is `Develop`; `main` is reserved for release cuts.
 
 - For ordinary feature/fix/refactor PRs, the base is **`Develop`**.
 - For release-cut PRs (`Develop` → `main`, mega-PRs), the base is **`main`**.
-- Run the universal merge-base detection (see user-level skill). If detection is ambiguous, fall back to `Develop` when HEAD is not `Develop` itself; otherwise fall back to `main`.
-- Persist via `git config branch.<name>.aspidBase "<base>"` so the next open/edit on the same branch skips the question.
+
+`gh pr create` will silently retarget at the repo's default (often `main`) — always override with `--base`.
+
+Detect the base as follows:
+
+```sh
+current=$(git rev-parse --abbrev-ref HEAD)
+
+# A. Explicit override saved on previous runs.
+explicit=$(git config --get "branch.${current}.aspidBase" 2>/dev/null)
+
+# B. Upstream tracking, if the branch tracks something concrete.
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null \
+  | sed 's@^origin/@@')
+
+# C. merge-base heuristic across local + remote refs.
+git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin \
+  | grep -v -E "(^|/)${current}$" \
+  | grep -v 'HEAD$' \
+  | sort -u \
+  | while read b; do
+      mb=$(git merge-base "$b" HEAD 2>/dev/null) || continue
+      [ "$mb" = "$(git rev-parse HEAD)" ] && continue
+      ahead=$(git rev-list --count "${mb}..HEAD")
+      printf '%s %s\n' "$ahead" "$b"
+    done \
+  | sort -n | head -3
+```
+
+Selection rules:
+
+- `explicit` wins immediately.
+- After normalising `origin/<x>` → `<x>` and deduping, if exactly one candidate has the minimal `ahead`, use it.
+- If detection is ambiguous, fall back to `Develop` when HEAD is not `Develop` itself; otherwise fall back to `main`. If still unsure, ask the user via `AskUserQuestion` with the top-3 candidates as options. Do **not** guess silently.
+- Persist the choice: `git config "branch.${current}.aspidBase" "${base}"`. Next time the skill runs on the same branch it skips the question.
+
+Pass the result via `gh pr create --base "${base}"`.
+
+## Title
+
+- Short imperative sentence describing the change. Aim for under 70 characters.
+- No auto-generated branch-name strings (`claude/add-onenable-…`, `bot/auto-merge-…`). If GitHub seeded the title from a branch name, **rewrite it** before reporting "PR opened".
+- Match the style already in `git log --oneline -10` — Aspid.FastTools uses **short bare imperatives** with **no Conventional Commits prefix**.
+- Examples that pass: `Mark IdRegistry cache dirty on OnEnable`, `Fix this.Marker() generator for explicit interfaces, generics and field naming`, `Document PR conventions in CLAUDE.md`.
 
 ## Body
 
-Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, omitted only when truly empty.
+Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, omitted only when truly empty. Do not invent your own structure.
 
 ### `## Summary`
 
@@ -45,11 +87,34 @@ Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, omitted only whe
 - `Refs #N` for related issues that the PR does not close.
 - Delete the section when nothing applies.
 
+Pass the body via HEREDOC to preserve newlines:
+
+```sh
+gh pr create --base "<base>" [--draft] --title "..." --body "$(cat <<'EOF'
+## Summary
+
+- …
+
+## Notes for review
+
+…
+
+## Linked issues
+
+Closes #N
+EOF
+)" --label "type: X,area: Y,status: work-in-progress"
+```
+
 ## Labels
 
-Pick from the existing label set; do **not** invent new labels silently. The label catalogue is visible via `gh label list --repo VPDPersonal/Aspid.FastTools`.
+Pick from the existing label set; do **not** invent new labels silently. The label catalogue is visible via:
 
-Three groups are required on every PR:
+```sh
+gh label list --repo VPDPersonal/Aspid.FastTools --limit 100
+```
+
+Three groups are **required** on every PR:
 
 | Group | Values | Rule |
 |---|---|---|
@@ -57,7 +122,7 @@ Three groups are required on every PR:
 | `area: *` | `runtime`, `editor`, `generator`, `samples` | **One or more** — one per area the PR actually touches. |
 | `status: *` | `work-in-progress`, `needs-review`, `needs-info`, `blocked`, `do-not-merge` | Exactly **one**. Default `work-in-progress`. |
 
-Special labels — `breaking-change`, `dependencies`, `needs-changelog` — only when literally true.
+Special labels — `breaking-change`, `dependencies`, `needs-changelog`, `security` — only when literally true.
 
 ### Draft + status default
 
@@ -74,34 +139,93 @@ gh pr edit <N> --remove-label "status: work-in-progress" --add-label "status: ne
 gh pr ready <N>
 ```
 
-### Missing-label flow
+### Partial-label flow
 
-If for any required group **no** existing label fits, use the universal create-new-label flow from the user-level skill:
+If at PR-creation time you only know some of the required labels:
 
-- Suggest a name in the project's style — `<group>: <kebab-slug>`.
-- Pick a colour from the palette already used in that group. Current palette (from `gh label list`):
-  - `type: *` — `#2369B4` (documentation), `#1E783C` (feature), `#A53232` (fix), `#F5B955` (performance), `#646464` (refactor/test/chore/ci/style).
-  - `area: *` — `#1E783C` (runtime), `#2369B4` (editor), `#646464` (generator/samples). Reuse a colour or pick from this same palette for new areas.
-  - `status: *` — `#F5B955` (in-progress/needs-info), `#2369B4` (needs-review), `#A53232` (blocked), `#000000` (do-not-merge).
-- Confirm with the user via `AskUserQuestion` before running `gh label create` — name, colour, description.
-- Then `gh pr edit <N> --add-label "<new-label>"`.
+1. Pass the labels you're sure of via `--label "label-a,label-b"` (commas, no spaces).
+2. **After** creation, for each required group that still has no label, run `AskUserQuestion` listing the candidates in that group (read with `gh label list`).
+3. Apply the chosen labels with `gh pr edit <N> --add-label "..."`.
 
-## SSH on push
+Never spam the user with one giant question for everything — one focused question per missing group.
 
-Follow the universal SSH recovery flow from the user-level skill. Notes for this repo:
+### Missing-label flow (create new label)
 
-- Remote is `git@github.com:VPDPersonal/Aspid.FastTools.git`. Default key per `~/.ssh/config` is `~/.ssh/vpd_personal_my_macbook`. If a push fails with `Permission denied (publickey)`, that usually means ssh-agent offered a different key first.
-- Always read `git config --get branch.<name>.sshCommand` before any push/fetch on a branch. Apply via `GIT_SSH_COMMAND` when set.
+If, after looking at the existing label set, **no** existing label fits a required group, propose to create a new one. Never create a label silently.
+
+1. Decide a candidate name in the project's style — `<group>: <kebab-slug>`.
+2. Pick a colour from the palette the existing labels in that group already use. Current palette (from `gh label list`):
+   - `type: *` — `#2369B4` (documentation), `#1E783C` (feature), `#A53232` (fix), `#F5B955` (performance), `#646464` (refactor/test/chore/ci/style).
+   - `area: *` — `#1E783C` (runtime), `#2369B4` (editor), `#646464` (generator/samples). Reuse a colour or pick from this same palette for new areas.
+   - `status: *` — `#F5B955` (in-progress/needs-info), `#2369B4` (needs-review), `#A53232` (blocked), `#000000` (do-not-merge).
+3. Write a one-line description.
+4. Ask the user via `AskUserQuestion`: "В группе `<group>` нет подходящего лейбла. Создать `<group>: <slug>` (#<color>, `<description>`) или пропустить?".
+5. On `Создать`: `gh label create "<group>: <slug>" --color "<hex-no-hash>" --description "<description>"`, then `gh pr edit <N> --add-label "<group>: <slug>"`.
+6. On `Пропустить`: leave the group empty and report it in the final summary so the user knows.
+7. Never create a label without a confirmed answer to step 4.
 
 ## Commit messages
 
-- Short imperative sentences in **English** (the chat may be in Russian; GitHub content is English per the `feedback_github_content_english` rule): `Add X`, `Fix Y`, `Mark Z`. Match the headline style already in `git log`.
-- **Never** append `Co-Authored-By: Claude …` or any other Claude/Anthropic attribution trailer. Commits are authored as the human user only.
+- Short imperative sentences in **English** (the chat may be in Russian; GitHub content is English per the project's GitHub-English rule): `Add X`, `Fix Y`, `Mark Z`. Match the headline style already in `git log`.
+- **Never** append `Co-Authored-By: Claude …`, `Co-Authored-By: Anthropic …`, or any other Claude/Anthropic attribution trailer. Commits are authored as the human user only. This overrides default templates from any skill (e.g. `commit-commands:commit`, `commit-commands:commit-push-pr`) or any shipped global rule.
+- Relaxes only if the user explicitly asks for the trailer in the current session.
+
+## SSH on push
+
+If the branch is not yet on the remote, the skill itself triggers the first push. Before pushing:
+
+```sh
+current=$(git rev-parse --abbrev-ref HEAD)
+sshcmd=$(git config --get "branch.${current}.sshCommand" 2>/dev/null)
+
+if [ -n "$sshcmd" ]; then
+    GIT_SSH_COMMAND="$sshcmd" git push --set-upstream origin "$current"
+else
+    git push --set-upstream origin "$current"
+fi
+```
+
+The `branch.<name>.sshCommand` key is a **custom** config the skill manages — git itself does not auto-pick it up. The point is to make per-branch SSH choices stick: once the user picks a key for this branch, every subsequent push/fetch the skill performs uses it.
+
+Notes for this repo: remote is `git@github.com:VPDPersonal/Aspid.FastTools.git`. Default key per `~/.ssh/config` is `~/.ssh/vpd_personal_my_macbook`. If a push fails with `Permission denied (publickey)`, that usually means ssh-agent offered a different key first.
+
+### SSH recovery flow
+
+If `git push` fails with any of:
+
+- `Permission denied (publickey).`
+- `fatal: Could not read from remote repository.`
+- `ERROR: Repository not found.` on an SSH remote.
+- `git@<host>: Permission denied (publickey)` from a forge other than github.com.
+
+…run the recovery flow:
+
+1. Enumerate available keys:
+   ```sh
+   ls -1 ~/.ssh/*.pub 2>/dev/null
+   awk '/IdentityFile/{print $2}' ~/.ssh/config 2>/dev/null | sort -u
+   ```
+   For each `.pub` file, read the trailing comment so the option labels are recognisable (`<key>  →  <comment>`). Skip `known_hosts`, `config`, and private keys without a matching `.pub`.
+2. Ask the user via `AskUserQuestion` which key to use. Include the path of each option and its comment as the description.
+3. Build the SSH command:
+   ```sh
+   ssh_cmd="ssh -i ~/.ssh/<chosen-private-key> -o IdentitiesOnly=yes"
+   ```
+   `IdentitiesOnly=yes` is mandatory — without it, ssh-agent may still offer a different key first and trigger the same failure.
+4. Retry the push: `GIT_SSH_COMMAND="$ssh_cmd" git push --set-upstream origin "$current"`.
+5. On success, persist the choice for this branch:
+   ```sh
+   git config "branch.${current}.sshCommand" "$ssh_cmd"
+   ```
+6. Going forward, every `git push` / `git fetch` for this branch (in this skill and in `commit-and-open-pr`) must read `branch.<name>.sshCommand` first and apply it via `GIT_SSH_COMMAND` if set.
+
+If recovery fails (none of the offered keys work), surface the raw `git push` stderr to the user and stop — do not try to guess further.
 
 ## Scope
 
 - One logical change per PR.
-- If the diff drags in unrelated noise from a base-branch merge, do **not** delete it — just call it out under *Notes for review*.
+- If the diff drags in unrelated noise from a base-branch merge or a stale rebase, do **not** delete it — call it out under *Notes for review* so reviewers know it is a no-op on merge.
+- Avoid mixing infrastructure / CI / template changes with feature work in the same PR. Split if reasonable.
 - Templates (`bug_report.yml`, `feature_request.yml`, `config.yml`, `PULL_REQUEST_TEMPLATE.md`) and CI workflows (`.github/workflows/*.yml`) live on `main`; targeting them at `Develop` directly is wrong unless the change is meant to ride a release merge.
 
 ## Release-notes mega-PRs (carve-out)
@@ -113,8 +237,8 @@ Follow the universal SSH recovery flow from the user-level skill. Notes for this
 When invoked, walk through this checklist before reporting "PR opened":
 
 1. **Branch** — `git rev-parse --abbrev-ref HEAD`. Confirm the head branch is named per existing patterns (`Feature/<name>`, `chore/<name>`, `claude/<auto>`). If the auto-name is ugly, live with it but compensate with a clean title.
-2. **Base** — run merge-base detection; fall back to `Develop` (or `main` for release-cut PRs); persist via `branch.<name>.aspidBase`.
-3. **Diff** — `git diff <base>...HEAD --stat`; identify the *one* logical change.
+2. **Base** — run the merge-base detection algorithm; fall back to `Develop` (or `main` for release-cut PRs); persist via `branch.<name>.aspidBase`. Ask the user only when ambiguous.
+3. **Diff** — `git diff <base>...HEAD --stat`; identify the *one* logical change vs. accidental noise.
 4. **Push** — read `branch.<name>.sshCommand`; push with `GIT_SSH_COMMAND` if set. On SSH failure run the SSH recovery flow and persist the chosen key.
 5. **Ready-state** — `--draft` + `status: work-in-progress` unless the user explicitly said ready.
 6. **Title / Body** — draft per rules above; HEREDOC for the body.
@@ -128,8 +252,10 @@ When invoked, walk through this checklist before reporting "PR opened":
 - Empty body. Fix immediately if you see `body=""` on a PR you opened.
 - Opening a feature PR against `main` instead of `Develop`.
 - Marking a PR ready when the user only asked to "open" it.
-- Auto-generated title from branch name (`claude/add-…`).
+- Auto-generated title from branch name (`claude/add-…`). Rewrite.
 - Two `type: *` labels at once (pick one).
 - Pasting unredacted Claude-attribution trailers in commit messages.
 - Creating a label without explicit user confirmation of name + colour.
-- Backtick-inside-`gh-pr-comment` shell injection (always HEREDOC).
+- Backtick-inside-`gh-pr-comment` shell injection (always HEREDOC or `--body-file`).
+- Force-pushing to a shared branch (`main`, `Develop`, release branches) — do this only on personal feature branches and only with `--force-with-lease`.
+- Merging without verifying mergeability — `gh pr view <N> --json mergeable,mergeStateStatus,statusCheckRollup` first.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,20 +1,31 @@
 ---
 name: open-pr
-description: Open a pull request following Aspid.FastTools project conventions — title format, PULL_REQUEST_TEMPLATE body, label policy, commit-message rules, and scope hygiene. Use this skill whenever the user asks to open / create / draft a PR, when running `@claude` triggers a PR-creation flow, or before invoking `gh pr create` directly.
+description: Open a pull request following Aspid.FastTools project conventions — title format, PULL_REQUEST_TEMPLATE body, base-branch (default `Develop`), label policy with required `type:`/`area:`/`status:` groups, draft + `status: work-in-progress` default, SSH-key per-branch recovery, and commit-message rules. Use this skill whenever the user asks to open / create / draft a PR, when running `@claude` triggers a PR-creation flow, or before invoking `gh pr create` directly.
 user-invocable: true
 ---
 
-Use this skill any time a pull request is being opened in the Aspid.FastTools repository — manual, scripted, or via `@claude` automation.
+# open-pr (Aspid.FastTools overrides)
+
+This skill is the project-scoped variant of `/open-pr`. The full universal procedure lives in `~/.claude/skills/open-pr/SKILL.md`. Follow it, then apply the project-specific rules below — they take precedence on any conflict.
 
 ## Title
 
 - Short imperative sentence describing the change. Aim for under 70 characters.
-- No auto-generated branch-name strings. `Claude/add onenable idregistry i bk jl` is **not** acceptable; rewrite it.
+- No auto-generated branch-name strings. `claude/add-onenable-idregistry-IBkJl` is **not** acceptable; rewrite it before reporting "PR opened".
 - Examples that pass: `Mark IdRegistry cache dirty on OnEnable`, `Fix this.Marker() generator for explicit interfaces, generics and field naming`, `Document PR conventions in CLAUDE.md`.
+
+## Base branch
+
+The active integration branch is `Develop`; `main` is reserved for release cuts.
+
+- For ordinary feature/fix/refactor PRs, the base is **`Develop`**.
+- For release-cut PRs (`Develop` → `main`, mega-PRs), the base is **`main`**.
+- Run the universal merge-base detection (see user-level skill). If detection is ambiguous, fall back to `Develop` when HEAD is not `Develop` itself; otherwise fall back to `main`.
+- Persist via `git config branch.<name>.aspidBase "<base>"` so the next open/edit on the same branch skips the question.
 
 ## Body
 
-Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, all of which may be omitted only when truly empty.
+Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, omitted only when truly empty.
 
 ### `## Summary`
 
@@ -36,19 +47,56 @@ Fill out `.github/PULL_REQUEST_TEMPLATE.md` — three sections, all of which may
 
 ## Labels
 
-Pick from the existing label set; do **not** invent new labels in PRs. The label catalogue is fixed and visible via `gh label list --repo VPDPersonal/Aspid.FastTools`.
+Pick from the existing label set; do **not** invent new labels silently. The label catalogue is visible via `gh label list --repo VPDPersonal/Aspid.FastTools`.
 
-| Group | Rule |
-|---|---|
-| `type: *` | Exactly **one**: `feature`, `fix`, `refactor`, `documentation`, `test`, `chore`, `ci`, `style`, `performance`. |
-| `area: *` | One or more for every part of the codebase the PR actually touches: `runtime`, `editor`, `generator`, `samples`. |
-| `status: *` | `needs-review` once the PR is ready, `work-in-progress` while still drafting. |
-| Special | `breaking-change`, `dependencies`, `needs-changelog` only when literally true. |
+Three groups are required on every PR:
+
+| Group | Values | Rule |
+|---|---|---|
+| `type: *` | `feature`, `fix`, `refactor`, `documentation`, `test`, `chore`, `ci`, `style`, `performance` | Exactly **one**. |
+| `area: *` | `runtime`, `editor`, `generator`, `samples` | **One or more** — one per area the PR actually touches. |
+| `status: *` | `work-in-progress`, `needs-review`, `needs-info`, `blocked`, `do-not-merge` | Exactly **one**. Default `work-in-progress`. |
+
+Special labels — `breaking-change`, `dependencies`, `needs-changelog` — only when literally true.
+
+### Draft + status default
+
+Unless the user explicitly says the PR is ready for review (`готово`, `на ревью`, `ready for review`), the PR opens as **draft** with `status: work-in-progress`:
+
+```sh
+gh pr create --draft --label "type: <X>,area: <Y>,status: work-in-progress" ...
+```
+
+When the user later flips the PR to ready:
+
+```sh
+gh pr edit <N> --remove-label "status: work-in-progress" --add-label "status: needs-review"
+gh pr ready <N>
+```
+
+### Missing-label flow
+
+If for any required group **no** existing label fits, use the universal create-new-label flow from the user-level skill:
+
+- Suggest a name in the project's style — `<group>: <kebab-slug>`.
+- Pick a colour from the palette already used in that group. Current palette (from `gh label list`):
+  - `type: *` — `#2369B4` (documentation), `#1E783C` (feature), `#A53232` (fix), `#F5B955` (performance), `#646464` (refactor/test/chore/ci/style).
+  - `area: *` — `#1E783C` (runtime), `#2369B4` (editor), `#646464` (generator/samples). Reuse a colour or pick from this same palette for new areas.
+  - `status: *` — `#F5B955` (in-progress/needs-info), `#2369B4` (needs-review), `#A53232` (blocked), `#000000` (do-not-merge).
+- Confirm with the user via `AskUserQuestion` before running `gh label create` — name, colour, description.
+- Then `gh pr edit <N> --add-label "<new-label>"`.
+
+## SSH on push
+
+Follow the universal SSH recovery flow from the user-level skill. Notes for this repo:
+
+- Remote is `git@github.com:VPDPersonal/Aspid.FastTools.git`. Default key per `~/.ssh/config` is `~/.ssh/vpd_personal_my_macbook`. If a push fails with `Permission denied (publickey)`, that usually means ssh-agent offered a different key first.
+- Always read `git config --get branch.<name>.sshCommand` before any push/fetch on a branch. Apply via `GIT_SSH_COMMAND` when set.
 
 ## Commit messages
 
-- Short imperative sentences: `Add X`, `Fix Y`, `Mark Z`. Match the headline style already in `git log`.
-- **Never** append `Co-Authored-By: Claude …` or any other Claude/Anthropic attribution trailer. Commits are authored as the human user only. This overrides default templates from any skill (e.g. `commit-commands:commit`, `commit-commands:commit-push-pr`).
+- Short imperative sentences in **English** (the chat may be in Russian; GitHub content is English per the `feedback_github_content_english` rule): `Add X`, `Fix Y`, `Mark Z`. Match the headline style already in `git log`.
+- **Never** append `Co-Authored-By: Claude …` or any other Claude/Anthropic attribution trailer. Commits are authored as the human user only.
 
 ## Scope
 
@@ -64,18 +112,24 @@ Pick from the existing label set; do **not** invent new labels in PRs. The label
 
 When invoked, walk through this checklist before reporting "PR opened":
 
-1. **Branch** — confirm the head branch is named per existing patterns (`Feature/<name>`, `chore/<name>`, `claude/<auto>`). If the auto-name is ugly (e.g. `claude/add-onenable-idregistry-IBkJl`), live with it but compensate with a clean PR title.
-2. **Diff** — run `git diff <base>...HEAD --stat` and skim what's actually changing. Identify the *one* logical change vs. accidental noise.
-3. **Title** — draft per the rules above.
-4. **Body** — fill the three template sections. Use `gh pr create --body "$(cat <<'EOF' ... EOF)"` with a HEREDOC; never inline backticks through zsh, they get eaten as command substitution and silently drop content (this happened on issue-comment 4415890039 — see the `gh api -X PATCH` recovery).
-5. **Labels** — apply via `--add-label "type: X,area: Y,…"` either at create time or right after.
-6. **Closes / Refs** — if any issues are involved, write them in *Linked issues*. Verify with `gh issue list --state open` what is actually linkable.
-7. **Verify** — `gh pr view <N> --json title,labels,body` to confirm everything took.
+1. **Branch** — `git rev-parse --abbrev-ref HEAD`. Confirm the head branch is named per existing patterns (`Feature/<name>`, `chore/<name>`, `claude/<auto>`). If the auto-name is ugly, live with it but compensate with a clean title.
+2. **Base** — run merge-base detection; fall back to `Develop` (or `main` for release-cut PRs); persist via `branch.<name>.aspidBase`.
+3. **Diff** — `git diff <base>...HEAD --stat`; identify the *one* logical change.
+4. **Push** — read `branch.<name>.sshCommand`; push with `GIT_SSH_COMMAND` if set. On SSH failure run the SSH recovery flow and persist the chosen key.
+5. **Ready-state** — `--draft` + `status: work-in-progress` unless the user explicitly said ready.
+6. **Title / Body** — draft per rules above; HEREDOC for the body.
+7. **Create** — `gh pr create --base "<base>" [--draft] --title "..." --body "..." --label "type: X,area: Y,status: work-in-progress"`.
+8. **Clarify labels** — for any required group still missing, run `AskUserQuestion` and `gh pr edit <N> --add-label "..."`.
+9. **Missing-label flow** — for any group where nothing existing fits, propose creating a new label and only run `gh label create` after explicit confirmation.
+10. **Verify** — `gh pr view <N> --json title,labels,body,isDraft,baseRefName`. Report URL, base, draft state, labels.
 
 ## Common failure modes to avoid
 
 - Empty body. Fix immediately if you see `body=""` on a PR you opened.
-- Auto-generated title from branch name (`Claude/add-…`).
+- Opening a feature PR against `main` instead of `Develop`.
+- Marking a PR ready when the user only asked to "open" it.
+- Auto-generated title from branch name (`claude/add-…`).
 - Two `type: *` labels at once (pick one).
 - Pasting unredacted Claude-attribution trailers in commit messages.
-- Backtick-inside-`gh-pr-comment` shell injection (always heredoc).
+- Creating a label without explicit user confirmation of name + colour.
+- Backtick-inside-`gh-pr-comment` shell injection (always HEREDOC).


### PR DESCRIPTION
## Summary

- Extend `~/.claude/skills/open-pr/SKILL.md` and `.claude/skills/open-pr/SKILL.md` with:
  - **Base-branch detection** — merge-base heuristic across local + `origin/*` refs, persisted in `branch.<name>.aspidBase`; falls back to user prompt when ambiguous.
  - **Draft + `status: work-in-progress` default** — PR opens as draft unless the user explicitly says it is ready for review.
  - **Partial-label flow** — after creation, ask the user about any required group (`type:` / `area:` / `status:`) that still has no label.
  - **Missing-label flow** — if no existing label fits a required group, propose `gh label create` (name, colour, description) and only run it after explicit confirmation.
  - **SSH push recovery** — list `~/.ssh/*.pub`, ask the user which key to use, retry with `GIT_SSH_COMMAND="ssh -i <key> -o IdentitiesOnly=yes" git push`, and persist the chosen command into `branch.<name>.sshCommand` so subsequent push/fetch on the same branch reuse it.
- Add a new composite skill **`commit-and-open-pr`** (user-level + Aspid.FastTools override) that orchestrates `commit` → push (honouring `branch.<name>.sshCommand`) → `open-pr`.

## Notes for review

- `area:` labels in this repo only cover Unity code (`runtime` / `editor` / `generator` / `samples`); this PR touches only `.claude/skills/`, which has no matching area. Worth deciding whether to add an `area: tooling` label (covering `.claude/`, `.github/`, dev-tooling commits) or to keep tooling PRs area-less, as PR #17 did.
- Project-level overrides (`Aspid.FastTools/.claude/skills/open-pr/SKILL.md`) reuse the existing label palette and call out the current `~/.ssh/vpd_personal_my_macbook` default from `~/.ssh/config`.

## Linked issues

_None._