### PR TITLE
Split upm and upm-preview URLs into separate code blocks

### DIFF
--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/EN/README.md
@@ -35,6 +35,9 @@ Install Aspid.FastTools via UPM (Unity Package Manager) — add the package usin
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
@@ -42,6 +45,9 @@ To install a specific version, target the immutable per-release tag (see [Releas
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Documentation/RU/README.md
@@ -35,6 +35,9 @@
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
@@ -42,6 +45,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Install Aspid.FastTools via UPM (Unity Package Manager) — add the package usin
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
@@ -44,6 +47,9 @@ To install a specific version, target the immutable per-release tag (see [Releas
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -37,6 +37,9 @@
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 
@@ -44,6 +47,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
+```
+
+```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
 


### PR DESCRIPTION
## Summary

- Split the combined `upm` / `upm-preview` Git URLs in the Integration section into separate code blocks (both the branch URLs and the per-release tag URLs), so each URL can be copied on its own.
- Applied across all four READMEs kept in sync: root `README.md` / `README_RU.md` and `Documentation/EN/README.md` / `Documentation/RU/README.md`.

## Notes for review

Docs-only change; no content edits beyond the code-block split.