### PR TITLE
Fan out Create New Script assignment across all selected objects

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
@@ -341,8 +341,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (fieldType != null)
                 menu.AddItem(new GUIContent("Create New Script…"), false, () =>
                 {
-                    if (SerializeReferenceScriptCreator.TryCreateSubclassStub(fieldType, out _, out var fullTypeName))
-                        SerializeReferencePendingAssignment.Enqueue(property.serializedObject.targetObject, property.propertyPath, fullTypeName);
+                    if (!SerializeReferenceScriptCreator.TryCreateSubclassStub(fieldType, out _, out var fullTypeName)) return;
+
+                    // Multi-object: enqueue one pending assignment PER target so every selected object gets the new type
+                    // after the script compiles — each entry carries its own GlobalObjectId, so the (GlobalId, path)-keyed
+                    // queue keeps them apart. Enqueuing only targetObject (singular) would leave objects 2..N untouched.
+                    foreach (var target in property.serializedObject.targetObjects)
+                        SerializeReferencePendingAssignment.Enqueue(target, property.propertyPath, fullTypeName);
                 });
 
             // Save the current instance as a durable named template, and paste any assignable saved template.

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -616,7 +616,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private void CreateNewScript()
         {
             if (!SerializeReferenceScriptCreator.TryCreateSubclassStub(_fieldType, out _, out var fullTypeName)) return;
-            SerializeReferencePendingAssignment.Enqueue(_property.serializedObject.targetObject, _property.propertyPath, fullTypeName);
+
+            // Multi-object: enqueue one pending assignment PER target so every selected object gets the new type after
+            // the script compiles — each entry carries its own GlobalObjectId, so the (GlobalId, path)-keyed queue
+            // keeps them apart. Enqueuing only targetObject (singular) would leave objects 2..N untouched.
+            foreach (var target in _property.serializedObject.targetObjects)
+                SerializeReferencePendingAssignment.Enqueue(target, _property.propertyPath, fullTypeName);
         }
 
         private void SaveAsTemplate(Type type)


### PR DESCRIPTION
## Summary

- Fix data loss where "Create New Script…" under a multi-object selection assigned the new type to only the first object.
- Both the UIToolkit `SerializeReferenceField.CreateNewScript()` and the IMGUI drawer now enqueue one pending assignment per `serializedObject.targetObjects` entry, matching how every other write path (type-pick, Paste, ApplyTemplate, drop) fans out across all targets.

## Notes for review

- `SerializeReferencePendingAssignment.Enqueue` already null-guards and de-duplicates via `Merge`, and each entry is keyed by its own `GlobalObjectId` + property path, so per-target entries coexist correctly.
- Single-object selection is unchanged: `targetObjects` is a one-element array in that case.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934051
