### PR TITLE
Bump version to 1.0.0-rc.2 and switch UPM URLs to upm branch

### DIFF
--- a/Aspid.FastTools/Assets/Aspid/FastTools/CHANGELOG.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] — 2026-05-18
+
+Release-workflow validation build. No functional changes versus `1.0.0-rc.1`.
+
+### Changed
+- Integration URL in all four READMEs now points at the dedicated `upm` branch / `upm/<version>` tag published by the release workflow (no `?path=` query needed).
+
 ## [1.0.0-rc.1] — 2026-05-18
 
 First release candidate for `1.0.0`. Marketed as a preview while the **ID System** is finalised — its public API, generated boilerplate and editor workflow may still change before the final `1.0.0` release.
@@ -82,5 +89,6 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 - EN and RU READMEs at the package root and at `Documentation/EN/` and `Documentation/RU/`, mirroring the same content with language-appropriate image paths.
 - Per-feature reference documents next to each README: `SerializedPropertyExtensions.md`, `VisualElementExtensions.md`.
 
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.1...HEAD
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/VPDPersonal/Aspid.FastTools/releases/tag/v1.0.0-rc.1

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
@@ -26,16 +26,16 @@
 
 ## Integration
 
-Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL:
+Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes a `upm` branch containing only the package contents at its root, so no `?path=` query is needed:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 ```
 
-To install a specific version, append the release tag as a `#<tag>` fragment (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available tags):
+To install a specific version, target the immutable per-release tag `upm/<version>` (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools#v1.0.0-rc.1
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
 ```
 
 ---

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
@@ -26,16 +26,16 @@
 
 ## Integration
 
-Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL:
+Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует ветку `upm`, в корне которой лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 ```
 
-Чтобы установить конкретную версию, добавьте тег релиза в виде `#<tag>`-фрагмента (список доступных тегов — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
+Чтобы установить конкретную версию, укажите неизменяемый per-release тег `upm/<version>` (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools#v1.0.0-rc.1
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
 ```
 
 ---

--- a/Aspid.FastTools/Assets/Aspid/FastTools/package.json
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.aspid.fasttools",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "displayName": "Aspid.FastTools",
   "description": "Unity tools to cut boilerplate — source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",
   "unity": "6000.0",

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@
 
 ## Integration
 
-Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL:
+Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes a `upm` branch containing only the package contents at its root, so no `?path=` query is needed:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 ```
 
-To install a specific version, append the release tag as a `#<tag>` fragment (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available tags):
+To install a specific version, target the immutable per-release tag `upm/<version>` (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools#v1.0.0-rc.1
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
 ```
 
 ---

--- a/README_RU.md
+++ b/README_RU.md
@@ -28,16 +28,16 @@
 
 ## Integration
 
-Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL:
+Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует ветку `upm`, в корне которой лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 ```
 
-Чтобы установить конкретную версию, добавьте тег релиза в виде `#<tag>`-фрагмента (список доступных тегов — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
+Чтобы установить конкретную версию, укажите неизменяемый per-release тег `upm/<version>` (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git?path=Aspid.FastTools/Assets/Aspid/FastTools#v1.0.0-rc.1
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Bumps `package.json` to `1.0.0-rc.2` and adds the matching `## [1.0.0-rc.2] — 2026-05-18` section to `CHANGELOG.md` (with the `compare/v1.0.0-rc.1...v1.0.0-rc.2` reference link), so the release workflow's CHANGELOG-extraction step has a section to lift into the GitHub Release body.
- Switches the UPM install URL in all four READMEs (root `README.md` / `README_RU.md` and `Documentation/EN` / `Documentation/RU`) from the legacy `?path=Aspid.FastTools/Assets/Aspid/FastTools` form to the dedicated `upm` branch / `upm/<version>` tag published by the new release workflow's subtree split — package contents live at the root of the ref, so no `?path=` query is needed:
  ```
  https://github.com/VPDPersonal/Aspid.FastTools.git#upm
  https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
  ```

## Notes for review

- Cut as a test of the release workflow added in #29 — no functional code changes, no generator changes, the deployed `Aspid.FastTools.Generators.dll` is untouched.
- After merge, dispatch the `Release` workflow with `version: 1.0.0-rc.2` (or push a `v1.0.0-rc.2` tag) to exercise the full path: tag → subtree split → `upm` branch / `upm/1.0.0-rc.2` tag → GitHub prerelease.

## Linked issues


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYtku4ATsLJeRkwu1bwAmY)_