### PR TITLE
Harden SerializeReference YAML writes against tab/non-Unity files

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorHardeningTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorHardeningTests.cs
@@ -1,0 +1,166 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Hardening coverage for the destructive write paths of <see cref="SerializeReferenceYamlEditor"/>: a file that is
+    /// not a Unity-serialized YAML asset (no <c>%TAG !u!</c> directive) or whose target entry uses unexpected (tab /
+    /// mixed) indentation must never be rewritten. The line-scanning editor relies on Unity's space-only indentation
+    /// invariant; outside it the <c>IndentOf</c> measure and the <c>"- rid:"</c> <c>\s*</c> regex can disagree on where
+    /// an entry ends, so the writers bail (no-op) rather than risk a mis-bounded, non-undoable edit.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorHardeningTests
+    {
+        // The single object-document file id shared by the fixtures below.
+        private const long FileId = 11400000L;
+        private const long Rid = 1001L;
+
+        // A RefIds-shaped document that carries a Unity object header (so the document is locatable) but LACKS the
+        // "%YAML 1.1" / "%TAG !u! …" directive preamble Unity always writes. Without the sniff every writer below would
+        // find rid 1001 and rewrite it — so a successful no-op here proves the %TAG guard, not a missing target.
+        private const string MissingDirectivePreamble =
+@"--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}
+  m_Name: NotAUnityAsset
+  _weapon:
+    rid: 1001
+  references:
+    version: 2
+    RefIds:
+    - rid: 1001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 10
+";
+
+        // A genuine Unity asset (full %YAML / %TAG preamble, so it passes the sniff) whose RefIds entry is TAB-indented.
+        // Built with explicit \t/\n so the indentation is unambiguous in source. The "- rid:" \s* regex still matches the
+        // tab-indented header, so the writers reach the bounding step — where the space-only-indent guard must stop them.
+        private const string TabIndentedUnityAsset =
+            "%YAML 1.1\n" +
+            "%TAG !u! tag:unity3d.com,2011:\n" +
+            "--- !u!114 &11400000\n" +
+            "MonoBehaviour:\n" +
+            "\tm_ObjectHideFlags: 0\n" +
+            "\tm_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}\n" +
+            "\tm_Name: TabIndentedAsset\n" +
+            "\t_weapon:\n" +
+            "\t\trid: 1001\n" +
+            "\treferences:\n" +
+            "\t\tversion: 2\n" +
+            "\t\tRefIds:\n" +
+            "\t\t- rid: 1001\n" +
+            "\t\t  type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}\n" +
+            "\t\t  data:\n" +
+            "\t\t\t_damage: 10\n";
+
+        private static readonly ManagedTypeName SomeType = new ManagedTypeName(
+            "Aspid.FastTools.Samples.SerializeReferences",
+            "Aspid.FastTools.Samples.SerializeReferences",
+            "Shotgun");
+
+        // ---- %TAG !u! sniff: a non-Unity YAML file is never rewritten -------------------------------------------------
+
+        [Test]
+        public void TryComputeRewrite_MissingDirectivePreamble_ReturnsFalse()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryComputeRewrite(path, FileId, Rid, SomeType, out var edit),
+                    "A file without Unity's %TAG directive must not even be offered as a rewrite candidate.");
+                Assert.IsFalse(edit.IsValid, "No edit should be produced for a non-Unity file.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRewriteType_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRewriteType(path, FileId, Rid, SomeType));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused rewrite must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRemoveEntry_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRemoveEntry(path, FileId, Rid));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused remove must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(path, FileId, Rid));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        // ---- indent bail: a tab-indented entry block is never destructively rewritten ---------------------------------
+
+        [Test]
+        public void TryRemoveEntry_TabIndentedEntry_BailsBeforeWrite_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(TabIndentedUnityAsset);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRemoveEntry(path, FileId, Rid),
+                    "A tab-indented entry can be mis-bounded — the remover must bail rather than write.");
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused remove must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_TabIndentedEntry_BailsBeforeWrite_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(TabIndentedUnityAsset);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(path, FileId, Rid),
+                    "A tab-indented entry block can be mis-bounded — the nuller must bail before writing.");
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        // ---- positive control: the guards do NOT regress a well-formed, space-indented Unity asset --------------------
+
+        [Test]
+        public void WellFormedUnityAsset_PassesGuards_RemoveEntrySucceeds()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryRemoveEntry(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid),
+                    "A canonical Unity asset (%TAG present, space-indented) must still be editable after hardening.");
+                StringAssert.DoesNotContain("Shotgun", File.ReadAllText(path));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorHardeningTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceYamlEditorHardeningTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbedf8e601524a36ba3a342f900b23d1

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
@@ -280,6 +280,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
 
                 var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never offer (or apply) a rewrite on a non-Unity YAML file
                 var (start, end) = FindDocumentRange(lines, fileId);
                 if (start < 0) return false;
 
@@ -330,6 +331,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
 
                 var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never rewrite a non-Unity YAML file
                 var (start, end) = FindDocumentRange(lines, fileId);
                 if (start < 0) return false;
 
@@ -347,6 +349,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     // the same bounding rule the data-block reader uses.
                     var entryIndent = match.Groups["indent"].Length;
                     var entryEnd = FindEntryEnd(lines, i, end, entryIndent);
+
+                    // Unexpected (tab / mixed) indentation in the entry block means IndentOf and the "- rid:" \s* regex
+                    // can disagree on where the block ends — bail rather than write a possibly mis-bounded deletion.
+                    if (!BlockIndentIsTrusted(lines, i, entryEnd)) return false;
 
                     var remaining = new List<string>(lines.Length - (entryEnd - i));
                     for (var k = 0; k < i; k++) remaining.Add(lines[k]);
@@ -391,6 +397,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
 
                 var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never rewrite a non-Unity YAML file
                 var (start, end) = FindDocumentRange(lines, fileId);
                 if (start < 0) return false;
 
@@ -438,6 +445,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
                 var blockStart = headerIndex;
                 var blockEnd = headerIndex >= 0 ? FindEntryEnd(lines, headerIndex, end, entryIndent) : -1;
+
+                // The entry block we're about to drop must use Unity's space-only indentation; a tab / mixed prefix can
+                // mis-bound it (IndentOf vs the "- rid:" \s* regex), so bail before this non-undoable rewrite. (Pointer
+                // nulling above is line-local and indent-agnostic, so no write has reached disk yet.)
+                if (headerIndex >= 0 && !BlockIndentIsTrusted(lines, blockStart, blockEnd)) return false;
 
                 // A "- rid: -2" pointer is valid only while the RefIds list carries Unity's null sentinel entry; add it
                 // when we just introduced a null pointer and the document does not already have one (a shared singleton).
@@ -788,12 +800,65 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return false;
         }
 
+        // Leading-indentation width of a line, counting each space or tab as one unit. Unity always indents its YAML
+        // with spaces, but the "- rid:" / "type:" indent regexes capture leading whitespace with \s* (which counts
+        // tabs too). Counting tabs here keeps this measure aligned with those regexes: a tab-indented line would
+        // otherwise read as indent 0 here while a regex sees it as N, and FindEntryEnd would mis-bound the entry.
+        // Alignment, not visual tab width, is what matters — both measures count one unit per character.
         private static int IndentOf(string line)
         {
             var count = 0;
-            while (count < line.Length && line[count] == ' ') count++;
+            while (count < line.Length && (line[count] == ' ' || line[count] == '\t')) count++;
             return count;
         }
+
+        // A line whose leading indentation is spaces only — Unity's invariant for serialized YAML. Returns false when
+        // the indent begins with a tab or any other whitespace, the case where IndentOf and the "- rid:" \s* regexes
+        // can still measure the same nesting differently (a single tab vs a run of spaces). Callers about to delete a
+        // bounded block bail on such a line rather than risk a mis-bounded, non-undoable write.
+        private static bool IndentIsSpaceOnly(string line)
+        {
+            for (var i = 0; i < line.Length; i++)
+            {
+                if (line[i] == ' ') continue;            // a space is fine — keep scanning the indent
+                if (char.IsWhiteSpace(line[i])) return false; // a tab / other whitespace in the indent: untrusted
+                return true;                             // first content char reached: the indent was spaces only
+            }
+
+            return true;
+        }
+
+        // Whether every line in [start, end) is indented with spaces only — the precondition the block-removing writes
+        // verify before touching the file, so an asset with unexpected (tab / mixed) indentation is left untouched.
+        private static bool BlockIndentIsTrusted(string[] lines, int start, int end)
+        {
+            for (var i = Math.Max(start, 0); i < end && i < lines.Length; i++)
+                if (!IndentIsSpaceOnly(lines[i])) return false;
+
+            return true;
+        }
+
+        // Whether the text looks like a Unity-serialized YAML asset: its directive preamble (everything before the
+        // first document "---") must carry Unity's signature "%TAG !u! tag:unity3d.com,2011:" directive. Guards the
+        // destructive writes so a hand-authored or foreign YAML file — which this line-scanning parser was never
+        // designed for — can never be surgically rewritten.
+        private static bool LooksLikeUnityYaml(string[] lines)
+        {
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = (i == 0 ? StripByteOrderMark(lines[i]) : lines[i]).TrimStart();
+                if (line.Length == 0) continue;
+                if (line.StartsWith("%TAG !u!", StringComparison.Ordinal)) return true;
+                if (line.StartsWith("---", StringComparison.Ordinal)) return false; // first document reached without the %TAG marker
+            }
+
+            return false;
+        }
+
+        // File.ReadAllLines strips a UTF-8 BOM in practice, but guard the first line defensively so the %TAG sniff is
+        // never thrown off by a leading byte-order mark.
+        private static string StripByteOrderMark(string line) =>
+            line.Length > 0 && line[0] == '\uFEFF' ? line.Substring(1) : line;
 
         /// <summary>
         /// Reads the managed-reference id stored at <paramref name="propertyPath"/> and the type recorded for it in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The **Repair Missing References** and **Managed References** windows are merged into a single workbench whose tabs are individual menu entries under `Tools → Aspid 🐍 → FastTools` — **Welcome**, **Asset References** (the reference graph with inline Fix / Clear / Open Source Prefab — which subsumes the old per-asset repair list), **Project References** (the project-wide grouped bulk fix), and **Settings**. A result in Project References links straight to that asset's Asset References graph.
 - The per-property missing-type probe now caches the asset YAML by path + write-time, eliminating a `File.ReadAllLines` on every IMGUI repaint.
 
+### Fixed
+- Hardened the asset-YAML managed-reference editor (`SerializeReferenceYamlEditor`) against non-Unity / oddly-indented files. Its indent measure now counts tabs so it stays aligned with the `- rid:` entry-bounding regexes (previously a tab read as indent 0 here but as a real indent in the regex, so an entry block could be mis-bounded), and the destructive writes (type rewrite, entry removal, reference null-out) now (a) refuse to touch a file that is not a Unity-serialized YAML asset — one lacking the `%TAG !u!` directive — and (b) bail before any write when the target `RefIds` entry uses unexpected tab / mixed indentation, rather than risk a mis-bounded, non-undoable edit. Unity always writes space-indented YAML with the directive preamble, so well-formed assets are unaffected.
+
 ### Added (internal)
-- First package test coverage: an `Aspid.FastTools.Unity.Editor.Tests` EditMode assembly exercising the `SerializeReferenceYamlEditor` parser (missing-type discovery, propertyPath → rid resolution incl. nested/list, stored-type reading, round-trip rewrite, entry removal, diff-preview consistency) plus the YAML probe cache.
+- First package test coverage: an `Aspid.FastTools.Unity.Editor.Tests` EditMode assembly exercising the `SerializeReferenceYamlEditor` parser (missing-type discovery, propertyPath → rid resolution incl. nested/list, stored-type reading, round-trip rewrite, entry removal, diff-preview consistency) plus the YAML probe cache, and the write-path hardening (non-Unity-file refusal, tab-indent bail).
 
 ## [1.0.0-rc.5] — 2026-06-06
 


### PR DESCRIPTION
## Summary

- Align `IndentOf` with the `- rid:` entry-bounding regexes by counting tabs. Previously a tab-indented line read as indent `0` here while the `\s*` regex counted it, so `FindEntryEnd` could mis-bound a `RefIds` entry block under genuine tab indentation.
- The destructive YAML writes — type rewrite (`TryComputeRewrite` / `TryRewriteType`), entry removal (`TryRemoveEntry`) and reference null-out (`TryNullReference`) — now **bail before any write** when (a) the file is not a Unity-serialized YAML asset (its directive preamble lacks `%TAG !u! tag:unity3d.com,2011:`), or (b) the target `RefIds` entry uses unexpected tab / mixed (non-space) indentation — rather than risk a mis-bounded, non-undoable edit.
- Added an `Aspid.FastTools.Unity.Editor.Tests` EditMode suite for the hardening (non-Unity-file refusal across all three writers, tab-indent bail, plus a space-indented positive control) and a CHANGELOG `Fixed` entry.

Unity always writes space-indented YAML with the directive preamble, so well-formed assets are unaffected.

## Notes for review

- **Re-scoped, low-priority hardening.** The Linear audit downgraded ASP-31 from "silent corruption" to "graceful fallback": the main type-repair write was already tab-tolerant (it preserves the captured indent group), so a tab-but-Unity-structured asset is still rewritten correctly. The real, narrow bug was the `IndentOf` vs `\s*`-regex divergence in the block-removing writers; the sniff + indent bail are defensive belt-and-suspenders.
- **Base branch** is `feature/serialize-reference-dropdown` (PR #49), not `main` — the touched `SerializeReferenceYamlEditor.cs` does not exist on `main` yet. Mirrors sibling PR #50.
- **Tests not run headlessly:** there is no Unity CLI in this environment (compilation happens in the open editor), so the new EditMode tests were not executed here. Correctness was instead checked by an independent adversarial code review (read-path regression, write-before-bail ordering, sniff false-reject risk, fixture fidelity) — all clear. Please run the EditMode suite in-editor before merge.

## Linked issues

Closes ASP-31