### PR TITLE
Apply TypeSelector base-type filter to paste and templates

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
@@ -63,7 +63,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var contextEvent = Event.current;
             if (contextEvent.type == EventType.ContextClick && line.Contains(contextEvent.mousePosition))
             {
-                ShowContextMenu(property, fieldType);
+                ShowContextMenu(property, fieldType, baseTypes);
                 contextEvent.Use();
             }
 
@@ -299,9 +299,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
         }
 
-        private static void ShowContextMenu(SerializedProperty property, Type fieldType)
+        private static void ShowContextMenu(SerializedProperty property, Type fieldType, Type[] baseTypes)
         {
             var persistent = property.Persistent();
+            var filter = SerializeReferenceHelpers.BuildAssignableFilter(baseTypes);
             var menu = new GenericMenu();
 
             // Copy reads the first target's value (Unity's convention for a multi-selection menu). Paste then applies an
@@ -310,7 +311,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 () => SerializeReferenceClipboard.Copy(persistent.managedReferenceValue));
 
             var pasteLabel = new GUIContent("Paste Serialize Reference");
-            if (SerializeReferenceClipboard.CanPasteInto(fieldType))
+            if (SerializeReferenceClipboard.CanPasteInto(fieldType, filter))
                 menu.AddItem(pasteLabel, false, () => Paste(persistent));
             else
                 menu.AddDisabledItem(pasteLabel);
@@ -357,6 +358,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             foreach (var template in SerializeReferenceTemplates.LoadResolved())
             {
                 if (fieldType != null && !fieldType.IsAssignableFrom(template.Type)) continue;
+                if (!filter(template.Type)) continue;
                 var name = template.Name;
                 menu.AddItem(new GUIContent($"Paste Template/{name}"), false, () => ApplyTemplate(property, name));
             }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceClipboard.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceClipboard.cs
@@ -33,13 +33,16 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// <summary>
         /// Returns <see langword="true"/> when the clipboard holds content that can be pasted into a field whose
         /// declared managed-reference type is <paramref name="fieldType"/> (an empty reference always pastes —
-        /// it clears the field).
+        /// it clears the field). The optional <paramref name="filter"/> applies the same <c>[TypeSelector]</c>
+        /// base-type narrowing the picker, drag-drop and Smart-Fix enforce, so paste cannot assign a type the
+        /// dropdown would hide.
         /// </summary>
-        public static bool CanPasteInto(Type fieldType)
+        public static bool CanPasteInto(Type fieldType, Func<Type, bool> filter = null)
         {
             if (!_hasContent) return false;
             if (_type is null) return true;
-            return fieldType is null || fieldType.IsAssignableFrom(_type);
+            if (fieldType is not null && !fieldType.IsAssignableFrom(_type)) return false;
+            return filter is null || filter(_type);
         }
 
         /// <summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -533,7 +533,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             evt.menu.AppendAction("Copy Serialize Reference",
                 _ => SerializeReferenceClipboard.Copy(_property.managedReferenceValue));
 
-            var canPaste = SerializeReferenceClipboard.CanPasteInto(_fieldType);
+            var canPaste = SerializeReferenceClipboard.CanPasteInto(_fieldType, _filter);
 
             evt.menu.AppendAction("Paste Serialize Reference",
                 _ => PasteFromClipboard(),
@@ -570,6 +570,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             foreach (var template in SerializeReferenceTemplates.LoadResolved())
             {
                 if (_fieldType != null && !_fieldType.IsAssignableFrom(template.Type)) continue;
+                if (!_filter(template.Type)) continue;
                 var name = template.Name;
                 evt.menu.AppendAction($"Paste Template/{name}", _ => ApplyTemplate(name));
             }


### PR DESCRIPTION
## Summary

- Paste / Paste-Template on a `[SerializeReference]` field now respect the `[TypeSelector]` base-type narrowing, so they can no longer assign a type the dropdown, drag-drop and Smart-Fix would hide.
- `SerializeReferenceClipboard.CanPasteInto` gained an optional `filter` argument; the UIToolkit field and the IMGUI drawer pass their `BuildAssignableFilter(baseTypes)` predicate to both the Paste gate and the Paste-Template assignability check.
- The IMGUI `ShowContextMenu` is now threaded `baseTypes` (it previously received only `fieldType`) so it can build the same narrowing filter the rest of the field uses.

## Notes for review

- The narrowing filter is `IsAssignableManagedReference` plus the base-type set; `fieldType.IsAssignableFrom` is still checked separately, so behaviour is unchanged for unconstrained `[TypeSelector]` fields (the filter falls back to the plain structural check).
- Empty-reference paste still always pastes (it clears the field) — the filter is only consulted when the clipboard holds a concrete type.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934252
