### PR TITLE
Rename package from com.aspid.fasttools to tech.aspid.fasttools

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,7 +7,7 @@ You are a C# code reviewer specializing in Unity packages and Roslyn source gene
 
 ## Project Context
 
-This is **Aspid.FastTools** — a Unity package (`com.aspid.fasttools`) with two separate projects:
+This is **Aspid.FastTools** — a Unity package (`tech.aspid.fasttools`) with two separate projects:
 - `Aspid.FastTools/` — Unity project (Runtime + Editor assemblies)
 - `Aspid.FastTools.Generators/` — .NET solution with Roslyn source generators
 

--- a/Aspid.FastTools.Generators/CLAUDE.md
+++ b/Aspid.FastTools.Generators/CLAUDE.md
@@ -1,6 +1,6 @@
 # Aspid.FastTools.Generators
 
-Standalone .NET solution containing Roslyn source generators for the `com.aspid.fasttools` Unity package.
+Standalone .NET solution containing Roslyn source generators for the `tech.aspid.fasttools` Unity package.
 
 ## Commands
 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/CHANGELOG.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Renamed UPM package from `com.aspid.fasttools` to `tech.aspid.fasttools` to align with the `tech.*` reverse-domain convention.
+
 ## [1.0.0-rc.3] — 2026-05-25
 
 ### Added

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Welcome/WelcomeWindow.cs
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Welcome/WelcomeWindow.cs
@@ -20,7 +20,7 @@ namespace Aspid.FastTools.Editors
 
         private const string MenuPath = "Tools/Aspid 🐍/Welcome FastTools";
 
-        private const string PackageName = "com.aspid.fasttools";
+        private const string PackageName = "tech.aspid.fasttools";
         private const string PackageRootPath = "Assets/Aspid/FastTools";
 
         private const string SamplesPath = PackageRootPath + "/Samples";

--- a/Aspid.FastTools/Assets/Aspid/FastTools/package.json
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "com.aspid.fasttools",
+  "name": "tech.aspid.fasttools",
   "version": "1.0.0-rc.3",
   "displayName": "Aspid.FastTools",
   "description": "Unity tools to cut boilerplate — source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-**Aspid.FastTools** is a Unity package (`com.aspid.fasttools`) targeting Unity 6.0+ that minimizes routine boilerplate code. It consists of two separate projects:
+**Aspid.FastTools** is a Unity package (`tech.aspid.fasttools`) targeting Unity 6.0+ that minimizes routine boilerplate code. It consists of two separate projects:
 
 1. **`Aspid.FastTools/`** — The Unity project containing the package source (Runtime + Editor code)
 2. **`Aspid.FastTools.Generators/`** — A standalone .NET solution containing Roslyn source generators


### PR DESCRIPTION
## Summary

- Rename UPM package identifier from `com.aspid.fasttools` to `tech.aspid.fasttools` across all sources: `package.json`, `WelcomeWindow.cs`, and documentation (`CLAUDE.md`, generator `CLAUDE.md`, `code-reviewer.md`).

## Notes for review

- The pre-existing `Aspid.FastTools.Generators.dll` change is **not** included — it was dirty before this branch and is unrelated.
- Consumers that reference the old package name in their `manifest.json` will need to update the entry.

## Linked issues

<!-- N/A -->