### PR TITLE
Anchor rid-pointer match to avoid string-value corruption

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
@@ -619,7 +619,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (entryIndent < 0) return false;
 
                 var headerPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
-                var pointerToken = new Regex($@"\brid:\s*{rid}\b");
+                var pointerToken = BuildPointerPattern(rid);
 
                 var headerIndex = -1;
                 var pointerNulled = false;
@@ -640,9 +640,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
                     // Null every pointer to the rid — a "- rid: N" array element, a "rid: N" scalar field or an inline
                     // "{rid: N}" — so no dangling pointer survives the entry's removal (which errors on array fields).
+                    // The anchored pattern preserves each pointer's structural prefix/suffix and only rewrites the id.
                     if (pointerToken.IsMatch(lines[i]))
                     {
-                        lines[i] = pointerToken.Replace(lines[i], $"rid: {NullRid}");
+                        lines[i] = pointerToken.Replace(lines[i], $"${{prefix}}rid: {NullRid}${{suffix}}");
                         pointerNulled = true;
                     }
                 }
@@ -717,7 +718,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (entryIndent < 0) return 0;
 
                 var headerPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
-                var pointerToken = new Regex($@"\brid:\s*{rid}\b");
+                var pointerToken = BuildPointerPattern(rid);
 
                 var headerSkipped = false;
                 var count = 0;
@@ -748,6 +749,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 return 0;
             }
         }
+
+        // An anchored matcher for a real "rid: N" pointer to a specific id — never a bare "rid: N" substring buried in a
+        // string field value (e.g. _note: 'see rid: 5'). Only Unity's three pointer shapes match: a line-anchored
+        // "- rid: N" sequence item, a line-anchored "rid: N" scalar child, or an inline "{rid: N}" mapping. The
+        // structural prefix/suffix (indent + dash, or the surrounding braces) are captured so a null-rewrite can keep
+        // them and replace only the id — mirroring the reader's knownRids validation, which is what keeps its same
+        // "rid:" scan from corrupting unrelated data.
+        private static Regex BuildPointerPattern(long rid) => new(
+            $@"(?<prefix>^\s*(?:-\s+)?)rid:\s*{rid}(?<suffix>\s*$)|(?<prefix>\{{\s*)rid:\s*{rid}(?<suffix>\s*\}})");
 
         // Whether the RefIds list already carries Unity's null sentinel entry ("- rid: -2"). The sentinel is a shared
         // singleton — at most one per object — so a second null pointer reuses it rather than adding another.


### PR DESCRIPTION
## Summary

- Anchor the `rid:` pointer matcher in `SerializeReferenceYamlEditor.TryNullReference` / `CountPointersTo` so it only matches Unity's real pointer shapes — a line-anchored `- rid: N` sequence item, a line-anchored `rid: N` scalar child, or an inline `{rid: N}` mapping — instead of any bare `rid: N` substring anywhere on a line.
- Prevents data loss where a string field value containing `rid: <orphan>` (e.g. `_note: 'see rid: 5'`) was rewritten to `rid: -2` on the non-undoable Clear write, and stops that same substring from inflating the Clear dialog's "aliased across N fields" count.
- Replacement now captures and preserves each pointer's structural prefix/suffix (indent + dash, or surrounding braces) and rewrites only the id.

## Notes for review

- The new inline branch matches `{rid: N}` (the only inline shape Unity writes for a managed-reference pointer); a multi-key inline mapping is intentionally not matched, which is strictly safer than the previous loose token.
- This mirrors the reader's intent: `SerializeReferenceGraphScanner` stays safe by validating every `rid:` match against its `knownRids` set; the writer has no such set, so anchoring to genuine pointer positions is the equivalent guard.
- Header-skip logic and the null-sentinel insertion are unchanged.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934023
