### PR TITLE
Match generic types by open-generic identity in delete guard

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceManagedTypeNameTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceManagedTypeNameTests.cs
@@ -10,6 +10,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
         internal sealed class NestingInner { }
     }
 
+    // Top-level generic types so the open/closed identity test keys on "Modifier`1"/"Pair`2" rather than a nested name.
+    internal sealed class GenericModifier<T> { }
+
+    internal sealed class GenericPair<T, U> { }
+
     /// <summary>
     /// Coverage for <see cref="ManagedTypeName"/> — the YAML type-identity builder used by every repair write. Pins the
     /// closed-generic <c>Name`N[[arg, asm]]</c> shape and the single-quote escaping Unity requires for class identities
@@ -49,6 +54,32 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
             // FromType must rebuild the declaring-type prefix or a repair to a nested type writes an unresolvable class.
             var name = ManagedTypeName.FromType(typeof(NestingOuter.NestingInner));
             Assert.AreEqual("NestingOuter/NestingInner", name.Class);
+        }
+
+        [Test]
+        public void OpenTypeKey_OpenAndClosedGeneric_CollapseToSameKey()
+        {
+            // The delete guard reads a generic script's OPEN definition (Modifier`1[[T]]), while YAML stores each CLOSED
+            // instantiation (Modifier`1[[System.Single, …]]) — they must reduce to the same open-generic key, or deleting
+            // a generic [SerializeReference] type's script never warns (the closed StoredTypeKey would never match).
+            var open = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(typeof(GenericModifier<>)));
+            var closedFloat = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(typeof(GenericModifier<float>)));
+            var closedInt = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(typeof(GenericModifier<int>)));
+
+            Assert.AreEqual(open, closedFloat, "The open definition and a closed instantiation must share one open-generic key.");
+            Assert.AreEqual(open, closedInt, "Every closed instantiation of the same definition must share one open-generic key.");
+            StringAssert.Contains("GenericModifier`1", open, "The open key keeps the backtick arity and drops the [[…]] argument expansion.");
+            StringAssert.DoesNotContain("[", open, "The open key must drop the bracketed closed-argument expansion.");
+        }
+
+        [Test]
+        public void OpenTypeKey_DifferentArity_DoNotCollapse()
+        {
+            // The backtick arity is retained, so a one-arg and a two-arg definition never share a key.
+            var arityOne = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(typeof(GenericModifier<>)));
+            var arityTwo = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(typeof(GenericPair<,>)));
+
+            Assert.AreNotEqual(arityOne, arityTwo);
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
@@ -75,6 +75,30 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// </summary>
         internal static string StoredTypeKey(ManagedTypeName type) =>
             $"{type.Assembly}|{type.Namespace}|{type.Class}";
+
+        /// <summary>
+        /// Open-generic identity key for a stored type: class name with its backtick arity but <b>without</b> the
+        /// <c>[[…]]</c> closed-argument expansion, plus namespace and assembly. A script's open definition
+        /// (<c>Modifier`1[[T]]</c>, what <see cref="MonoScript.GetClass"/> yields) and the closed forms YAML stores
+        /// (<c>Modifier`1[[System.Single, …]]</c>) collapse to the same key, so the delete guard and usage index match
+        /// every closed instantiation of a generic type to its script. A non-generic type has no <c>[[…]]</c> suffix and
+        /// keys identically to <see cref="StoredTypeKey"/>.
+        /// </summary>
+        internal static string OpenTypeKey(ManagedTypeName type) =>
+            OpenTypeKey(StoredTypeKey(type));
+
+        /// <summary>
+        /// Reduces a <see cref="StoredTypeKey"/> string to its open-generic form by dropping the bracketed closed-argument
+        /// expansion (<c>Foo`1[[…]]</c> -> <c>Foo`1</c>). The bracket only appears inside the class segment and the
+        /// backtick arity is kept, so different arities never collapse and namespace/assembly stay intact.
+        /// </summary>
+        internal static string OpenTypeKey(string storedTypeKey)
+        {
+            if (string.IsNullOrEmpty(storedTypeKey)) return storedTypeKey ?? string.Empty;
+
+            var bracket = storedTypeKey.IndexOf('[');
+            return bracket >= 0 ? storedTypeKey[..bracket] : storedTypeKey;
+        }
         #endregion
 
         #region Multi-object editing

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceDeleteGuard.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceDeleteGuard.cs
@@ -64,7 +64,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 return paths;
             }
 
-            var key = SerializeReferenceHelpers.StoredTypeKey(ManagedTypeName.FromType(type));
+            // Match on the open-generic identity: a script resolves to the open definition (Modifier`1[[T]]), while YAML
+            // stores each closed instantiation (Modifier`1[[System.Single, …]]) under its own key — comparing the closed
+            // stored key would never match a generic type's script and the delete would slip through unwarned.
+            var key = SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(type));
             foreach (var path in AssetDatabase.GetAllAssetPaths())
             {
                 if (!SerializeReferenceHelpers.IsScanCandidate(path)) continue;
@@ -75,7 +78,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     foreach (var node in document.Nodes)
                     {
                         if (node.StoredType.IsEmpty) continue;
-                        if (!string.Equals(SerializeReferenceHelpers.StoredTypeKey(node.StoredType), key, StringComparison.Ordinal)) continue;
+                        if (!string.Equals(SerializeReferenceHelpers.OpenTypeKey(node.StoredType), key, StringComparison.Ordinal)) continue;
 
                         count++;
                         usedHere = true;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
@@ -67,9 +67,36 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return _index.TryGetValue(storedTypeKey, out var set) ? set : Array.Empty<Usage>();
         }
 
-        /// <summary>Every use site of <paramref name="type"/> by its concrete stored-type identity.</summary>
+        /// <summary>
+        /// Every use site of <paramref name="type"/> by its open-generic stored-type identity. A generic type's script
+        /// resolves to the open definition (<c>Modifier`1[[T]]</c>), while YAML stores each closed instantiation
+        /// (<c>Modifier`1[[System.Single, …]]</c>) under its own key — so the lookup keys on the open identity to gather
+        /// every closed form. A non-generic type has a single key and behaves exactly as a direct lookup.
+        /// </summary>
         public static IReadOnlyCollection<Usage> FindUsages(Type type) =>
-            type is null ? Array.Empty<Usage>() : FindUsages(SerializeReferenceHelpers.StoredTypeKey(ManagedTypeName.FromType(type)));
+            type is null ? Array.Empty<Usage>() : FindUsagesByOpenKey(SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(type)));
+
+        /// <summary>
+        /// Every use site whose stored type shares the open-generic identity <paramref name="openTypeKey"/> (warms the
+        /// index if cold). Aggregates across the closed-form keys a generic type splits into; for a non-generic identity
+        /// the open key equals the stored key and at most one entry contributes.
+        /// </summary>
+        public static IReadOnlyCollection<Usage> FindUsagesByOpenKey(string openTypeKey)
+        {
+            if (string.IsNullOrEmpty(openTypeKey)) return Array.Empty<Usage>();
+            EnsureBuilt();
+
+            HashSet<Usage> result = null;
+            foreach (var (key, set) in _index)
+            {
+                if (!string.Equals(SerializeReferenceHelpers.OpenTypeKey(key), openTypeKey, StringComparison.Ordinal))
+                    continue;
+
+                (result ??= new HashSet<Usage>()).UnionWith(set);
+            }
+
+            return (IReadOnlyCollection<Usage>)result ?? Array.Empty<Usage>();
+        }
 
         /// <summary>Number of use sites of <paramref name="type"/>.</summary>
         public static int CountUsages(Type type) => FindUsages(type).Count;


### PR DESCRIPTION
## Summary

- The `[SerializeReference]` delete guard never warned when deleting a generic type's script: a script resolves to its **open** definition (`Modifier`1[[T]]`), while YAML stores each **closed** instantiation (`Modifier`1[[System.Single, …]]`), so the closed `StoredTypeKey` could never match and the script deleted silently, breaking references.
- Added `SerializeReferenceHelpers.OpenTypeKey` (class name + backtick arity + namespace + assembly, dropping the `[[…]]` argument expansion) and matched on it in both the delete guard's cold scan and the warm `SerializeReferenceTypeUsageIndex` path (`FindUsages(Type)` / `CountUsages(Type)` now aggregate every closed instantiation via the new `FindUsagesByOpenKey`).
- Non-generic types are unaffected (their open key equals the stored key); added regression tests for the open/closed collapse and the arity-distinction guarantee.

## Notes for review

- The widening only affects generic types and only flows into the delete guard — `FindUsages(Type)` / `CountUsages(Type)` have no other callers in the package, so Find Usages of a non-generic type is byte-for-byte unchanged.
- `FindUsagesByOpenKey` walks the index keys once per lookup; that runs only on a single delete, not in a hot path.
- Backtick arity is retained so `Foo`1` and `Foo`2` never collapse together; namespace and assembly stay in the key so cross-namespace same-name types remain distinct.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934084
