### PR TITLE
chore: release 1.0.0

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
@@ -53,7 +53,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 To install a specific preview version, target the immutable per-release tag (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
 ```
 
 ---

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
@@ -53,7 +53,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Чтобы установить конкретную preview-версию, укажите неизменяемый per-release тег (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
 ```
 
 ---

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech.aspid.fasttools",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0",
   "displayName": "Aspid.FastTools",
   "description": "Unity tools to cut boilerplate \u2014 source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",
   "unity": "6000.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-06-06
+
+First stable release. Consolidates everything from the `1.0.0-rc.*` cycle; the **ID System** graduates from Beta to a stable, supported API. No functional or API changes versus `1.0.0-rc.5`.
+
+### Highlights
+- **ProfilerMarkers** — `this.Marker()` extension backed by `ProfilerMarkersGenerator`, emitting one zero-cost `ProfilerMarker` per call-site (gated behind `#if ENABLE_PROFILER`).
+- **Serializable Type System** — `SerializableType` / `SerializableType<T>`, `[TypeSelector]`, `ComponentTypeSelector` and the `TypeSelectorWindow` picker (IMGUI + UI Toolkit drawers).
+- **Enum System** — `EnumValues<TValue>` enum-keyed dictionary (with `[Flags]` support) and `EnumValue<TKey, TValue>`, plus inline inspector drawers.
+- **ID System** — `IId` / `[UniqueId]` structs bound to `IdRegistry` assets for stable `int ↔ string` IDs, `IdStructGenerator` boilerplate, `AFID001`/`AFID002` diagnostics and the `RegistryEditorCore` editor UI.
+- **VisualElement fluent extensions** — extensive UI Toolkit fluent API (layout, sizing, style, borders, colors, transitions, callbacks, USS, child management) across all common element types, with conditional `*If` variants and per-type `SetLabel` overloads.
+- **Optional Mathematics integration** — satellite assembly adding `INotifyValueChanged` extensions for `Unity.Mathematics` types, compiled only when `com.unity.mathematics` is installed.
+- **Editor tooling** — `SerializedProperty` fluent helpers, IMGUI scopes, `MonoScript` name helpers, internal UI Toolkit component library and the `WelcomeWindow`.
+- **Samples & docs** — five installable samples (`Types`, `EnumValues`, `Ids`, `ProfilerMarkers`, `VisualElements`) and EN/RU READMEs with per-feature reference docs.
+
+See the `1.0.0-rc.1` … `1.0.0-rc.5` sections below for the full itemised history.
+
 ## [1.0.0-rc.5] — 2026-06-06
 
 Packaging-only release. No functional or API changes versus `1.0.0-rc.4`.
@@ -136,7 +152,8 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 [#38]: https://github.com/VPDPersonal/Aspid.FastTools/pull/38
 [#43]: https://github.com/VPDPersonal/Aspid.FastTools/pull/43
 [#44]: https://github.com/VPDPersonal/Aspid.FastTools/pull/44
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...v1.0.0
 [1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...v1.0.0-rc.3

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 To install a specific preview version, target the immutable per-release tag (see [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases) for the list of available versions):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
 ```
 
 ---

--- a/README_RU.md
+++ b/README_RU.md
@@ -56,7 +56,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Чтобы установить конкретную preview-версию, укажите неизменяемый per-release тег (список доступных версий — на странице [Releases](https://github.com/VPDPersonal/Aspid.FastTools/releases)):
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Bump `tech.aspid.fasttools` package version `1.0.0-rc.5` → `1.0.0` — the first stable release.
- Add the `[1.0.0]` CHANGELOG section summarising the full feature set delivered across the `1.0.0-rc.*` cycle; the **ID System** graduates from Beta to a stable, supported API.
- Bump the preview install URL in all four READMEs `upm-preview/1.0.0-rc.2` → `upm-preview/1.0.0-rc.5` to match the latest published preview tag.

## Notes for review

- No functional or API changes versus `1.0.0-rc.5` — this is a version/changelog/docs cut only.
- The `[1.0.0]` entry is a consolidated highlights summary; the itemised per-feature history remains in the `rc.1`…`rc.5` sections below it.
- Comparison links updated: `[Unreleased]` now points at `v1.0.0`, and a `[1.0.0]` link was added.

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- Бамп версии пакета `tech.aspid.fasttools` `1.0.0-rc.5` → `1.0.0` — первый стабильный релиз.
- Добавлена секция `[1.0.0]` в CHANGELOG, суммирующая всю функциональность цикла `1.0.0-rc.*`; **ID System** переходит из Beta в стабильный поддерживаемый API.
- Preview-URL установки во всех четырёх README обновлён `upm-preview/1.0.0-rc.2` → `upm-preview/1.0.0-rc.5` под последний опубликованный preview-тег.

## Notes for review

- Функциональных и API-изменений относительно `1.0.0-rc.5` нет — только версия/чейнджлог/доки.
- Секция `[1.0.0]` — консолидированные highlights; попунктная история остаётся в секциях `rc.1`…`rc.5` ниже.
- Обновлены ссылки сравнения: `[Unreleased]` теперь указывает на `v1.0.0`, добавлена ссылка `[1.0.0]`.

</details>
