### PR TITLE
fix: keep EnumValues flags selection from resetting

### DIFF
--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
@@ -82,12 +82,14 @@ namespace Aspid.FastTools.Enums.Editors
                 }
 
                 var enumValue = (Enum)parsed;
-                keyProperty.SetStringAndApply(enumValue.ToString());
+
+                if (keyProperty.stringValue != enumValue.ToString())
+                    keyProperty.SetStringAndApply(enumValue.ToString());
 
                 if (enumType.IsDefined(typeof(FlagsAttribute), false))
                 {
                     keyEnumFlagField
-                        .SetValue(null)
+                        .SetValue(null, notify: false)
                         .Initialize(enumValue)
                         .SetDisplay(DisplayStyle.Flex);
                 }

--- a/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Enums/EnumValuesPropertyDrawer.cs
+++ b/Aspid.FastTools/Assets/Aspid/FastTools/Unity/Editor/Scripts/Enums/EnumValuesPropertyDrawer.cs
@@ -64,8 +64,10 @@ namespace Aspid.FastTools.Enums.Editors
 
                 for (var i = 0; i < values.arraySize; i++)
                 {
-                    var element = values.GetArrayElementAtIndex(i);
-                    element.FindPropertyRelative("_enumType").SetStringAndApply(enumTypeValue);
+                    var enumTypeElement = values.GetArrayElementAtIndex(i).FindPropertyRelative("_enumType");
+
+                    if (enumTypeElement.stringValue != enumTypeValue)
+                        enumTypeElement.SetStringAndApply(enumTypeValue);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fix `[Flags]` enum keys in `EnumValues<TValue>` resetting to `None` while editing or after adding an entry.
- `EnumValuePropertyDrawer`: refresh the `EnumFlagsField` without notification (`SetValue(null, notify: false)`) so the programmatic reset no longer fires the value-changed callback that wiped the stored key; only write `_key` back when the parsed value actually differs.
- `EnumValuesPropertyDrawer`: skip identical `_enumType` writes so a key edit no longer marks the object dirty and re-enters the per-row drawer mid-edit.

## Notes for review

The Flags branch was the only path adding a notifying `SetValue(null)` before `Init` — the regular enum branch already used `Initialize` (no notify), which is why non-Flags enums were unaffected. Editor-only change; no runtime/generator impact.