### PR TITLE
Name the cleared field count in the missing-reference clear dialog

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Fixtures/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Fixtures/YamlFixtures.cs
@@ -94,6 +94,53 @@ MonoBehaviour:
         _damagePerSecond: 5
 ";
 
+        // A MonoBehaviour where the MISSING reference (GhostPistol, rid 1002) is ALIASED across two slots — both
+        // _primaryWeapon and _sidearms[0] point at the one rid — alongside a singly-pointed sibling (Shotgun, rid 1003,
+        // _sidearms[1]) and a healthy effect (rid 1004). Pins the all-pointer-null behaviour and the pointer-count helper:
+        // clearing rid 1002 must null BOTH aliased slots (count 2) while leaving the Shotgun slot intact. Same indentation
+        // and layout as MissingTypePrefab; reuses MonoBehaviourFileId / GhostPistolRid / ShotgunRid.
+        public const string AliasedMissingTypePrefab =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6500000000000000001
+GameObject:
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6500000000000000003}
+  m_Name: LoadoutAliasedMissing
+--- !u!114 &6500000000000000003
+MonoBehaviour:
+  m_GameObject: {fileID: 6500000000000000001}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name:
+  _primaryWeapon:
+    rid: 1002
+  _sidearms:
+  - rid: 1002
+  - rid: 1003
+  _onHitEffect:
+    rid: 1004
+  references:
+    version: 2
+    RefIds:
+    - rid: 1002
+      type: {class: GhostPistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 15
+        _magazineSize: 12
+    - rid: 1003
+      type: {class: Shotgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _pellets: 8
+        _spreadAngle: 25
+    - rid: 1004
+      type: {class: FreezeEffect, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _duration: 2.5
+        _slowPercent: 40
+";
+
         // RefIds present in the empty-fields fixture below.
         public const long EmptyRailgunRid = 1001;  // _primaryWeapon  (resolvable, holds a cleared nested _chargeEffect)
         public const long EmptyPistolRid = 1002;   // _sidearms[0]    (resolvable)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorNullReferenceTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorNullReferenceTests.cs
@@ -6,8 +6,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
     /// <summary>
     /// Coverage for <see cref="SerializeReferenceYamlEditor.TryNullReference"/> — the most surgery-heavy, non-undoable
     /// write path: it nulls every pointer to a rid (to <c>-2</c>), removes the now-orphaned <c>RefIds</c> entry, and
-    /// inserts Unity's shared null-sentinel entry exactly once when a null pointer was introduced. These tests pin that
-    /// contract against temp files so a refactor cannot silently change null-vs-real-rid semantics.
+    /// inserts Unity's shared null-sentinel entry exactly once when a null pointer was introduced. Also covers the
+    /// companion <see cref="SerializeReferenceYamlEditor.CountPointersTo"/>, whose count the clear-confirmation dialog
+    /// names so an aliased reference doesn't silently null sibling slots. These tests pin that contract against temp
+    /// files so a refactor cannot silently change null-vs-real-rid semantics or drift the dialog count off the rewrite.
     /// </summary>
     [TestFixture]
     internal sealed class SerializeReferenceYamlEditorNullReferenceTests
@@ -74,6 +76,101 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
                 Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(
                     path, YamlFixtures.MonoBehaviourFileId, 987654));
                 Assert.AreEqual(before, File.ReadAllText(path), "A no-op null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_AliasedRid_NullsEverySharedSlot_LeavesSiblingIntact()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // The missing rid is aliased across _primaryWeapon and _sidearms[0]; clearing it must null both.
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_primaryWeapon", out var primary));
+                Assert.AreEqual(-2, primary, "The first aliased slot must read the null id after the clear.");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var sidearm0));
+                Assert.AreEqual(-2, sidearm0, "The second aliased slot must read the null id after the clear.");
+
+                // The singly-pointed sibling that did NOT share the rid keeps its reference.
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[1]", out var sidearm1));
+                Assert.AreEqual(YamlFixtures.ShotgunRid, sidearm1, "A slot that didn't alias the rid must be untouched.");
+
+                var after = File.ReadAllText(path);
+                StringAssert.DoesNotContain("GhostPistol", after);
+                Assert.AreEqual(1, CountOccurrences(after, NullSentinelType),
+                    "Two nulled aliases still share Unity's single null sentinel.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_AliasedRid_CountsEverySharedSlot()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // _primaryWeapon + _sidearms[0] both point at the rid; the RefIds entry header is NOT a pointer.
+                Assert.AreEqual(2, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_SingleSlotMissingRid_ReturnsOne()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                // The missing rid is pointed at by exactly one slot (_sidearms[0]) in this fixture.
+                Assert.AreEqual(1, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_MatchesPointersNulledByTryNullReference()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // The count the dialog shows must equal the number of "rid: -2" pointers the rewrite introduces, so the
+                // confirmation can never under- or over-state the damage. The fixture starts with no null pointers.
+                var before = File.ReadAllText(path);
+                Assert.AreEqual(0, CountOccurrences(before, "rid: -2"), "Fixture sanity: no null pointers before the clear.");
+
+                var count = SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid);
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+
+                // The introduced null pointers are the field pointers (the inserted sentinel ENTRY header is "- rid: -2"
+                // at the entry indent, so subtract that one occurrence to compare against the field-pointer count).
+                var after = File.ReadAllText(path);
+                Assert.AreEqual(count, CountOccurrences(after, "rid: -2") - 1,
+                    "CountPointersTo must equal the number of field pointers TryNullReference nulls.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_UnknownRid_ReturnsZero()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.AreEqual(0, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, 987654));
             }
             finally { YamlFixtures.Delete(path); }
         }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
@@ -471,6 +471,64 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
         }
 
+        /// <summary>
+        /// Counts how many field / array-element pointers in the document anchored at <paramref name="fileId"/> hold
+        /// <paramref name="rid"/> — the number of slots a <see cref="TryNullReference"/> would null. A missing reference
+        /// can be aliased across several slots (all sharing one rid); clearing it nulls every one of them, so the confirm
+        /// dialog calls this first to name the count before the irreversible rewrite. The rid's own <c>RefIds</c> entry
+        /// header is excluded (it is the entry, not a pointer to it). Returns <c>0</c> when the document / <c>RefIds</c>
+        /// list / entry indent cannot be located — the same guards <see cref="TryNullReference"/> uses — so a non-positive
+        /// result means "count unknown" and the caller can fall back to unnumbered wording.
+        /// </summary>
+        public static int CountPointersTo(string assetPath, long fileId, long rid)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return 0;
+
+                var lines = File.ReadAllLines(assetPath);
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return 0;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return 0;
+
+                var entryIndent = FindRefIdsEntryIndent(lines, refIdsStart, end);
+                if (entryIndent < 0) return 0;
+
+                var headerPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
+                var pointerToken = new Regex($@"\brid:\s*{rid}\b");
+
+                var headerSkipped = false;
+                var count = 0;
+
+                for (var i = start; i < end; i++)
+                {
+                    // Skip this rid's own RefIds entry header exactly once (the "- rid: N" at the entry indent under
+                    // RefIds): it is the entry being removed, not a pointer that gets nulled. Mirrors the header skip in
+                    // TryNullReference so the count equals the number of pointers that path would rewrite.
+                    if (!headerSkipped && i > refIdsStart)
+                    {
+                        var header = headerPattern.Match(lines[i]);
+                        if (header.Success && header.Groups["indent"].Length == entryIndent)
+                        {
+                            headerSkipped = true;
+                            continue;
+                        }
+                    }
+
+                    if (pointerToken.IsMatch(lines[i])) count++;
+                }
+
+                return count;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[Aspid FastTools] Failed to count managed-reference pointers to rid {rid} in '{assetPath}': {exception}");
+                return 0;
+            }
+        }
+
         // Whether the RefIds list already carries Unity's null sentinel entry ("- rid: -2"). The sentinel is a shared
         // singleton — at most one per object — so a second null pointer reuses it rather than adding another.
         private static bool HasNullSentinelEntry(string[] lines, int refIdsStart, int end, int entryIndent)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
@@ -946,15 +946,26 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // exactly what Unity writes for a cleared [SerializeReference] field. Reached by picking <None> in a missing
         // card's Fix picker (a missing reference cannot be cleared through the serialization API, so it is done in the
         // YAML). Confirmed and not undoable: the reference's broken payload is discarded, mirroring ClearOrphan. A shared
-        // (aliased) reference nulls every field that points at it. The captured file id targets exactly this document's
-        // rid (rids collide across documents). Healthy / empty slots clear through the live path (see ApplyLive) instead.
+        // (aliased) reference nulls every field that points at it, so the confirm dialog names that count up front (the
+        // rid is unrecoverable, so a per-slot detach isn't offered here). The captured file id targets exactly this
+        // document's rid (rids collide across documents). Healthy / empty slots clear through the live path (see ApplyLive).
         private void ClearReference(string assetPath, long fileId, long rid)
         {
+            // Name how many fields the clear will null so an aliased reference doesn't silently take down siblings the
+            // user didn't realize shared the rid. A non-positive count means the pointers couldn't be located — fall
+            // back to the unnumbered wording rather than print "0 fields".
+            var fieldCount = SerializeReferenceYamlEditor.CountPointersTo(assetPath, fileId, rid);
+            var pointerLine = fieldCount switch
+            {
+                1 => "This nulls the 1 field pointing at it",
+                > 1 => $"This reference is aliased across {fieldCount} fields — clearing it nulls every one of them",
+                _ => "This nulls every field pointing at it",
+            };
+
             if (!EditorUtility.DisplayDialog(
                     "Clear Reference",
                     $"Reset this managed reference (rid {rid}) to <None> in\n{assetPath}?\n\n" +
-                    "This nulls every field pointing at it and discards its stored data. It edits the asset file " +
-                    "directly and cannot be undone.",
+                    $"{pointerLine} and discards its stored data. It edits the asset file directly and cannot be undone.",
                     "Clear", "Cancel"))
                 return;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The **Repair Missing References** and **Managed References** windows are merged into a single workbench whose tabs are individual menu entries under `Tools → Aspid 🐍 → FastTools` — **Welcome**, **Asset References** (the reference graph with inline Fix / Clear / Open Source Prefab — which subsumes the old per-asset repair list), **Project References** (the project-wide grouped bulk fix), and **Settings**. A result in Project References links straight to that asset's Asset References graph.
 - The per-property missing-type probe now caches the asset YAML by path + write-time, eliminating a `File.ReadAllLines` on every IMGUI repaint.
+- The confirm dialog for clearing a missing managed reference now names how many fields it will null, so an aliased reference shared across several slots makes its all-pointer clear explicit before the irreversible YAML edit (the clear still nulls every aliased field — only the wording changed).
 
 ### Added (internal)
-- First package test coverage: an `Aspid.FastTools.Unity.Editor.Tests` EditMode assembly exercising the `SerializeReferenceYamlEditor` parser (missing-type discovery, propertyPath → rid resolution incl. nested/list, stored-type reading, round-trip rewrite, entry removal, diff-preview consistency) plus the YAML probe cache.
+- First package test coverage: an `Aspid.FastTools.Unity.Editor.Tests` EditMode assembly exercising the `SerializeReferenceYamlEditor` parser (missing-type discovery, propertyPath → rid resolution incl. nested/list, stored-type reading, round-trip rewrite, entry removal, aliased-pointer nulling + the dialog pointer-count helper, diff-preview consistency) plus the YAML probe cache.
 
 ## [1.0.0-rc.5] — 2026-06-06
 


### PR DESCRIPTION
## Summary

- Clearing one slot of a **missing** managed reference that is aliased across several slots nulls them all — deliberate and correct for an unrecoverable rid — but the confirm dialog never said how many fields it would clear. It now names that count up front.
- Adds `SerializeReferenceYamlEditor.CountPointersTo(assetPath, fileId, rid)`: a read-only scan that mirrors `TryNullReference`'s header-skip + pointer-match logic, so it returns exactly the number of field pointers the clear will null (the rid's own `RefIds` entry header is excluded).
- `SerializeReferenceGraphView.ClearReference` calls it before the dialog and adapts the wording: `the 1 field` / `aliased across N fields — clearing it nulls every one of them` / an unnumbered fallback when the count can't be determined (returns 0).
- Behaviour is unchanged — the clear still nulls every aliased field; only the dialog text gained the count.

## Notes for review

- The count is computed by a **second** read of the asset (the dialog precedes the rewrite), so `CountPointersTo` and `TryNullReference` deliberately share the same scan shape and regex (`\brid:\s*{rid}\b`) to guarantee the dialog can't under- or over-state the damage. A test pins `count == pointers-nulled` parity.
- The diff is scoped to the SerializeReference editor code + its EditMode tests + CHANGELOG; no runtime, generator, or sample changes.
- Unity EditMode tests can't run from CLI here (Unity owns compilation); correctness was verified by an adversarial code-review pass over the count/rewrite parity, regex edge cases (prefix-collision rids, inline `{rid: N}`, the `-2` sentinel), fixture indentation, and C# 9 compatibility.

## Linked issues

Closes ASP-28