### PR TITLE
Add CHANGELOG.md at package root

### DIFF
--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/CHANGELOG.md
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to **Aspid.FastTools** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0]
+
+Initial public release.
+
+### Added
+- **ProfilerMarkers** — `this.Marker()` extension and a Roslyn source generator (`ProfilerMarkersGenerator`) that emits a unique `ProfilerMarker` per call-site (class + method + line). Supports `.WithName(literal)` and interpolated `$"..."` names; the generated dispatcher is gated by `ENABLE_PROFILER` so non-development builds carry no per-call cost.
+- **SerializableType / SerializableType\<T\>** — `System.Type` wrappers serialisable in the Unity Inspector with assembly-qualified names and lazy resolution; generic constraint support.
+- **TypeSelector** — `EditorWindow`-based hierarchical type picker with search, used as the property drawer for `SerializableType` and as `ComponentTypeSelector`.
+- **EnumValues\<TValue\>** — serializable dictionary mapping enum values to arbitrary values, with `[Flags]` support.
+- **Id system** — `IId` / `[UniqueId]` structs paired with `IdRegistry` (`ScriptableObject`) for stable `int ↔ string` mappings. `IdStructGenerator` emits the struct boilerplate and reports diagnostics `AFID001` (missing `partial`) and `AFID002` (member already declared). Editor UI features name validation, full Undo, clean-up flow for invalid entries, sort/group toolbar, manual next-id with backward-step warning.
+- **VisualElement fluent extensions** — extensive UIToolkit API covering layout, sizing, style, borders, colors, transitions, callbacks, USS, child management, and per-element helpers (`Button`, `Field`, `Foldout`, `HelpBox`, `Image`, `List`, `ProgressBar`, `Slider`, `TextElement`, etc.).
+- **Optional Mathematics integration** — satellite assembly `Aspid.FastTools.Unity.VisualElements.Math` adds `INotifyValueChanged` extensions for `float2/3/4`, `int2/3/4`, etc., compiled only when `com.unity.mathematics` is installed.
+- **SerializedProperty extensions** — fluent chainable helpers (`SetValue`, `Apply`, reflection helpers, `Persistent` extension).
+- **IMGUI scopes** — disposable `VerticalScope`, `HorizontalScope`, `ScrollViewScope` with `Rect` properties.
+- **Editor extensions** — `MonoScript.GetScriptName()` / `GetScriptNameWithIndex()` honouring `[AddComponentMenu]` and duplicate-component index suffixes.
+- **Welcome window** — `Tools/Aspid FastTools/Welcome` editor window listing installable samples from `package.json`; shown automatically on first import.
+- **Internal editor components** — `AspidLabel`, `AspidBox`, `AspidGradientButton`, `AspidHelpBox`, `AspidInspectorHeader`, `AspidDividingLine`, `AspidAnimatedLogo`, `AspidAnimatedTitle`, `AspidAnimatedDotsBackground`, `AspidHoverGradientOverlay` with USS-driven presets and a shared dark palette (`Aspid-FastTools-Default-Dark.uss`).
+- **Samples** — `Types`, `EnumValues`, `Ids`, `ProfilerMarkers`, `VisualElements` (installable via Package Manager).

--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/CHANGELOG.md.meta
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: feb8641612d44a0498af86ef18621b44
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` (and `.meta`) at the package root, next to `package.json`, so Unity Package Manager surfaces it as a dedicated "Changelog" tab in its UI.
- Use the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format + SemVer. Includes an empty `[Unreleased]` section and a `[1.0.0]` entry summarising the initial feature set (ProfilerMarkers, SerializableType / TypeSelector, EnumValues, Id system, VisualElement fluent extensions, Math satellite asmdef, SerializedProperty extensions, IMGUI scopes, Welcome window, internal editor components, Samples).

## Notes for review

- The `[1.0.0]` entry is intentionally undated — there is no matching git tag / GitHub release yet to point at. Happy to backfill a date once one exists.
- `.meta` GUID was freshly generated; the file mirrors the structure of the existing `package.json.meta`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ev979MnzfnK2sNKzNKrTng)_