### PR TITLE
Fix TypeSelector picker crash on null Type[] element

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeSelectorPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeSelectorPropertyDrawer.cs
@@ -111,7 +111,7 @@ namespace Aspid.FastTools.Types.Editors
                     return;
                 
                 case Type[] typeArray:
-                    types.AddRange(typeArray);
+                    types.AddRange(typeArray.Where(t => t is not null));
                     return;
                 
                 case string assemblyQualifiedName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A `null` element in a `Type[]` member referenced by a `string` / `SerializableType` `[TypeSelector]` field no longer throws `NullReferenceException` and aborts the type picker — null entries are now filtered out before building the candidate list. ([#51])
+
 ## [1.0.0-rc.5] — 2026-06-06
 
 Packaging-only release. No functional or API changes versus `1.0.0-rc.4`.
@@ -136,6 +139,7 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 [#38]: https://github.com/VPDPersonal/Aspid.FastTools/pull/38
 [#43]: https://github.com/VPDPersonal/Aspid.FastTools/pull/43
 [#44]: https://github.com/VPDPersonal/Aspid.FastTools/pull/44
+[#51]: https://github.com/VPDPersonal/Aspid.FastTools/pull/51
 [Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
 [1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4


### PR DESCRIPTION
## Summary

- A `null` element in a `Type[]` member bound to a `string` / `SerializableType` `[TypeSelector]` field was added unfiltered and reached `TypeInfo.GetAllTypeInfos`, where `baseType.IsAssignableFrom(t)` threw a `NullReferenceException` and aborted the type picker dropdown.
- Filter nulls out of the `Type[]` case in `TypeSelectorPropertyDrawer.AddTypesFromMember`:

  ```csharp
  case Type[] typeArray:
      types.AddRange(typeArray.Where(t => t is not null));
      return;
  ```

- Added a CHANGELOG entry under `[Unreleased]` → `Fixed`.

## Notes for review

- Narrow fix per the ASP-23 scope audit: the other value paths (`case null`, single `Type`, `string`, `string[]`, and the `[SerializeReference]` managed-reference path) are already null-safe, so only the `Type[]` case needed the guard.
- The CHANGELOG link reference targets `#51` as the anticipated PR number — will correct if GitHub assigns a different one.

## Linked issues

Closes ASP-23