### PR TITLE
Add blank line between SerializableType GIF and TypeSelectorAttribute heading

### DIFF
--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/EN/README.md
@@ -153,6 +153,7 @@ public sealed class AbilitySelector : MonoBehaviour
 }
 ```
 ![aspid_fasttools_serializable_type.gif](../Images/aspid_fasttools_serializable_type.gif)
+
 ### TypeSelectorAttribute
 
 An editor-only `PropertyAttribute` that restricts the type selection popup to specific base types. Applied to `string` fields that store assembly-qualified type names.

--- a/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/RU/README.md
@@ -153,6 +153,7 @@ public sealed class AbilitySelector : MonoBehaviour
 }
 ```
 ![aspid_fasttools_serializable_type.gif](../Images/aspid_fasttools_serializable_type.gif)
+
 ### TypeSelectorAttribute
 
 Атрибут `PropertyAttribute`, доступный только в редакторе, ограничивающий всплывающее окно выбора типа конкретными базовыми типами. Применяется к полям `string`, хранящим assembly-qualified имена типов.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ public sealed class AbilitySelector : MonoBehaviour
 }
 ```
 ![aspid_fasttools_serializable_type.gif](Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/Images/aspid_fasttools_serializable_type.gif)
+
 ### TypeSelectorAttribute
 
 An editor-only `PropertyAttribute` that restricts the type selection popup to specific base types. Applied to `string` fields that store assembly-qualified type names.

--- a/README_RU.md
+++ b/README_RU.md
@@ -155,6 +155,7 @@ public sealed class AbilitySelector : MonoBehaviour
 }
 ```
 ![aspid_fasttools_serializable_type.gif](Aspid.FastTools/Assets/Plugins/Aspid/FastTools/Documentation/Images/aspid_fasttools_serializable_type.gif)
+
 ### TypeSelectorAttribute
 
 Атрибут `PropertyAttribute`, доступный только в редакторе, ограничивающий всплывающее окно выбора типа конкретными базовыми типами. Применяется к полям `string`, хранящим assembly-qualified имена типов.


### PR DESCRIPTION
## Summary

- Insert a blank line between the `aspid_fasttools_serializable_type.gif` image and the `### TypeSelectorAttribute` heading in all four README copies (root EN/RU + `Documentation/EN`/`RU`), so the heading renders correctly under the image instead of being glued to it.

## Notes for review

- Whitespace-only change; identical 1-line insertion in each of the four README files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1M6EGocj93nbq5k6WRqJ2)_