### PR TITLE
Share per-frame state between GetHeight and Draw

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
@@ -940,21 +940,38 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (property.managedReferenceValue is null) return false;
 
             var id = property.managedReferenceId;
-            var shared = false;
-            var path = property.propertyPath;
 
-            TraverseManagedReferences(property.serializedObject, other =>
+            // GetHeight and Draw each ask this for every managed-reference field, every IMGUI repaint, so a naive
+            // per-property full-object walk is 2·N walks per frame. Instead the object's managed-reference id → use-count
+            // is built once per object per frame and reused: an id used by more than one field is aliased.
+            return GetReferenceIdCounts(property.serializedObject).TryGetValue(id, out var count) && count > 1;
+        }
+
+        // Per-object, per-frame memo of how many managed-reference fields carry each id. Built by a single full-object
+        // walk and shared across every HasSharedReference call in the same repaint (keyed by the SerializedObject and the
+        // current IMGUI frame), collapsing the 2·N walks GetHeight + Draw would otherwise do into one walk per object.
+        private static int _aliasFrame = -1;
+        private static SerializedObject _aliasSerializedObject;
+        private static readonly Dictionary<long, int> AliasCounts = new();
+
+        private static Dictionary<long, int> GetReferenceIdCounts(SerializedObject serializedObject)
+        {
+            var frame = Time.frameCount;
+            if (_aliasFrame == frame && ReferenceEquals(_aliasSerializedObject, serializedObject))
+                return AliasCounts;
+
+            AliasCounts.Clear();
+            TraverseManagedReferences(serializedObject, other =>
             {
-                if (other.propertyPath != path && other.managedReferenceId == id)
-                {
-                    shared = true;
-                    return true;
-                }
-
+                var id = other.managedReferenceId;
+                AliasCounts.TryGetValue(id, out var count);
+                AliasCounts[id] = count + 1;
                 return false;
             });
 
-            return shared;
+            _aliasFrame = frame;
+            _aliasSerializedObject = serializedObject;
+            return AliasCounts;
         }
 
         /// <summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRequiredGate.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRequiredGate.cs
@@ -97,6 +97,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Per-type memo for GetRequiredFields — the reflected field set is stable until a domain reload clears statics.
         private static readonly Dictionary<Type, IReadOnlyList<RequiredFieldDescriptor>> RequiredFieldCache = new();
 
+        // Memoises ResolveFieldInfo by (target type, property path): the reflected field is stable for a given type and
+        // path until a domain reload clears statics, so IsViolation/TryGetRequired — called from both GetHeight and Draw
+        // every IMGUI repaint — reflect each path only once instead of re-walking it on every frame.
+        private static readonly Dictionary<(Type, string), FieldInfo> ResolvedFieldCache = new();
+
         // Walks the property path against the target object's type to find the declared field (which carries the
         // attribute). For a list/array element the field is the collection itself, matching PropertyDrawer.fieldInfo.
         private static FieldInfo ResolveFieldInfo(SerializedProperty property)
@@ -104,8 +109,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var type = property.serializedObject?.targetObject?.GetType();
             if (type is null) return null;
 
+            var cacheKey = (type, property.propertyPath);
+            if (ResolvedFieldCache.TryGetValue(cacheKey, out var cachedField)) return cachedField;
+
+            var field = ResolveFieldInfoUncached(type, property.propertyPath);
+            ResolvedFieldCache[cacheKey] = field;
+            return field;
+        }
+
+        private static FieldInfo ResolveFieldInfoUncached(Type targetType, string propertyPath)
+        {
+            var type = targetType;
+
             // "_slots.Array.data[0]._weapon" -> "_slots[0]._weapon"
-            var path = property.propertyPath.Replace(".Array.data[", "[");
+            var path = propertyPath.Replace(".Array.data[", "[");
             FieldInfo field = null;
 
             foreach (var rawSegment in path.Split('.'))


### PR DESCRIPTION
## Summary

- The `[SerializeReference]` IMGUI drawer asked `HasSharedReference` for every managed-reference field from both `GetHeight` and `Draw` on each repaint, and each call did a full `SerializedObject` walk — `2·N` whole-object walks per frame. `HasSharedReference` now builds the object's managed-reference id → use-count once per `(SerializedObject, frame)` and reuses it, so the object is walked once per repaint instead of `2·N` times.
- `SerializeReferenceRequiredGate.ResolveFieldInfo` now memoises its reflection walk by `(target type, property path)` — like the existing `RequiredFieldCache` — so `IsViolation` / `TryGetRequired` (also called from both `GetHeight` and `Draw`) reflect each path once instead of re-walking it every frame.

## Notes for review

- The alias detection switched from "another field at a different path shares my id" to "my id is used by more than one field". These are equivalent: a field's own path contributes exactly 1 to its id's count, so `count > 1` means at least one other field aliases it. The existing `managedReferenceValue is null` guard still short-circuits empty references first.
- The per-frame alias cache is keyed by `Time.frameCount` + the `SerializedObject` reference; an in-frame mutation (e.g. `MakeReferenceUnique`) is applied via a button click that ends the draw and rebuilds the inspector next frame, so the cache rebuilds then — same staleness tolerance as the existing per-selection `_mixedResult` memo.
- The `ResolveFieldInfo` cache is static and never explicitly cleared, which matches `RequiredFieldCache` in the same class: the reflected field set is stable until a domain reload wipes statics.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934357
