### PR TITLE
chore: release 1.0.0-rc.5

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech.aspid.fasttools",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "displayName": "Aspid.FastTools",
   "description": "Unity tools to cut boilerplate \u2014 source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",
   "unity": "6000.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.5] — 2026-06-06
+
+Packaging-only release. No functional or API changes versus `1.0.0-rc.4`.
+
+### Changed
+- The package is now developed as an embedded UPM package under `Packages/tech.aspid.fasttools` (previously kept inside the Unity project's `Assets/`), aligning the repository layout with the published `upm` / `upm-preview` subtree. No effect on the published package contents. ([#44])
+
 ## [1.0.0-rc.4] — 2026-06-05
 
 ### Fixed
@@ -128,7 +135,9 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 [#33]: https://github.com/VPDPersonal/Aspid.FastTools/pull/33
 [#38]: https://github.com/VPDPersonal/Aspid.FastTools/pull/38
 [#43]: https://github.com/VPDPersonal/Aspid.FastTools/pull/43
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...HEAD
+[#44]: https://github.com/VPDPersonal/Aspid.FastTools/pull/44
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
+[1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.1...v1.0.0-rc.2


### PR DESCRIPTION
## Summary

- Bump `tech.aspid.fasttools` to `1.0.0-rc.5`.
- Add the matching `## [1.0.0-rc.5]` CHANGELOG section.

Packaging-only release reflecting the embedded UPM layout introduced in #44. No functional or API changes versus `1.0.0-rc.4` — the published `upm-preview` subtree content is identical.

## Notes for review

Verified locally that `git subtree split --prefix=Aspid.FastTools/Packages/tech.aspid.fasttools` produces a clean package root (package.json at root, generator DLL present), so the preview release workflow will publish correctly.