### PR TITLE
Guard against null types in TypeSelectorAttribute constructor

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/TypeSelectorAttribute.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/TypeSelectorAttribute.cs
@@ -90,6 +90,7 @@ namespace Aspid.FastTools.Types
         public TypeSelectorAttribute(params Type[] types)
         {
             AssemblyQualifiedNames = types
+                .Where(type => type is not null)
                 .Select(type => type.AssemblyQualifiedName)
                 .ToArray();
         }


### PR DESCRIPTION
## Summary

- Guard the `TypeSelectorAttribute(params Type[])` constructor against `null` type arguments by filtering them with `.Where(type => type is not null)` before projecting to assembly-qualified names.
- Prevents a `NullReferenceException` during inspector drawer initialization (at `GetCustomAttribute`) when an attribute is declared with a `null` element, e.g. `[SerializeReference, TypeSelector(typeof(IMelee), null)]`.

## Notes for review

- The filter mirrors the existing `.Where(t => t is not null)` guard added in `TypeSelectorPropertyDrawer`, moving the protection earlier so the crash no longer happens before any drawer-side filtering.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934113
