### PR TITLE
Use persistent property in deferred IMGUI context-menu callbacks

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
@@ -334,7 +334,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 {
                     var path = candidate.Path;
                     menu.AddItem(new GUIContent($"Link to Existing/{candidate.Type.Name}  ({path})"), false,
-                        () => SerializeReferenceLinker.LinkTo(property, path));
+                        () => SerializeReferenceLinker.LinkTo(persistent, path));
                 }
 
             // Generate a new subclass of the field's type and assign it once it compiles.
@@ -342,7 +342,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 menu.AddItem(new GUIContent("Create New Script…"), false, () =>
                 {
                     if (SerializeReferenceScriptCreator.TryCreateSubclassStub(fieldType, out _, out var fullTypeName))
-                        SerializeReferencePendingAssignment.Enqueue(property.serializedObject.targetObject, property.propertyPath, fullTypeName);
+                        SerializeReferencePendingAssignment.Enqueue(persistent.serializedObject.targetObject, persistent.propertyPath, fullTypeName);
                 });
 
             // Save the current instance as a durable named template, and paste any assignable saved template.
@@ -358,7 +358,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             {
                 if (fieldType != null && !fieldType.IsAssignableFrom(template.Type)) continue;
                 var name = template.Name;
-                menu.AddItem(new GUIContent($"Paste Template/{name}"), false, () => ApplyTemplate(property, name));
+                menu.AddItem(new GUIContent($"Paste Template/{name}"), false, () => ApplyTemplate(persistent, name));
             }
 
             menu.ShowAsContext();


### PR DESCRIPTION
## Summary

- Fix three deferred `GenericMenu` callbacks in the IMGUI serialize-reference drawer that captured the stale per-frame `property` instead of the `persistent` snapshot the drawer already builds for the menu.
- `Create New Script…`, `Paste Template/*`, and `Link to Existing/*` now read/write through `persistent`, so by click time they no longer dereference a `SerializedObject` that may have been disposed after the frame.

## Notes for review

- `LinkTo` reads its source via `property.serializedObject.FindProperty(sourcePath)` and writes back on the same `SerializedObject`; passing `persistent` keeps both sides on one live SO and preserves the shared `managedReferenceId`.
- `ApplyTemplate` still calls `property.Persistent()` internally — now harmlessly idempotent since it receives an already-persistent property, and the deferred callback dereferences a live SO.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934164
