### PR TITLE
Expand BaseField .meta files and add .zed to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/settings.local.json
 .worktrees/
+.zed/
 
 # UPM convention: `Samples~` is hidden from Unity importer but must be tracked.
 # Override global `*~` ignore.

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFieldExtensionsSetLabelQuaternion.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFieldExtensionsSetLabelQuaternion.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: f00d796bf1574aaf8014ad61a4265ea3
-timeCreated: 1779651087
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelAnimationCurve.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelAnimationCurve.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 59bc1174cae34b3b89f0cc5afc66c730
-timeCreated: 1779651740
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelBounds.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelBounds.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: afc50e3a9b3d42dbb9e8eb8a8d473dba
-timeCreated: 1779651716
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelBoundsInt.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelBoundsInt.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 3152344fb1bd4e3f82a80bfae41b3b51
-timeCreated: 1779651720
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelByte.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelByte.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: babe05b587ae401bb87cfec8029aff8e
-timeCreated: 1779651620
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelChar.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelChar.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: a7803a9724ae4ad7b94a06b9bfd7f267
-timeCreated: 1779651656
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelColor.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelColor.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 4ce625c963a940dd9980b8dc76702433
-timeCreated: 1779651660
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelColor32.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelColor32.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: aae4e62fbd3a4b78b6d49231f80bbadf
-timeCreated: 1779651664
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelDecimal.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelDecimal.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: f639ff2a7b7a4cf8aeb509070b1eabeb
-timeCreated: 1779651647
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelDouble.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelDouble.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: c956291219fe48e5b410cf7983980d80
-timeCreated: 1779651643
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelEnum.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelEnum.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 7fa245d21e3340f08d181d6a53a026ca
-timeCreated: 1779651724
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelFloat.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelFloat.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: a862800655c34f4d82ad1a0de3b4e6cd
-timeCreated: 1779651639
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelGradient.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelGradient.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 9aa250fc505d44d3984ac124958c35ca
-timeCreated: 1779651745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelHash128.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelHash128.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 081bb387baf242ffb33ddea9f46f136e
-timeCreated: 1779651736
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelInt.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelInt.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 470d72e9a3bc484681794904f80d70ff
-timeCreated: 1779651601
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelLong.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelLong.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 96e56cc0885a4978b448d910eff9f074
-timeCreated: 1779651611
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelObject.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelObject.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: f755d90213834f999fd306ccce6aec1d
-timeCreated: 1779651731
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelRect.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelRect.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: f10fc775898743a582956a910791955c
-timeCreated: 1779651708
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelSbyte.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelSbyte.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 7ba363de3b634253b84af99e0cee4f20
-timeCreated: 1779651625
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelShort.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelShort.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 6268150d76dd4407a3145e0333b978b6
-timeCreated: 1779651630
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelString.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelString.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: ab886207cb174fa994ecd1671288bbcf
-timeCreated: 1779651652
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelULong.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelULong.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 912d8d9c7d224d779e6ab9c751def840
-timeCreated: 1779651616
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelUint.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelUint.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: b1c82b41e5714d4d8dcbf896c6c5839f
-timeCreated: 1779651606
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelUshort.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelUshort.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 8a1ee93e4fd543939bd2581c7cd6d0e4
-timeCreated: 1779651635
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector2.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector2.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: d65c28d485fe4e4792d71c56de31b802
-timeCreated: 1779651680
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector2Int.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector2Int.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: c8055b60c12e438da3a5b3792c852a54
-timeCreated: 1779651685
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector3.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector3.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 949ec825c5444442bde994337363dd83
-timeCreated: 1779651695
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector3Int.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector3Int.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 7464ec4dc9964e478881970cd1d60fab
-timeCreated: 1779651699
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector4.cs.meta
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Runtime/VisualElements/Extensions/Field/BaseFields/BaseFieldExtensionsSetLabelVector4.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 76101f990e73454195d90715b59a1fa3
-timeCreated: 1779651703
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Unity re-imported 29 BaseField extension `.meta` files from minimal 3-line stubs to full MonoImporter format with icon references and proper newline termination
- Added `.zed/` to `.gitignore`