### PR TITLE
Add upm-preview URLs to READMEs

### DIFF
--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
@@ -26,16 +26,23 @@
 
 ## Integration
 
-Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes a `upm` branch containing only the package contents at its root, so no `?path=` query is needed:
+Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes two branches containing only the package contents at their root, so no `?path=` query is needed:
+
+| Branch | Contents |
+|---|---|
+| `upm` | Latest **stable** release |
+| `upm-preview` | Latest **preview** release (rc, beta, alpha, …) |
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
-To install a specific version, target the immutable per-release tag `upm/<version>` (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
+To install a specific version, target the immutable per-release tag (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 
 ---

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
@@ -26,16 +26,23 @@
 
 ## Integration
 
-Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует ветку `upm`, в корне которой лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
+Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует две ветки, в корне которых лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
+
+| Ветка | Содержимое |
+|---|---|
+| `upm` | Последний **стабильный** релиз |
+| `upm-preview` | Последний **preview** релиз (rc, beta, alpha, …) |
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
-Чтобы установить конкретную версию, укажите неизменяемый per-release тег `upm/<version>` (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
+Чтобы установить конкретную версию, укажите неизменяемый per-release тег (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,16 +28,23 @@
 
 ## Integration
 
-Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes a `upm` branch containing only the package contents at its root, so no `?path=` query is needed:
+Install Aspid.FastTools via UPM (Unity Package Manager) — add the package using its Git URL. The release workflow publishes two branches containing only the package contents at their root, so no `?path=` query is needed:
+
+| Branch | Contents |
+|---|---|
+| `upm` | Latest **stable** release |
+| `upm-preview` | Latest **preview** release (rc, beta, alpha, …) |
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
-To install a specific version, target the immutable per-release tag `upm/<version>` (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
+To install a specific version, target the immutable per-release tag (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 
 ---

--- a/README_RU.md
+++ b/README_RU.md
@@ -28,16 +28,23 @@
 
 ## Integration
 
-Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует ветку `upm`, в корне которой лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
+Установите Aspid.FastTools через UPM (Unity Package Manager) — добавьте пакет по его Git URL. Релизный workflow публикует две ветки, в корне которых лежит само содержимое пакета, поэтому параметр `?path=` указывать не нужно:
+
+| Ветка | Содержимое |
+|---|---|
+| `upm` | Последний **стабильный** релиз |
+| `upm-preview` | Последний **preview** релиз (rc, beta, alpha, …) |
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
-Чтобы установить конкретную версию, укажите неизменяемый per-release тег `upm/<version>` (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
+Чтобы установить конкретную версию, укажите неизменяемый per-release тег (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Document the `upm` / `upm-preview` branch split introduced in #31
- Add a table explaining which branch serves stable vs preview releases
- Update installation examples to show both `upm` and `upm-preview` URLs with per-version tag examples

## Linked issues

Refs #31