### PR TITLE
Propagate SerializeReference settings changes to index and surfaces

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSettingsTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSettingsTests.cs
@@ -1,0 +1,148 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Behavioural coverage for the SerializeReference settings propagation contract (ASP-22):
+    /// <list type="bullet">
+    /// <item>the excluded-folder set raises the dedicated <see cref="SerializeReferenceSettings.ExcludedFoldersChanged"/>
+    /// signal only when it genuinely changes — so the usage index drops its warm copy on a real change but an unrelated
+    /// setting never triggers a costly index rebuild;</item>
+    /// <item>the shared controls built by <see cref="SerializeReferenceSettingsUI"/> mirror the store live, so the
+    /// in-window Settings tab and the Project Settings page stay in sync when either edits a value.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceSettingsTests
+    {
+        private bool _ridColors;
+        private bool _autoDeAlias;
+        private string[] _excludedFolders;
+        private GateSeverity _buildSeverity;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Snapshot the project's real settings so the assertions below can mutate them freely and restore on teardown.
+            _ridColors = SerializeReferenceSettings.RidColorsEnabled;
+            _autoDeAlias = SerializeReferenceSettings.AutoDeAliasEnabled;
+            _excludedFolders = SerializeReferenceSettings.ExcludedFolders;
+            _buildSeverity = SerializeReferenceSettings.BuildSeverity;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SerializeReferenceSettings.RidColorsEnabled = _ridColors;
+            SerializeReferenceSettings.AutoDeAliasEnabled = _autoDeAlias;
+            SerializeReferenceSettings.ExcludedFolders = _excludedFolders;
+            SerializeReferenceSettings.BuildSeverity = _buildSeverity;
+        }
+
+        // -----------------------------------------------------------------------------------------------------
+        // A — excluded folders drive the dedicated index-invalidation signal (and nothing else does)
+        // -----------------------------------------------------------------------------------------------------
+
+        [Test]
+        public void ExcludedFolders_NewValue_RaisesExcludedFoldersChanged()
+        {
+            SerializeReferenceSettings.ExcludedFolders = Array.Empty<string>();
+
+            var fired = 0;
+            void Handler() => fired++;
+            SerializeReferenceSettings.ExcludedFoldersChanged += Handler;
+            try
+            {
+                SerializeReferenceSettings.ExcludedFolders = new[] { "Assets/Third Party/" };
+                Assert.AreEqual(1, fired, "A genuinely new excluded-folder set must raise ExcludedFoldersChanged exactly once.");
+            }
+            finally { SerializeReferenceSettings.ExcludedFoldersChanged -= Handler; }
+        }
+
+        [Test]
+        public void ExcludedFolders_SameValue_DoesNotRaiseExcludedFoldersChanged()
+        {
+            SerializeReferenceSettings.ExcludedFolders = new[] { "Assets/Plugins/" };
+
+            var fired = 0;
+            void Handler() => fired++;
+            SerializeReferenceSettings.ExcludedFoldersChanged += Handler;
+            try
+            {
+                // Same paths, fresh array instance: the set did not move, so the warm index must not be dropped.
+                SerializeReferenceSettings.ExcludedFolders = new[] { "Assets/Plugins/" };
+                Assert.AreEqual(0, fired, "Re-assigning an identical set must not raise ExcludedFoldersChanged (no needless index rebuild).");
+            }
+            finally { SerializeReferenceSettings.ExcludedFoldersChanged -= Handler; }
+        }
+
+        [Test]
+        public void UnrelatedSetting_DoesNotRaiseExcludedFoldersChanged()
+        {
+            var fired = 0;
+            void Handler() => fired++;
+            SerializeReferenceSettings.ExcludedFoldersChanged += Handler;
+            try
+            {
+                SerializeReferenceSettings.RidColorsEnabled = !SerializeReferenceSettings.RidColorsEnabled;
+                SerializeReferenceSettings.AutoDeAliasEnabled = !SerializeReferenceSettings.AutoDeAliasEnabled;
+                SerializeReferenceSettings.BuildSeverity = GateSeverity.Fail;
+                Assert.AreEqual(0, fired, "Toggling an unrelated setting must never raise ExcludedFoldersChanged (the index stays warm).");
+            }
+            finally { SerializeReferenceSettings.ExcludedFoldersChanged -= Handler; }
+        }
+
+        [Test]
+        public void AnySetting_RaisesGeneralChanged()
+        {
+            var fired = 0;
+            void Handler() => fired++;
+            SerializeReferenceSettings.Changed += Handler;
+            try
+            {
+                SerializeReferenceSettings.RidColorsEnabled = !SerializeReferenceSettings.RidColorsEnabled;
+                Assert.GreaterOrEqual(fired, 1, "Every setter must still raise the general Changed for repaint and live-sync.");
+            }
+            finally { SerializeReferenceSettings.Changed -= Handler; }
+        }
+
+        // -----------------------------------------------------------------------------------------------------
+        // B — the shared controls mirror the store live (the two settings surfaces stay in sync)
+        // -----------------------------------------------------------------------------------------------------
+
+        [Test]
+        public void BuildControls_LiveSyncsControlsFromSettings()
+        {
+            SerializeReferenceSettings.RidColorsEnabled = true;
+            SerializeReferenceSettings.AutoDeAliasEnabled = true;
+            SerializeReferenceSettings.BuildSeverity = GateSeverity.Warn;
+            SerializeReferenceSettings.ExcludedFolders = Array.Empty<string>();
+
+            var container = new VisualElement();
+            SerializeReferenceSettingsUI.BuildControls(container);
+
+            var toggles = container.Query<Toggle>().ToList();
+            Assert.AreEqual(2, toggles.Count, "BuildControls must emit the rid-colours and auto-de-alias toggles.");
+            var ridColors = toggles[0];
+            var autoDeAlias = toggles[1];
+            var severity = container.Q<EnumField>();
+            var folders = container.Q<TextField>();
+            Assert.IsNotNull(severity, "BuildControls must emit the build-gate EnumField.");
+            Assert.IsNotNull(folders, "BuildControls must emit the excluded-folders TextField.");
+
+            // Mutating the shared store (as the other surface would) must reach these controls without a manual refresh:
+            // each control re-reads its backing value off SerializeReferenceSettings.Changed.
+            SerializeReferenceSettings.RidColorsEnabled = false;
+            SerializeReferenceSettings.AutoDeAliasEnabled = false;
+            SerializeReferenceSettings.BuildSeverity = GateSeverity.Fail;
+            SerializeReferenceSettings.ExcludedFolders = new[] { "Assets/Plugins/", "Assets/Generated/" };
+
+            Assert.IsFalse(ridColors.value, "The rid-colours toggle must mirror Settings live.");
+            Assert.IsFalse(autoDeAlias.value, "The auto-de-alias toggle must mirror Settings live.");
+            Assert.AreEqual(GateSeverity.Fail, (GateSeverity)severity.value, "The build-gate field must mirror Settings live.");
+            Assert.AreEqual("Assets/Plugins/\nAssets/Generated/", folders.value, "The folders field must mirror Settings live.");
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSettingsTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSettingsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ee3099db459445eb72ef93137fac051

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndexInvalidator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndexInvalidator.cs
@@ -11,6 +11,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// </summary>
     internal sealed class SerializeReferenceTypeUsageIndexInvalidator : AssetPostprocessor
     {
+        // Editor-startup hook: a change to the excluded-scan-folder set must drop the warm index. IsExcluded is consulted
+        // only while the index is (re)built (IsScanCandidate), so a warm index would keep serving now-excluded assets
+        // until an unrelated import or a domain reload reset it. Reset is lazy — it nulls the index and the next lookup
+        // rebuilds — so this is cheap and never warms a cold index on its own.
+        [InitializeOnLoadMethod]
+        private static void HookSettings() =>
+            SerializeReferenceSettings.ExcludedFoldersChanged += SerializeReferenceTypeUsageIndex.Reset;
+
         private static void OnPostprocessAllAssets(string[] imported, string[] deleted, string[] moved, string[] movedFrom)
         {
             if (HasCandidate(deleted) || HasCandidate(moved))

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettings.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettings.cs
@@ -24,6 +24,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// <summary>Raised whenever a setting changes.</summary>
         public static event Action Changed;
 
+        /// <summary>
+        /// Raised only when the <see cref="ExcludedFolders"/> set actually changes — the precise signal the usage index
+        /// listens for to drop its warm copy, since <see cref="IsExcluded"/> is consulted only while the index is
+        /// (re)built. Kept separate from <see cref="Changed"/> so an unrelated setting (rid colours, the gate) never
+        /// triggers a costly index rebuild.
+        /// </summary>
+        public static event Action ExcludedFoldersChanged;
+
         private const string KeyPrefix = "Aspid.FastTools.SerializeReference.Settings.";
 
         [Serializable]
@@ -55,7 +63,16 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         public static string[] ExcludedFolders
         {
             get => Data.excludedFolders ?? Array.Empty<string>();
-            set { Data.excludedFolders = value ?? Array.Empty<string>(); Save(); }
+            set
+            {
+                var next = value ?? Array.Empty<string>();
+                // Detect a genuine change before persisting so the index reset (and its lazy rebuild) only fires when
+                // the exclusion set really moved — re-assigning the same paths leaves the warm index untouched.
+                var changed = !FoldersEqual(Data.excludedFolders, next);
+                Data.excludedFolders = next;
+                Save();
+                if (changed) ExcludedFoldersChanged?.Invoke();
+            }
         }
 
         public static GateSeverity BuildSeverity
@@ -78,6 +95,21 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             return false;
+        }
+
+        // Ordinal, order-sensitive set comparison (null treated as empty). A reorder counts as a change too — harmless,
+        // since it only drops the warm index, which the next scan rebuilds.
+        private static bool FoldersEqual(string[] a, string[] b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            var lengthA = a?.Length ?? 0;
+            var lengthB = b?.Length ?? 0;
+            if (lengthA != lengthB) return false;
+
+            for (var i = 0; i < lengthA; i++)
+                if (!string.Equals(a[i], b[i], StringComparison.Ordinal)) return false;
+
+            return true;
         }
 
         private static Store Load()

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsUI.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -25,6 +26,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 tooltip = "Colour-code shared managed references by rid in the inspector stripe/chip and the graph window.",
             };
             ridColors.RegisterValueChangedCallback(evt => SerializeReferenceSettings.RidColorsEnabled = evt.newValue);
+            SyncFromSettings(ridColors, () => SerializeReferenceSettings.RidColorsEnabled);
             container.Add(ridColors);
 
             var autoDeAlias = new Toggle("Auto de-alias duplicated list elements")
@@ -33,6 +35,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 tooltip = "Give a duplicated list element its own independent instance instead of sharing the original's rid.",
             };
             autoDeAlias.RegisterValueChangedCallback(evt => SerializeReferenceSettings.AutoDeAliasEnabled = evt.newValue);
+            SyncFromSettings(autoDeAlias, () => SerializeReferenceSettings.AutoDeAliasEnabled);
             container.Add(autoDeAlias);
 
             var severity = new EnumField("Build / CI gate", SerializeReferenceSettings.BuildSeverity)
@@ -40,6 +43,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 tooltip = "Off: never check. Warn: log missing / unset-required references at build time. Fail: abort the build.",
             };
             severity.RegisterValueChangedCallback(evt => SerializeReferenceSettings.BuildSeverity = (GateSeverity)evt.newValue);
+            SyncFromSettings<EnumField, Enum>(severity, () => SerializeReferenceSettings.BuildSeverity);
             container.Add(severity);
 
             container.Add(new Label("Excluded scan folders (one path per line)")
@@ -54,7 +58,32 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .Select(line => line.Trim())
                 .Where(line => line.Length > 0)
                 .ToArray());
+            SyncFromSettings(folders, () => string.Join("\n", SerializeReferenceSettings.ExcludedFolders));
             container.Add(folders);
+        }
+
+        /// <summary>
+        /// Keeps <paramref name="control"/> in lock-step with the shared <see cref="SerializeReferenceSettings"/> store so
+        /// the in-window Settings tab and the Project Settings page reflect each other live: on every
+        /// <see cref="SerializeReferenceSettings.Changed"/> the control re-reads its backing value through
+        /// <paramref name="read"/> <i>without notifying</i>, so it never writes back or loops. The control the user is
+        /// actively editing is skipped, so an in-progress edit (e.g. typing a path into the multiline folders field) is
+        /// never normalized out from under the cursor. The subscription is released on
+        /// <see cref="DetachFromPanelEvent"/> so a closed surface leaks nothing.
+        /// </summary>
+        private static void SyncFromSettings<TControl, TValue>(TControl control, Func<TValue> read)
+            where TControl : VisualElement, INotifyValueChanged<TValue>
+        {
+            void Handler()
+            {
+                // Don't clobber the surface the user is typing into; the other (unfocused) surface still syncs, and the
+                // focused one re-reads the (already-correct) value on its next change or re-attach.
+                if (control.focusController?.focusedElement == control) return;
+                control.SetValueWithoutNotify(read());
+            }
+
+            SerializeReferenceSettings.Changed += Handler;
+            control.RegisterCallback<DetachFromPanelEvent>(_ => SerializeReferenceSettings.Changed -= Handler);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Editing **Excluded folders** while the usage index is warm left excluded assets in project scans until an unrelated import/move or a domain reload. A new dedicated `SerializeReferenceSettings.ExcludedFoldersChanged` event — raised only when the folder set actually changes — now resets `SerializeReferenceTypeUsageIndex`, so the next scan honours the new exclusions.
- The in-window **Settings** tab and the **Project Settings** page now reflect each other live: each shared control re-reads its backing value off `SerializeReferenceSettings.Changed` via `SetValueWithoutNotify`, skipping the focused control, and unsubscribes on `DetachFromPanelEvent`.

## Notes for review

- **Base branch is `feature/serialize-reference-dropdown` (PR #49), not `main`** — the SerializeReference settings files don't exist on `main` yet, so this stacks on the feature branch.
- The index reset is wired to a **dedicated** `ExcludedFoldersChanged` signal (not the general `Changed`) so toggling an unrelated setting (rid colours, the gate) never forces a costly cold index rebuild. The reset is lazy (it nulls the index; the next lookup rebuilds), so it never warms a cold index on its own.
- The folders multiline field is guarded by a focus check so live-sync never normalizes an in-progress edit out from under the cursor.
- No package CLI build exists (Unity compiles on open), so the change was verified statically and with 5 EditMode tests covering the event semantics and the control live-sync.

## Linked issues

Closes ASP-22