### PR TITLE
Align SerializeReference UIToolkit notice position with IMGUI

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Guards the cross-drawer notice-position contract (ASP-24): the UIToolkit <see cref="SerializeReferenceField"/>
+    /// must render a per-asset notice ABOVE the assigned instance's child fields, exactly like the IMGUI drawer, which
+    /// draws notices after the header row and before the children. The regression was that the notices were appended to
+    /// the field root after the foldout, so when expanded they sat BELOW the children.
+    /// </summary>
+    /// <remarks>
+    /// Reuses <c>LinkerTestObject</c> / <c>TestSword</c> from <see cref="SerializeReferenceInspectorTests"/>: linking two
+    /// managed-reference fields onto one rid surfaces the shared-reference notice on a field that also has a value (so it
+    /// renders child fields), which is the only notice that co-exists with children — the case the bug was about.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class SerializeReferenceFieldNoticeLayoutTests
+    {
+        [Test]
+        public void SharedNotice_RendersAboveChildFields()
+        {
+            var obj = ScriptableObject.CreateInstance<LinkerTestObject>();
+            try
+            {
+                var serialized = new SerializedObject(obj);
+                serialized.FindProperty("a").managedReferenceValue = new TestSword { damage = 7 };
+                serialized.ApplyModifiedProperties();
+
+                // Put both fields on one shared rid so field 'a' shows the shared-reference notice while still holding a
+                // value (and therefore rendering the TestSword.damage child field).
+                Assert.IsTrue(SerializeReferenceLinker.LinkTo(serialized.FindProperty("b"), "a"));
+                serialized.Update();
+
+                var property = serialized.FindProperty("a");
+                property.isExpanded = true;
+
+                var field = new SerializeReferenceField("A", property);
+
+                var notice = FindFirst<SerializeReferenceNotice>(field);
+                Assert.IsNotNull(notice, "A shared reference must surface a notice in the UIToolkit field.");
+
+                var content = FindFirstWithClass(field, Foldout.contentUssClassName);
+                Assert.IsNotNull(content, "The foldout content container (which hosts the child fields) must exist.");
+
+                // The notice must NOT live inside the content container — it is a sibling that precedes it, so it never
+                // inherits the child indent and always renders above the children.
+                Assert.IsFalse(IsAncestorOf(content, notice),
+                    "The notice must not be nested inside the foldout content (the children container).");
+
+                Assert.Less(
+                    PreOrderIndex(field, notice),
+                    PreOrderIndex(field, content),
+                    "The notice must render above (before) the foldout content/children, matching the IMGUI drawer.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(obj);
+            }
+        }
+
+        // Pre-order (document-order) position of an element in the real visual tree, so "renders above" reduces to a
+        // smaller index. Walks the hierarchy (not the contentContainer view) so the toggle, the notices host and the
+        // content container are all visited as siblings of the foldout.
+        private static int PreOrderIndex(VisualElement root, VisualElement target)
+        {
+            var index = 0;
+            foreach (var element in DescendantsAndSelf(root))
+            {
+                if (element == target) return index;
+                index++;
+            }
+
+            return -1;
+        }
+
+        private static T FindFirst<T>(VisualElement root) where T : VisualElement
+        {
+            foreach (var element in DescendantsAndSelf(root))
+                if (element is T match)
+                    return match;
+
+            return null;
+        }
+
+        private static VisualElement FindFirstWithClass(VisualElement root, string className)
+        {
+            foreach (var element in DescendantsAndSelf(root))
+                if (element.ClassListContains(className))
+                    return element;
+
+            return null;
+        }
+
+        private static bool IsAncestorOf(VisualElement ancestor, VisualElement node)
+        {
+            for (var current = node.hierarchy.parent; current is not null; current = current.hierarchy.parent)
+                if (current == ancestor)
+                    return true;
+
+            return false;
+        }
+
+        private static IEnumerable<VisualElement> DescendantsAndSelf(VisualElement root)
+        {
+            yield return root;
+
+            for (var i = 0; i < root.hierarchy.childCount; i++)
+                foreach (var descendant in DescendantsAndSelf(root.hierarchy[i]))
+                    yield return descendant;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81d5faee01a145f1b06783e54fda3f98

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -32,6 +32,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string EmptyClass = BlockClass + "--empty";
         private const string DropdownClass = BlockClass + "__dropdown";
 
+        // Wrapper that hosts the per-asset notices (missing / shared / required / mixed) between the foldout toggle and
+        // its content, so an expanded field shows the notices ABOVE its child fields — matching the IMGUI drawer.
+        private const string NoticesClass = BlockClass + "__notices";
+
         // A single 3 px stripe on the field's left edge flags it at a glance. The --active modifier gives it width;
         // the colour is either set inline from code (the per-rid shared-reference colour) or, for the --warning
         // modifier (a missing type), pulled from the warning palette in USS.
@@ -61,6 +65,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private readonly VisualElement _dropdown;
         private readonly Button _openButton;
         private readonly VisualElement _content;
+        private readonly VisualElement _notices;
         private readonly SerializedProperty _property;
         private readonly Type _fieldType;
         private readonly Type[] _baseTypes;
@@ -96,6 +101,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _foldout = new Foldout();
             _foldout.RegisterValueChangedCallback(OnFoldoutToggled);
             _content = _foldout.contentContainer;
+
+            // Host the per-asset notices between the foldout toggle and its content. When the foldout is expanded the
+            // notices then render ABOVE the child fields — matching the IMGUI drawer, which draws the same notices after
+            // the header row and before the children. Appended straight to `this` (after the foldout) they would instead
+            // sit BELOW the children. As a sibling of the content container — not inside it — the host carries no child
+            // indent and stays visible while the foldout is collapsed, exactly like the IMGUI path.
+            _notices = new VisualElement().AddClass(NoticesClass);
+            _foldout.hierarchy.Insert(_foldout.hierarchy.IndexOf(_content), _notices);
 
             _caption = new TextElement()
                 .AddClass(EnumField.textUssClassName)
@@ -251,7 +264,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             _mixedNotice ??= new SerializeReferenceNotice();
-            if (_mixedNotice.parent is null) this.AddChild(_mixedNotice);
+            if (_mixedNotice.parent is null) _notices.AddChild(_mixedNotice);
 
             // Stands in for the per-instance child fields, which cannot be merged across different types. Keep it
             // terse and non-actionable: selecting a single object restores its own field, or picking a type from the
@@ -274,7 +287,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             _requiredNotice ??= new SerializeReferenceNotice();
-            if (_requiredNotice.parent is null) this.AddChild(_requiredNotice);
+            if (_requiredNotice.parent is null) _notices.AddChild(_requiredNotice);
 
             SerializeReferenceRequiredGate.TryGetRequired(_property, out var selector);
             var message = string.IsNullOrEmpty(selector?.RequiredMessage) ? "Required reference is not set" : selector.RequiredMessage;
@@ -303,7 +316,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             _missingNotice ??= new SerializeReferenceNotice();
-            if (_missingNotice.parent is null) this.AddChild(_missingNotice);
+            if (_missingNotice.parent is null) _notices.AddChild(_missingNotice);
 
             var typeName = SerializeReferenceHelpers.GetMissingTypeDisplayName(_property);
 
@@ -369,7 +382,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _sharedStripeColor = ridColorsEnabled ? SerializeReferenceRidColor.ForRid(rid) : null;
 
             _sharedNotice ??= new SerializeReferenceNotice();
-            if (_sharedNotice.parent is null) this.AddChild(_sharedNotice);
+            if (_sharedNotice.parent is null) _notices.AddChild(_sharedNotice);
 
             _sharedNotice.Set(
                 message: "Shared reference —",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The **Repair Missing References** and **Managed References** windows are merged into a single workbench whose tabs are individual menu entries under `Tools → Aspid 🐍 → FastTools` — **Welcome**, **Asset References** (the reference graph with inline Fix / Clear / Open Source Prefab — which subsumes the old per-asset repair list), **Project References** (the project-wide grouped bulk fix), and **Settings**. A result in Project References links straight to that asset's Asset References graph.
 - The per-property missing-type probe now caches the asset YAML by path + write-time, eliminating a `File.ReadAllLines` on every IMGUI repaint.
 
+### Fixed
+- The UIToolkit `[TypeSelector]` managed-reference drawer now renders its missing / shared / required notices **above** the assigned instance's child fields when the foldout is expanded, matching the IMGUI drawer (the notices previously appeared *below* the children because they were appended to the field root after the foldout). They are now hosted between the foldout toggle and its content, so collapsed-state behaviour is unchanged.
+
 ### Added (internal)
 - First package test coverage: an `Aspid.FastTools.Unity.Editor.Tests` EditMode assembly exercising the `SerializeReferenceYamlEditor` parser (missing-type discovery, propertyPath → rid resolution incl. nested/list, stored-type reading, round-trip rewrite, entry removal, diff-preview consistency) plus the YAML probe cache.
 


### PR DESCRIPTION
## Summary

- The UIToolkit `[TypeSelector]` managed-reference drawer (`SerializeReferenceField`) appended its missing / shared / required notices to the field root **after** the foldout, so an expanded reference rendered them **below** the child fields — while the IMGUI drawer draws the same notices **above** the children.
- Host the notices in a wrapper inserted between the foldout toggle and its content, so both drawers now place the notice above the children. Collapsed-state behaviour and horizontal alignment are unchanged.

## Notes for review

- Pure UIToolkit layout change — no USS edits needed. The `.aspid-fasttools-reference-notice` block keeps its own `margin` / 5px left inset, which still clears the absolutely-positioned left stripe (`left: 0`) regardless of nesting.
- The notice host is a sibling of (not inside) the foldout content container, so it carries no child indent and stays visible while collapsed — matching the IMGUI path, which also draws notices when collapsed.
- Added an EditMode test that builds the field for a shared reference and asserts the notice precedes the foldout content in the visual tree. Tests run inside the Unity editor (no CLI runner in this environment), so they were not executed locally.

## Linked issues

Closes ASP-24