### PR TITLE
Cache per-asset constraint map in graph view

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
@@ -127,6 +127,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private AspidGradientButton _openPickerRow;
         private VisualElement _openPickerCard;
 
+        // Per-asset constraint map cache, mirroring SerializeReferenceProjectView: BuildConstraintMap does a
+        // LoadAllAssetsAtPath + full SerializedObject walk, so without this each Fix-Missing picker open would re-scan
+        // the whole asset. Keyed by asset path (the graph maps one asset at a time, but a multi-document asset still
+        // shares one map across its cards). Cleared on every Rescan / apply so a fix's rewritten YAML is re-read.
+        private readonly Dictionary<string, Dictionary<(long fileId, long rid), Type>> _constraintCache = new(StringComparer.Ordinal);
+
         public SerializeReferenceGraphView(Object target, Action<Color> onCanvasTone, Action<Object> onTargetChanged = null)
         {
             _target = target;
@@ -245,6 +251,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (_list is null) return;
 
             ClosePicker();
+            // Drop the per-asset constraint maps so a rescan after a fix / clear re-reads the rewritten YAML rather than
+            // a stale map. Every apply path (ApplyFix / ClearReference / ApplyLive / ClearOrphan) funnels through here.
+            _constraintCache.Clear();
             _list.Clear();
 
             var assetPath = _target ? AssetDatabase.GetAssetPath(_target) : null;
@@ -1092,12 +1101,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         // Recovers the declared field type backing rid so the Fix picker is constrained the same way the Repair window
         // constrains its own. The asset's whole managed-reference constraint map (keyed by document file id + rid) is
-        // built once and looked up by the owning document's exact (fileId, rid) key, so a rid that collides across
-        // documents resolves to this document's field type rather than another's. Returns null (unconstrained) when no
-        // field points at the rid (an orphaned payload) or the field type is unresolvable.
-        private static Type ResolveConstraint(string assetPath, long fileId, long rid)
+        // built once, cached per asset path (so K missing cards on one asset share a single scan rather than re-scanning
+        // per picker open) and looked up by the owning document's exact (fileId, rid) key, so a rid that collides across
+        // documents resolves to this document's field type rather than another's. The cache is dropped on every Rescan /
+        // apply so a fix's rewritten YAML is re-read. Returns null (unconstrained) when no field points at the rid (an
+        // orphaned payload) or the field type is unresolvable.
+        private Type ResolveConstraint(string assetPath, long fileId, long rid)
         {
-            var map = SerializeReferenceHelpers.BuildConstraintMap(assetPath);
+            if (!_constraintCache.TryGetValue(assetPath, out var map))
+            {
+                map = SerializeReferenceHelpers.BuildConstraintMap(assetPath);
+                _constraintCache[assetPath] = map;
+            }
+
             return map.TryGetValue((fileId, rid), out var constraint) ? constraint : null;
         }
 


### PR DESCRIPTION
## Summary

- Cache the per-asset managed-reference constraint map in `SerializeReferenceGraphView` so opening the "Fix Missing" / "Change" picker no longer re-runs `BuildConstraintMap` (a `LoadAllAssetsAtPath` + full `SerializedObject` walk) on every card click.
- Mirror the existing `SerializeReferenceProjectView` pattern: an instance `_constraintCache` keyed by asset path, populated lazily in `ResolveConstraint` (now an instance method) and cleared at the top of `Rescan` (which every apply path funnels through) so a fix's rewritten YAML is re-read.

## Notes for review

- `_constraintCache.Clear()` lives at the start of `Rescan`; `ApplyFix`, `ClearReference`, `ApplyLive`, and `ClearOrphan` all end by calling `Rescan`, so the cache can never serve a map staled by an in-view edit.
- Keyed by asset path (not a single map) so a multi-document asset still shares one map across its cards while staying correct if the target ever changes.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448934432
