### PR TITLE
Make List + add a single undo step without rid alias

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
@@ -89,12 +89,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var array = serializedObject.FindProperty(arrayPath);
             if (array is null || !array.isArray) return;
 
+            // Grow the array and assign the fresh instance before a single apply. arraySize++ copies the previous last
+            // element's managedReferenceId, but assigning a fresh instance overwrites it in the same modification —
+            // collapsing both into one Undo step and leaving no rid-aliased duplicate behind.
             var index = array.arraySize;
             array.arraySize = index + 1;
+            array.GetArrayElementAtIndex(index).SetManagedReference(SerializeReferenceHelpers.CreateInstance(type));
             serializedObject.ApplyModifiedProperties();
-            serializedObject.Update();
-
-            array.GetArrayElementAtIndex(index).SetManagedReferenceAndApply(SerializeReferenceHelpers.CreateInstance(type));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Make the picker-backed `+` add on a `List<[SerializeReference]>` a single Undo step by growing the array and assigning the fresh instance before one `ApplyModifiedProperties()`, instead of applying twice.
- This also overwrites the rid copied from the previous last element by `arraySize++` within the same modification, so no rid-aliased duplicate is left behind.

## Notes for review

- Dropped the intermediate `ApplyModifiedProperties()`/`Update()`; `SetManagedReferenceAndApply` is now `SetManagedReference` plus the single trailing apply. One Ctrl+Z now reverts the whole add, matching native add semantics.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934271
