### PR TITLE
Retry deferred Create-new-script assignment across domain reloads

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Entry = Aspid.FastTools.SerializeReferences.Editors.SerializeReferencePendingAssignment.Entry;
+using Store = Aspid.FastTools.SerializeReferences.Editors.SerializeReferencePendingAssignment;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Coverage for the persistence contract of <see cref="SerializeReferencePendingAssignment"/> — the deferred
+    /// "Create new script" assignment that must survive every domain reload until the new type compiles. The bug being
+    /// pinned here is the old up-front erase that dropped any entry unresolvable in the first post-reload pass; these
+    /// tests fix the wire format (so re-persisted entries round-trip), the legacy back-compat decode, malformed-line
+    /// rejection, the supersede-on-re-pick merge, and the cross-reload give-up boundary.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferencePendingAssignmentTests
+    {
+        private const string GlobalId = "GlobalObjectId_V1-2-0000000000000000f000000000000000-12345678901234567-0";
+        private const string Path = "_weapons.Array.data[3]._primary";
+        private const string TypeName = "Game.Weapons.Pistol";
+
+        [Test]
+        public void Entry_RoundTrips_AllFieldsThroughEncodeDecode()
+        {
+            var entry = new Entry(GlobalId, Path, TypeName, attempts: 7);
+
+            Assert.IsTrue(Entry.TryDecode(entry.Encode(), out var decoded));
+            Assert.AreEqual(entry, decoded, "Encode/TryDecode must be a lossless round-trip including the attempt count.");
+        }
+
+        [Test]
+        public void Entry_GenericAqnTypeName_SurvivesRoundTrip()
+        {
+            // An assembly-qualified closed-generic name carries '[', ']', ',' and '.' — but never '|' or '\n', so the
+            // pipe/newline split must not corrupt it.
+            const string generic = "Game.Inventory.Slot`1[[Game.Weapons.Pistol, Game.Runtime]]";
+            var entry = new Entry(GlobalId, Path, generic, attempts: 0);
+
+            Assert.IsTrue(Entry.TryDecode(entry.Encode(), out var decoded));
+            Assert.AreEqual(generic, decoded.FullTypeName);
+        }
+
+        [Test]
+        public void TryDecode_LegacyThreeFieldLine_DecodesWithZeroAttempts()
+        {
+            // Entries written before retry tracking have no attempt field; they must decode (attempts = 0), not be dropped.
+            var legacy = $"{GlobalId}|{Path}|{TypeName}";
+
+            Assert.IsTrue(Entry.TryDecode(legacy, out var decoded));
+            Assert.AreEqual(0, decoded.Attempts);
+            Assert.AreEqual(TypeName, decoded.FullTypeName);
+        }
+
+        [Test]
+        public void TryDecode_NonPositiveOrGarbageAttempts_ClampToZero()
+        {
+            Assert.IsTrue(Entry.TryDecode($"{GlobalId}|{Path}|{TypeName}|-5", out var negative));
+            Assert.AreEqual(0, negative.Attempts);
+
+            Assert.IsTrue(Entry.TryDecode($"{GlobalId}|{Path}|{TypeName}|oops", out var garbage));
+            Assert.AreEqual(0, garbage.Attempts);
+        }
+
+        [Test]
+        public void TryDecode_MalformedLines_AreRejected()
+        {
+            Assert.IsFalse(Entry.TryDecode(null, out _), "null line");
+            Assert.IsFalse(Entry.TryDecode("", out _), "empty line");
+            Assert.IsFalse(Entry.TryDecode($"{GlobalId}|{Path}", out _), "fewer than three fields");
+            Assert.IsFalse(Entry.TryDecode($"|{Path}|{TypeName}", out _), "empty global id");
+            Assert.IsFalse(Entry.TryDecode($"{GlobalId}||{TypeName}", out _), "empty property path");
+            Assert.IsFalse(Entry.TryDecode($"{GlobalId}|{Path}|", out _), "empty type name");
+        }
+
+        [Test]
+        public void Decode_SkipsMalformedLines_KeepsValidOnes()
+        {
+            var raw = string.Join("\n",
+                $"{GlobalId}|{Path}|{TypeName}|1",
+                "garbage-without-separators",
+                $"{GlobalId}|{Path}|Game.Weapons.Rifle|0");
+
+            var entries = Store.Decode(raw);
+
+            Assert.AreEqual(2, entries.Count, "The malformed middle line must be skipped, not abort the whole decode.");
+            Assert.AreEqual(TypeName, entries[0].FullTypeName);
+            Assert.AreEqual("Game.Weapons.Rifle", entries[1].FullTypeName);
+        }
+
+        [Test]
+        public void Decode_EmptyOrNull_ReturnsEmptyList()
+        {
+            Assert.IsEmpty(Store.Decode(null));
+            Assert.IsEmpty(Store.Decode(string.Empty));
+        }
+
+        [Test]
+        public void EncodeDecode_MultipleEntries_PreserveOrderAndContent()
+        {
+            var original = new List<Entry>
+            {
+                new(GlobalId, "_a", "Game.A", 0),
+                new(GlobalId, "_b", "Game.B", 4),
+                new(GlobalId, "_c", "Game.C", 31),
+            };
+
+            var roundTripped = Store.Decode(Store.Encode(original));
+
+            CollectionAssert.AreEqual(original, roundTripped, "A multi-entry queue must survive encode/decode in order.");
+        }
+
+        [Test]
+        public void WithIncrementedAttempt_BumpsCount_PreservesIdentity()
+        {
+            var entry = new Entry(GlobalId, Path, TypeName, attempts: 2);
+            var next = entry.WithIncrementedAttempt();
+
+            Assert.AreEqual(3, next.Attempts);
+            Assert.IsTrue(entry.SameTarget(next), "Incrementing the attempt must not change the entry's target.");
+            Assert.AreEqual(TypeName, next.FullTypeName);
+        }
+
+        [Test]
+        public void Merge_RePickSameField_SupersedesPreviousEntry()
+        {
+            var queue = new List<Entry> { new(GlobalId, Path, "Game.OldPick", 5) };
+
+            Store.Merge(queue, new Entry(GlobalId, Path, "Game.NewPick", 0));
+
+            Assert.AreEqual(1, queue.Count, "Re-picking the same field must replace, not append, the pending assignment.");
+            Assert.AreEqual("Game.NewPick", queue[0].FullTypeName);
+            Assert.AreEqual(0, queue[0].Attempts, "The superseding pick starts its own attempt budget.");
+        }
+
+        [Test]
+        public void Merge_DifferentField_AppendsAndKeepsExisting()
+        {
+            var queue = new List<Entry> { new(GlobalId, "_a", "Game.A", 1) };
+
+            Store.Merge(queue, new Entry(GlobalId, "_b", "Game.B", 0));
+
+            Assert.AreEqual(2, queue.Count);
+            Assert.AreEqual("Game.A", queue[0].FullTypeName, "An unrelated pending field must be untouched.");
+            Assert.AreEqual("Game.B", queue[1].FullTypeName);
+        }
+
+        [Test]
+        public void GiveUpBoundary_OneIncrementBelowCap_StillSurvives()
+        {
+            var entry = new Entry(GlobalId, Path, TypeName, Store.MaxResolveAttempts - 2);
+
+            Assert.Less(entry.WithIncrementedAttempt().Attempts, Store.MaxResolveAttempts,
+                "An entry one short of the cap must remain pending after the next reload.");
+        }
+
+        [Test]
+        public void GiveUpBoundary_AtCap_IsAbandoned()
+        {
+            var entry = new Entry(GlobalId, Path, TypeName, Store.MaxResolveAttempts - 1);
+
+            Assert.GreaterOrEqual(entry.WithIncrementedAttempt().Attempts, Store.MaxResolveAttempts,
+                "Reaching the attempt cap is the give-up boundary the resolver drops (with a warning) on.");
+        }
+    }
+
+    // A persistable target for the resolve-pass tests: saved as an asset so its GlobalObjectId round-trips back to the
+    // live object (an in-memory ScriptableObject's id does not). No fields are needed — an unresolved type short-circuits
+    // before the property is ever read.
+    internal sealed class PendingAssignmentProbeObject : ScriptableObject { }
+
+    /// <summary>
+    /// Integration coverage that drives <see cref="SerializeReferencePendingAssignment.ResolvePass"/> against a real
+    /// <see cref="SessionState"/>. This is the assertion that actually pins ASP-29: an entry that cannot be applied this
+    /// pass must be <b>re-persisted, not erased</b>. It also pins the budget split — a not-yet-loaded target must not
+    /// spend the cross-reload give-up budget, while a loaded target whose type is unresolved spends exactly one attempt.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferencePendingAssignmentResolveTests
+    {
+        // A well-formed GlobalObjectId that parses but resolves to no live object (its owner is "not loaded").
+        private const string UnloadedGlobalId =
+            "GlobalObjectId_V1-2-0000000000000000f000000000000000-12345678901234567-0";
+        private const string UnresolvableType = "Aspid.FastTools.Tests.NoSuchPendingType";
+        private const string ProbeAssetPath = "Assets/__AspidPendingAssignmentProbe__.asset";
+
+        [SetUp]
+        public void SetUp() => SessionState.EraseString(Store.Key);
+
+        [TearDown]
+        public void TearDown() => SessionState.EraseString(Store.Key);
+
+        [Test]
+        public void ResolvePass_UnapplicableEntry_IsRePersisted_NotErased()
+        {
+            // The ASP-29 regression guard: the old code erased the key up front and dropped any entry it could not
+            // resolve in the first pass. A re-introduction of that bug must fail HERE, not slip past the wire-model tests.
+            Seed(new Entry(UnloadedGlobalId, "_field", UnresolvableType, attempts: 0));
+
+            var stillPending = Store.ResolvePass(countAttempt: true);
+
+            Assert.IsTrue(stillPending, "An entry that cannot be applied yet must keep the queue pending.");
+            var survivors = Store.Decode(SessionState.GetString(Store.Key, string.Empty));
+            Assert.AreEqual(1, survivors.Count, "The unapplied entry must be re-persisted, not erased (the ASP-29 bug).");
+            Assert.AreEqual(UnresolvableType, survivors[0].FullTypeName);
+        }
+
+        [Test]
+        public void ResolvePass_TargetNotLoaded_DoesNotSpendTheGiveUpBudget()
+        {
+            // A closed scene/asset can never be fixed by a domain reload, so its attempt counter must stay put — otherwise
+            // unrelated reloads burn the budget and silently drop a still-valid assignment.
+            Seed(new Entry(UnloadedGlobalId, "_field", UnresolvableType, attempts: 5));
+
+            Store.ResolvePass(countAttempt: true);
+
+            var survivors = Store.Decode(SessionState.GetString(Store.Key, string.Empty));
+            Assert.AreEqual(1, survivors.Count);
+            Assert.AreEqual(5, survivors[0].Attempts, "A not-yet-loaded target must not increment the give-up budget.");
+        }
+
+        [Test]
+        public void ResolvePass_LoadedTargetUnresolvedType_SpendsExactlyOneAttempt()
+        {
+            var probe = ScriptableObject.CreateInstance<PendingAssignmentProbeObject>();
+            try
+            {
+                AssetDatabase.CreateAsset(probe, ProbeAssetPath);
+                var globalId = GlobalObjectId.GetGlobalObjectIdSlow(probe).ToString();
+                Seed(new Entry(globalId, "_field", UnresolvableType, attempts: 0));
+
+                Store.ResolvePass(countAttempt: true);
+
+                var survivors = Store.Decode(SessionState.GetString(Store.Key, string.Empty));
+                Assert.AreEqual(1, survivors.Count, "A resolvable target with an unresolved type stays pending.");
+                Assert.AreEqual(1, survivors[0].Attempts,
+                    "A loaded target whose type has not compiled yet spends exactly one attempt per reload pass.");
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(ProbeAssetPath);
+            }
+        }
+
+        private static void Seed(Entry entry) =>
+            SessionState.SetString(Store.Key, Store.Encode(new List<Entry> { entry }));
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 918145ce11349475e8e26598f39fd9c2

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Scripting/SerializeReferencePendingAssignment.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Scripting/SerializeReferencePendingAssignment.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text;
 using UnityEditor;
 using UnityEngine;
 using Aspid.FastTools.Editors;
@@ -9,54 +11,161 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// <summary>
     /// Completes a "Create new script" flow across the domain reload that the new <c>.cs</c> triggers. The pending
     /// (target, propertyPath, expected type) is parked in <see cref="SessionState"/> before the reload and resolved on
-    /// the next load once the script has compiled — assigning a fresh instance of the new type to the field.
+    /// a later load once the script has compiled — assigning a fresh instance of the new type to the field.
     /// </summary>
+    /// <remarks>
+    /// The assignment can outlive several reloads: a stub may fail to compile, or the new assembly may register only on
+    /// a later reload than the one whose <see cref="EditorApplication.delayCall"/> fires first. Unresolved entries are
+    /// therefore <b>re-persisted</b> and retried on every subsequent load instead of being dropped. Only the
+    /// <i>type-not-resolved</i> reason — the one a reload can actually fix — spends the cross-reload budget and is
+    /// abandoned (with a warning) after <see cref="MaxResolveAttempts"/> loads; an entry whose <i>target is merely not
+    /// loaded</i> (its scene/asset is closed) waits indefinitely without spending the budget, since no reload count can
+    /// fix that. Provably-dead entries (malformed id, path no longer a managed reference) are dropped silently. Across
+    /// the same load a small bounded number of in-session re-arms catches an assembly that lands a tick late without a
+    /// fresh reload.
+    /// </remarks>
     internal static class SerializeReferencePendingAssignment
     {
-        private const string Key = "Aspid.FastTools.SerializeReference.PendingAssignment";
+        internal const string Key = "Aspid.FastTools.SerializeReference.PendingAssignment";
         private const char EntrySeparator = '\n';
         private const char FieldSeparator = '|';
 
-        /// <summary>Parks an assignment to complete after the next domain reload (when the new type compiles).</summary>
+        /// <summary>Cross-reload backstop: a still-unresolved entry is dropped (with a warning) after this many loads.</summary>
+        internal const int MaxResolveAttempts = 32;
+
+        /// <summary>Per-load belt-and-suspenders: how many extra <c>delayCall</c> passes to arm for a late same-load load.</summary>
+        internal const int MaxInSessionRetries = 3;
+
+        // Re-arms left for the current load; reset by Hook on every domain reload (static state does not survive a reload).
+        private static int _inSessionRetriesLeft;
+
+        /// <summary>Parks an assignment to complete after a later domain reload (when the new type compiles).</summary>
         public static void Enqueue(UnityEngine.Object target, string propertyPath, string fullTypeName)
         {
             if (target == null || string.IsNullOrEmpty(propertyPath) || string.IsNullOrEmpty(fullTypeName)) return;
 
-            var globalId = GlobalObjectId.GetGlobalObjectIdSlow(target);
-            var entry = $"{globalId}{FieldSeparator}{propertyPath}{FieldSeparator}{fullTypeName}";
+            var globalId = GlobalObjectId.GetGlobalObjectIdSlow(target).ToString();
+            var entry = new Entry(globalId, propertyPath, fullTypeName, attempts: 0);
 
-            var existing = SessionState.GetString(Key, string.Empty);
-            SessionState.SetString(Key, string.IsNullOrEmpty(existing) ? entry : existing + EntrySeparator + entry);
+            var queue = Decode(SessionState.GetString(Key, string.Empty));
+            Merge(queue, entry);
+            SessionState.SetString(Key, Encode(queue));
         }
 
         [InitializeOnLoadMethod]
-        private static void Hook() => EditorApplication.delayCall += Resolve;
-
-        private static void Resolve()
+        private static void Hook()
         {
-            var raw = SessionState.GetString(Key, string.Empty);
-            if (string.IsNullOrEmpty(raw)) return;
-            SessionState.EraseString(Key);
+            _inSessionRetriesLeft = MaxInSessionRetries;
+            EditorApplication.delayCall += ResolveAfterLoad;
+        }
 
-            foreach (var line in raw.Split(EntrySeparator))
+        // First pass after a load: a still-pending entry counts one resolve attempt against its cross-reload budget.
+        private static void ResolveAfterLoad() => Resolve(countAttempt: true);
+
+        // In-session re-arm: retries without spending the cross-reload budget (no new information has reloaded yet).
+        private static void ResolveRetry() => Resolve(countAttempt: false);
+
+        private static void Resolve(bool countAttempt)
+        {
+            // Re-arm another same-load pass (bounded) only while something is still pending, in case an assembly lands a
+            // tick after this one without a fresh reload. The cross-reload budget is spent by ResolvePass, not here.
+            if (ResolvePass(countAttempt) && _inSessionRetriesLeft > 0)
             {
-                var parts = line.Split(FieldSeparator);
-                if (parts.Length < 3) continue;
-
-                if (!GlobalObjectId.TryParse(parts[0], out var globalId)) continue;
-                var target = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(globalId);
-                if (target == null) continue;
-
-                var type = ResolveType(parts[2]);
-                if (type is null) continue;
-
-                var serializedObject = new SerializedObject(target);
-                var property = serializedObject.FindProperty(parts[1]);
-                if (property is null || property.propertyType != SerializedPropertyType.ManagedReference) continue;
-
-                property.SetManagedReferenceAndApply(SerializeReferenceHelpers.CreateInstance(type));
+                _inSessionRetriesLeft--;
+                EditorApplication.delayCall += ResolveRetry;
             }
         }
+
+        /// <summary>
+        /// Runs one resolve pass over the persisted queue: applies what it can, re-persists what is still pending, erases
+        /// the queue once nothing remains. Returns <c>true</c> while at least one entry is still pending. Internal so the
+        /// EditMode tests can drive the re-persist invariant without scheduling a <c>delayCall</c>.
+        /// </summary>
+        internal static bool ResolvePass(bool countAttempt)
+        {
+            var raw = SessionState.GetString(Key, string.Empty);
+            if (string.IsNullOrEmpty(raw)) return false;
+
+            var pending = Decode(raw);
+            var survivors = new List<Entry>(pending.Count);
+
+            foreach (var entry in pending)
+            {
+                ApplyOutcome outcome;
+                try
+                {
+                    outcome = TryApply(entry);
+                }
+                catch (Exception)
+                {
+                    // A resolved-but-incompatible type (e.g. a cross-assembly full-name collision) throws on assign.
+                    // Treat it as an unresolved attempt so it is bounded by the give-up cap instead of re-throwing every
+                    // reload, and — crucially — so it never strands the entries queued after it.
+                    outcome = ApplyOutcome.PendingUnresolved;
+                }
+
+                switch (outcome)
+                {
+                    case ApplyOutcome.Applied:
+                    case ApplyOutcome.Dead:
+                        break; // resolved or provably dead — drop from the queue.
+
+                    case ApplyOutcome.PendingUnloaded:
+                        // The owning scene/asset just isn't open; a reload cannot fix that, so keep waiting without
+                        // spending the cross-reload budget — only opening the owner (or quitting the session) resolves it.
+                        survivors.Add(entry);
+                        break;
+
+                    case ApplyOutcome.PendingUnresolved:
+                        // The type has not compiled/loaded yet (or could not be applied). This is what the budget bounds.
+                        var next = countAttempt ? entry.WithIncrementedAttempt() : entry;
+                        if (next.Attempts >= MaxResolveAttempts) WarnDropped(next);
+                        else survivors.Add(next);
+                        break;
+                }
+            }
+
+            if (survivors.Count == 0)
+            {
+                SessionState.EraseString(Key);
+                return false;
+            }
+
+            SessionState.SetString(Key, Encode(survivors));
+            return true;
+        }
+
+        private enum ApplyOutcome
+        {
+            Applied,
+            Dead,
+            PendingUnloaded,
+            PendingUnresolved,
+        }
+
+        private static ApplyOutcome TryApply(Entry entry)
+        {
+            if (!GlobalObjectId.TryParse(entry.GlobalId, out var globalId)) return ApplyOutcome.Dead;
+
+            var target = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(globalId);
+            if (target == null) return ApplyOutcome.PendingUnloaded; // the scene/asset holding the field isn't open yet.
+
+            var type = ResolveType(entry.FullTypeName);
+            if (type is null) return ApplyOutcome.PendingUnresolved; // the new assembly has not compiled/loaded yet.
+
+            var serializedObject = new SerializedObject(target);
+            var property = serializedObject.FindProperty(entry.PropertyPath);
+            if (property is null || property.propertyType != SerializedPropertyType.ManagedReference) return ApplyOutcome.Dead;
+
+            property.SetManagedReferenceAndApply(SerializeReferenceHelpers.CreateInstance(type));
+            return ApplyOutcome.Applied;
+        }
+
+        private static void WarnDropped(Entry entry) =>
+            Debug.LogWarning(
+                $"[Aspid.FastTools] Dropping the pending \"Create new script\" assignment of '{entry.FullTypeName}' to " +
+                $"'{entry.PropertyPath}' after {MaxResolveAttempts} domain reloads — its type never resolved (a compile " +
+                "error or unsupported generated stub) or could not be applied to the field. Re-pick the type once it compiles.");
 
         private static Type ResolveType(string fullName)
         {
@@ -70,6 +179,96 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             return null;
+        }
+
+        // --------------------------------------------------------------------------------------------------------------
+        // Wire model — pure, side-effect-free, unit-testable. SessionState stores newline-separated entries, each a
+        // pipe-separated (globalId | propertyPath | fullTypeName | attempts) record. None of those fields can contain a
+        // pipe or newline (GlobalObjectId, a serialized property path and an assembly-qualified type name never do), so
+        // the split is unambiguous. Legacy three-field records (written before retry tracking) decode as attempts = 0.
+        // --------------------------------------------------------------------------------------------------------------
+
+        internal readonly struct Entry : IEquatable<Entry>
+        {
+            public readonly string GlobalId;
+            public readonly string PropertyPath;
+            public readonly string FullTypeName;
+            public readonly int Attempts;
+
+            public Entry(string globalId, string propertyPath, string fullTypeName, int attempts)
+            {
+                GlobalId = globalId;
+                PropertyPath = propertyPath;
+                FullTypeName = fullTypeName;
+                Attempts = attempts;
+            }
+
+            public Entry WithIncrementedAttempt() => new(GlobalId, PropertyPath, FullTypeName, Attempts + 1);
+
+            /// <summary>True when both entries target the same field on the same object (ignores type and attempts).</summary>
+            public bool SameTarget(Entry other) => GlobalId == other.GlobalId && PropertyPath == other.PropertyPath;
+
+            public string Encode() =>
+                $"{GlobalId}{FieldSeparator}{PropertyPath}{FieldSeparator}{FullTypeName}{FieldSeparator}{Attempts}";
+
+            public static bool TryDecode(string line, out Entry entry)
+            {
+                entry = default;
+                if (string.IsNullOrEmpty(line)) return false;
+
+                var parts = line.Split(FieldSeparator);
+                if (parts.Length < 3) return false;
+                if (string.IsNullOrEmpty(parts[0]) || string.IsNullOrEmpty(parts[1]) || string.IsNullOrEmpty(parts[2])) return false;
+
+                var attempts = parts.Length > 3 && int.TryParse(parts[3], out var parsed) && parsed > 0 ? parsed : 0;
+                entry = new Entry(parts[0], parts[1], parts[2], attempts);
+                return true;
+            }
+
+            public bool Equals(Entry other) =>
+                GlobalId == other.GlobalId && PropertyPath == other.PropertyPath &&
+                FullTypeName == other.FullTypeName && Attempts == other.Attempts;
+
+            public override bool Equals(object obj) => obj is Entry other && Equals(other);
+
+            public override int GetHashCode() => HashCode.Combine(GlobalId, PropertyPath, FullTypeName, Attempts);
+
+            public override string ToString() => Encode();
+        }
+
+        internal static List<Entry> Decode(string raw)
+        {
+            var entries = new List<Entry>();
+            if (string.IsNullOrEmpty(raw)) return entries;
+
+            foreach (var line in raw.Split(EntrySeparator))
+                if (Entry.TryDecode(line, out var entry))
+                    entries.Add(entry);
+
+            return entries;
+        }
+
+        internal static string Encode(IReadOnlyList<Entry> entries)
+        {
+            var builder = new StringBuilder();
+            for (var i = 0; i < entries.Count; i++)
+            {
+                if (i > 0) builder.Append(EntrySeparator);
+                builder.Append(entries[i].Encode());
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Appends <paramref name="entry"/> to <paramref name="queue"/>, replacing any earlier entry that targets the
+        /// same field on the same object — re-picking a field's "new script" supersedes the previous pending pick rather
+        /// than queuing a second, stale assignment to the same path.
+        /// </summary>
+        internal static void Merge(List<Entry> queue, Entry entry)
+        {
+            queue.RemoveAll(existing => existing.SameTarget(entry));
+            queue.Add(entry);
         }
     }
 }


### PR DESCRIPTION
## Summary

- `SerializeReferencePendingAssignment.Resolve()` erased its `SessionState` queue **before** the resolve loop, so a "Create new script" assignment that wasn't resolvable in the first post-reload pass (the stub hadn't compiled yet, or the new assembly registered only on a later reload) was **lost forever**. Unresolved entries are now **re-persisted** and retried on every later domain reload instead of being dropped.
- The pending outcome is split: only a **not-yet-compiled type** spends the bounded cross-reload budget (`MaxResolveAttempts`, warns on give-up); a **not-yet-loaded target** (closed scene/asset) waits without burning it. The per-entry apply is wrapped in `try/catch`, so a resolved-but-non-assignable type (a cross-assembly full-name collision) can no longer re-throw every reload or strand the entries queued after it. A same-field re-pick now supersedes the previous pending entry instead of queuing a stale duplicate.

## Notes for review

- **Base branch is `feature/serialize-reference-dropdown` (PR #49), not `main`** — `SerializeReferencePendingAssignment.cs` doesn't exist on `main` yet, so this stacks on the feature branch.
- The fix was hardened against three defects surfaced by an adversarial multi-agent review: (1) the 32-reload budget was burned by unrelated reloads while a target sat in a closed scene, silently dropping a still-valid assignment; (2) a non-assignable resolved type re-threw on every reload, never hit the cap, and wedged later queue entries; (3) the regression itself was never directly asserted. All three are addressed here.
- A new `internal ResolvePass(bool)` seam lets the EditMode tests drive the re-persist invariant against a real `SessionState` without scheduling a `delayCall`.
- No package CLI build exists (Unity compiles on open), so the change was verified statically and by adversarial review. **The EditMode tests have not yet been run in the Unity Test Runner** — please run them before marking ready.

## Linked issues

Closes ASP-29