### PR TITLE
Add deterministic tie-break to repair suggestion ranking

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRepairSuggestions.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRepairSuggestions.cs
@@ -87,7 +87,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             if (scored.Count == 0) return Array.Empty<RepairCandidate>();
 
-            scored.Sort((a, b) => b.Score.CompareTo(a.Score));
+            // Sort by descending score, then break ties deterministically on the candidate's full name and assembly
+            // (both Ordinal) so equally-scored same-named types in different namespaces always order the same way —
+            // otherwise the surfaced one-click fix would depend on TypeCache order and could flip across domain reloads.
+            scored.Sort(static (a, b) =>
+            {
+                var byScore = b.Score.CompareTo(a.Score);
+                if (byScore != 0) return byScore;
+
+                var byName = string.CompareOrdinal(a.Type.FullName, b.Type.FullName);
+                if (byName != 0) return byName;
+
+                return string.CompareOrdinal(a.Type.Assembly.GetName().Name, b.Type.Assembly.GetName().Name);
+            });
             return scored.Count <= max ? scored : scored.GetRange(0, max);
         }
 


### PR DESCRIPTION
## Summary

- Add a deterministic tie-break to the Smart-Fix candidate ranking in `SerializeReferenceRepairSuggestions.Rank`: after the descending-score sort, ties now break on the candidate's `Type.FullName` and then its assembly name (both Ordinal).
- Prevents the one-click repair suggestion from flipping between equally-scored same-named types (e.g. two `Pistol` classes in different namespaces) across domain reloads, which could otherwise re-point a reference to the wrong type.

## Notes for review

- The previous sort keyed only on the discrete `float Score` with an unstable `List.Sort`, so the winner depended on `TypeCache` ordering. The new comparator is total and stable across reloads. No behavioural change for the common single-best-candidate case.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934226
