### PR TITLE
Collapse Preview install section and add donate quick link

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
@@ -2,6 +2,8 @@
 
 **Aspid.FastTools** is a set of tools designed to minimize routine code writing in Unity. It combines Roslyn-powered source generators with a curated collection of runtime and editor utilities — including per-call-site `ProfilerMarker` registration, a serializable `System.Type`, an `EnumValues<TValue>` dictionary, a stable `int ↔ string` ID registry, fluent UI Toolkit extensions and IMGUI layout scopes.
 
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
+
 ## Source Code
 
 [[Aspid.FastTools](https://github.com/VPDPersonal/Aspid.FastTools)]
@@ -42,7 +44,12 @@ To install a specific version, target the immutable per-release tag (see [Releas
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
 ```
 
-### Preview
+Prefer a manual install? Download the `.unitypackage` from the [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) page, or get the package from the [Unity Asset Store](https://assetstore.unity.com/packages/slug/365584).
+
+<details>
+<summary><strong>Preview</strong></summary>
+
+<br>
 
 The `upm-preview` branch always points to the latest **preview** release (rc, beta, alpha, …):
 
@@ -55,6 +62,8 @@ To install a specific preview version, target the immutable per-release tag (see
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
+
+</details>
 
 ---
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
@@ -2,6 +2,8 @@
 
 **Aspid.FastTools** — набор инструментов, предназначенных для минимизации рутинного написания кода в Unity. Пакет объединяет генераторы кода на базе Roslyn и подборку runtime- и editor-утилит: регистрация `ProfilerMarker` для каждого места вызова, сериализуемый `System.Type`, словарь `EnumValues<TValue>`, стабильный реестр `int ↔ string` ID, fluent-расширения UI Toolkit и IMGUI-скоупы для разметки.
 
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
+
 ## Source Code
 
 [[Aspid.FastTools](https://github.com/VPDPersonal/Aspid.FastTools)]
@@ -42,7 +44,12 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
 ```
 
-### Preview
+Предпочитаете установку вручную? Скачайте `.unitypackage` со страницы [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) или возьмите пакет в [Unity Asset Store](https://assetstore.unity.com/packages/slug/365584).
+
+<details>
+<summary><strong>Preview</strong></summary>
+
+<br>
 
 Ветка `upm-preview` всегда указывает на последний **preview** релиз (rc, beta, alpha, …):
 
@@ -55,6 +62,8 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/VPDPersonal/Aspid.FastTools?label=License&labelColor=254d2c&color=4fa35d" alt="License" /></a>
 </p>
 
-### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
-
 **Aspid.FastTools** is a set of tools designed to minimize routine code writing in Unity. It combines Roslyn-powered source generators with a curated collection of runtime and editor utilities — including per-call-site `ProfilerMarker` registration, a serializable `System.Type`, an `EnumValues<TValue>` dictionary, a stable `int ↔ string` ID registry, fluent UI Toolkit extensions and IMGUI layout scopes.
+
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/VPDPersonal/Aspid.FastTools?label=License&labelColor=254d2c&color=4fa35d" alt="License" /></a>
 </p>
 
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
+
 **Aspid.FastTools** is a set of tools designed to minimize routine code writing in Unity. It combines Roslyn-powered source generators with a curated collection of runtime and editor utilities — including per-call-site `ProfilerMarker` registration, a serializable `System.Type`, an `EnumValues<TValue>` dictionary, a stable `int ↔ string` ID registry, fluent UI Toolkit extensions and IMGUI layout scopes.
 
 ## Table of Contents
@@ -45,7 +47,12 @@ To install a specific version, target the immutable per-release tag (see [Releas
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
 ```
 
-### Preview
+Prefer a manual install? Download the `.unitypackage` from the [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) page, or get the package from the [Unity Asset Store](https://assetstore.unity.com/packages/slug/365584).
+
+<details>
+<summary><strong>Preview</strong></summary>
+
+<br>
 
 The `upm-preview` branch always points to the latest **preview** release (rc, beta, alpha, …):
 
@@ -58,6 +65,8 @@ To install a specific preview version, target the immutable per-release tag (see
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
+
+</details>
 
 ---
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -7,6 +7,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/VPDPersonal/Aspid.FastTools?label=License&labelColor=254d2c&color=4fa35d" alt="License" /></a>
 </p>
 
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
+
 **Aspid.FastTools** — набор инструментов, предназначенных для минимизации рутинного написания кода в Unity. Пакет объединяет генераторы кода на базе Roslyn и подборку runtime- и editor-утилит: регистрация `ProfilerMarker` для каждого места вызова, сериализуемый `System.Type`, словарь `EnumValues<TValue>`, стабильный реестр `int ↔ string` ID, fluent-расширения UI Toolkit и IMGUI-скоупы для разметки.
 
 ## Содержание
@@ -45,7 +47,12 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm/1.0.0
 ```
 
-### Preview
+Предпочитаете установку вручную? Скачайте `.unitypackage` со страницы [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) или возьмите пакет в [Unity Asset Store](https://assetstore.unity.com/packages/slug/365584).
+
+<details>
+<summary><strong>Preview</strong></summary>
+
+<br>
 
 Ветка `upm-preview` всегда указывает на последний **preview** релиз (rc, beta, alpha, …):
 
@@ -58,6 +65,8 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 ```
 https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 ```
+
+</details>
 
 ---
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -7,9 +7,9 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/VPDPersonal/Aspid.FastTools?label=License&labelColor=254d2c&color=4fa35d" alt="License" /></a>
 </p>
 
-### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
-
 **Aspid.FastTools** — набор инструментов, предназначенных для минимизации рутинного написания кода в Unity. Пакет объединяет генераторы кода на базе Roslyn и подборку runtime- и editor-утилит: регистрация `ProfilerMarker` для каждого места вызова, сериализуемый `System.Type`, словарь `EnumValues<TValue>`, стабильный реестр `int ↔ string` ID, fluent-расширения UI Toolkit и IMGUI-скоупы для разметки.
+
+### \[[Unity Asset Store](https://assetstore.unity.com/packages/slug/365584)\] \[[Donate](#donate)\]
 
 ## Содержание
 


### PR DESCRIPTION
## Summary

- Wrap the **Preview** UPM install subsection in a `<details>` block so it is collapsed by default, keeping the install section focused on the stable flow.
- Note the manual `.unitypackage` install (Releases page / Unity Asset Store) right under the **Stable** instructions.
- Add a top-of-readme quick link `\[[Unity Asset Store]\] \[[Donate]\]` mirroring the Aspid.MVVM readme; donate currently routes to the Asset Store only.
- Applied identically across all four README copies: root `README.md` / `README_RU.md` and `Documentation/EN` / `Documentation/RU`.

## Notes for review

- Docs-only change; no code or area-specific files touched, so no `area: *` label applies.