### PR TITLE
Detect in-place class rename breakage across the detector chain

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageDetector.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageDetector.cs
@@ -15,7 +15,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// The usage index is reset on every domain reload, so it cannot remember a prior state; the detector keeps its own
     /// baseline of resolvable stored-type keys in <see cref="SessionState"/>. The baseline is established silently on the
     /// first run of a session, so pre-existing breakages never alarm — only a key that WAS resolvable and is now missing
-    /// is reported. Driven by <see cref="SerializeReferenceBreakageHook"/> on relevant asset/script changes.
+    /// is reported. When the index is cold (an in-place rename forces a domain reload that resets it), the detector
+    /// re-resolves the baseline keys directly rather than warming the index, so the rename still alarms type-level.
+    /// Driven by <see cref="SerializeReferenceBreakageHook"/> on relevant asset/script changes.
     /// </remarks>
     internal static class SerializeReferenceBreakageDetector
     {
@@ -57,9 +59,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             // Never warm a cold index from the import / domain-reload path: that runs a modal full-project sweep on every
             // routine save (risk register 3/10). Detection is active only once the index is already warm (built by a
-            // deliberate Find Usages / Project References scan) and kept warm incrementally on import. When cold, the
-            // explicit Project References scan still finds everything; the proactive toast just stays quiet.
-            if (!SerializeReferenceTypeUsageIndex.IsWarm) return;
+            // deliberate Find Usages / Project References scan) and kept warm incrementally on import. When cold — e.g.
+            // after the domain reload an in-place class rename forces — fall back to re-resolving the prior baseline
+            // keys directly (no index, no modal sweep) so the headline rename case still alarms; the explicit Project
+            // References scan continues to find everything.
+            if (!SerializeReferenceTypeUsageIndex.IsWarm)
+            {
+                RunDetectionCold(report);
+                return;
+            }
 
             var resolvable = new HashSet<string>(StringComparer.Ordinal);
             var unresolved = new List<SerializeReferenceTypeUsageIndex.Usage>();
@@ -85,6 +93,62 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             SessionState.SetBool(EstablishedKey, true);
 
             if (result.HasAny) BreakageDetected?.Invoke(result);
+        }
+
+        // Cold-index path (the index was reset by the domain reload an in-place rename forces): the index cannot be
+        // enumerated and must not be warmed here, but the per-session baseline of resolvable stored-type keys survives in
+        // SessionState. Each key is re-resolved directly via Type.GetType; a key that WAS resolvable and no longer
+        // resolves is a type that just broke. The report is type-level only (no asset/rid sites — those need the index);
+        // the toast/console warning still fire and the Repair window rebuilds the index to list the exact sites.
+        private static void RunDetectionCold(bool report)
+        {
+            // No baseline yet means this is the session's first run with a cold index: there is nothing to compare
+            // against, so establishing silently (no alarm for pre-existing breakages) waits for a warm scan.
+            if (!report || !SessionState.GetBool(EstablishedKey, false)) return;
+
+            var baseline = LoadBaseline();
+            if (baseline.Count == 0) return;
+
+            var entries = new List<BreakageEntry>();
+            var brokenTypes = new HashSet<string>(StringComparer.Ordinal);
+            var stillResolvable = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var key in baseline)
+            {
+                if (!TryParseStoredTypeKey(key, out var storedType)) continue;
+
+                if (SerializeReferenceHelpers.StoredTypeResolves(storedType))
+                {
+                    stillResolvable.Add(key);
+                    continue;
+                }
+
+                // Type-level entry: no asset path / file id / rid is available without the index. Consumers on this path
+                // (the toast + console warning) read only the count and StoredType, and the Repair window rescans.
+                entries.Add(new BreakageEntry(null, 0, 0, storedType, isRepairable: false, topSuggestion: null));
+                brokenTypes.Add(key);
+            }
+
+            // Advance the baseline to the keys that still resolve so a type that just broke drops out and is never
+            // re-alarmed on the next cold scan, mirroring the warm path.
+            SaveBaseline(stillResolvable);
+
+            if (entries.Count == 0) return;
+            BreakageDetected?.Invoke(new BreakageReport(entries, brokenTypes.Count));
+        }
+
+        // Parses a "Assembly|Namespace|Class" baseline key (see SerializeReferenceHelpers.StoredTypeKey) back into a
+        // ManagedTypeName for direct re-resolution. Returns false for a malformed key or one with no class identity.
+        private static bool TryParseStoredTypeKey(string key, out ManagedTypeName storedType)
+        {
+            storedType = default;
+            if (string.IsNullOrEmpty(key)) return false;
+
+            var parts = key.Split('|');
+            if (parts.Length != 3 || parts[2].Length == 0) return false;
+
+            storedType = new ManagedTypeName(parts[0], parts[1], parts[2]);
+            return true;
         }
 
         // Builds the report from the unresolved usages whose stored type was resolvable in the baseline (i.e. just broke).

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageHook.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageHook.cs
@@ -8,8 +8,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 {
     /// <summary>
     /// Drives <see cref="SerializeReferenceBreakageDetector"/> when assets or scripts change: a renamed/deleted script
-    /// surfaces as a <c>.cs</c> in the deleted/moved lists, and a re-saved prefab/asset/scene as a candidate import. The
-    /// scan is debounced to one run per change burst via <see cref="EditorApplication.delayCall"/>.
+    /// surfaces as a <c>.cs</c> in the deleted/moved lists, an in-place class rename as an edited <c>.cs</c> in the
+    /// imported list, and a re-saved prefab/asset/scene as a candidate import. The scan is debounced to one run per
+    /// change burst via <see cref="EditorApplication.delayCall"/>.
     /// </summary>
     internal sealed class SerializeReferenceBreakageHook : AssetPostprocessor
     {
@@ -19,7 +20,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         {
             if (Application.isBatchMode) return;
 
-            var relevant = HasScript(deleted) || HasScript(moved)
+            // An in-place class rename (edit the .cs, no file move, no [MovedFrom]) reimports the script, so the edited
+            // .cs lands in `imported` — not deleted/moved. That is the detector's headline case, so it must schedule a
+            // scan too, alongside the rename/delete (.cs in deleted/moved) and re-saved-asset (candidate import) paths.
+            var relevant = HasScript(imported) || HasScript(deleted) || HasScript(moved)
                            || HasCandidate(imported) || HasCandidate(deleted) || HasCandidate(moved);
             if (!relevant || _scheduled) return;
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndexInvalidator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndexInvalidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 
@@ -21,7 +22,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private static void OnPostprocessAllAssets(string[] imported, string[] deleted, string[] moved, string[] movedFrom)
         {
-            if (HasCandidate(deleted) || HasCandidate(moved))
+            // An in-place class rename reimports the script (an edited .cs in `imported`, no file move). It changes which
+            // stored types resolve without touching any asset YAML, so a surgical per-asset patch would never run and the
+            // warm index would keep serving stale Resolves==true entries for the old type. A coarse reset is the only fix
+            // that re-evaluates resolution across every cached usage; the next lookup rebuilds.
+            if (HasCandidate(deleted) || HasCandidate(moved) || HasScript(imported))
             {
                 SerializeReferenceTypeUsageIndex.Reset();
                 return;
@@ -34,5 +39,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private static bool HasCandidate(string[] paths) =>
             paths.Any(SerializeReferenceHelpers.IsScanCandidate);
+
+        private static bool HasScript(string[] paths) =>
+            paths.Any(path => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## Summary

- Make proactive SerializeReference breakage detection fire for an in-place class rename (edit the `.cs`, no file move, no `[MovedFrom]`) — previously missed at all three layers.
- Hook: schedule a scan when an edited `.cs` lands in `imported`, not just on `.cs` in `deleted`/`moved`.
- Invalidator: `Reset()` the usage index when a `.cs` is imported, so the warm index drops stale `Resolves == true` entries for the renamed type instead of keeping a surgical per-asset patch that never runs.
- Detector: on the cold-index path (the rename forces a domain reload that resets the index) re-resolve the prior baseline keys directly via `Type.GetType` instead of early-returning, so the rename still raises a type-level toast/console warning without warming the index (no modal full-project sweep).

## Notes for review

- The cold-path report is type-level only (no asset/file-id/rid sites — those require the warm index). The toast and console warning read only the count and stored type, so they render correctly; the Repair window still rebuilds the index to list the exact sites. Worth eyeballing the toast wording ("N managed references became missing") against a type-level count.
- Cold-path baseline advancement mirrors the warm path: a type that just broke drops out of the baseline so it is not re-alarmed on the next cold scan.
- First-run-of-session safety preserved: with no established baseline the cold path establishes silently and never alarms pre-existing breakages.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934204
