### PR TITLE
Add PR status-label automation workflow

### DIFF
--- a/.github/workflows/pr-ready-labels.yml
+++ b/.github/workflows/pr-ready-labels.yml
@@ -1,0 +1,47 @@
+name: PR Ready Labels
+
+on:
+  pull_request_target:
+    types: [ready_for_review, converted_to_draft, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ready for review
+        if: github.event.action == 'ready_for_review'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: work-in-progress' });
+            } catch {}
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['status: needs-review'] });
+
+      - name: Converted to draft
+        if: github.event.action == 'converted_to_draft'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: needs-review' });
+            } catch {}
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['status: work-in-progress'] });
+
+      - name: Closed
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: needs-review' });
+            } catch {}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-ready-labels.yml`, mirroring the equivalent workflow in `Aspid.MVVM`.
- On `ready_for_review`: remove `status: work-in-progress`, add `status: needs-review`.
- On `converted_to_draft`: remove `status: needs-review`, add `status: work-in-progress`.
- On `closed` (new vs. the MVVM original): remove `status: needs-review` — fires both on merge and on close-without-merge, so the status label never lingers on a closed PR.

## Notes for review

- Uses `pull_request_target` with `pull-requests: write` so it works for PRs from forks.
- Each `removeLabel` call is wrapped in `try/catch {}` to avoid failing when the label isn't present.
- The `closed` step intentionally touches only `status: needs-review`; `status: work-in-progress` is left as-is on a closed draft.