### PR TITLE
Confirm before overwriting an existing template by name

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
@@ -351,7 +351,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 var value = persistent.managedReferenceValue;
                 menu.AddItem(new GUIContent("Save as Template…"), false,
                     () => SerializeReferenceNamePrompt.Show("Save Template",
-                        SerializeReferenceTemplates.SuggestName(usagesType), name => SerializeReferenceTemplates.Save(name, value)));
+                        SerializeReferenceTemplates.SuggestName(usagesType),
+                        name => SerializeReferenceTemplates.SaveConfirmed(name, value)));
             }
 
             foreach (var template in SerializeReferenceTemplates.LoadResolved())

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceTemplates.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceTemplates.cs
@@ -49,6 +49,21 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private static string Key => KeyPrefix + PlayerSettings.productGUID;
 
+        /// <summary>Whether a template with <paramref name="name"/> already exists.</summary>
+        public static bool Contains(string name) => Load().entries.Exists(entry => entry.name == name);
+
+        /// <summary>
+        /// Saves <paramref name="value"/> under <paramref name="name"/>, asking for confirmation first when a template
+        /// with that name already exists (the existing one would be overwritten).
+        /// </summary>
+        public static void SaveConfirmed(string name, object value)
+        {
+            if (Contains(name) && !EditorUtility.DisplayDialog("Overwrite Template?",
+                    $"A template named \"{name}\" already exists. Overwrite it?", "Overwrite", "Cancel")) return;
+
+            Save(name, value);
+        }
+
         /// <summary>Saves <paramref name="value"/> under <paramref name="name"/> (replacing an existing one).</summary>
         public static void Save(string name, object value)
         {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -625,7 +625,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (value is null) return;
 
             SerializeReferenceNamePrompt.Show("Save Template", SerializeReferenceTemplates.SuggestName(type),
-                name => SerializeReferenceTemplates.Save(name, value));
+                name => SerializeReferenceTemplates.SaveConfirmed(name, value));
         }
 
         private void ApplyTemplate(string name)


### PR DESCRIPTION
## Summary

- Saving a managed-reference template under an existing name now prompts for confirmation instead of silently overwriting the stored entry (durable EditorPrefs data loss).
- Added `SerializeReferenceTemplates.Contains(string)` and a `SaveConfirmed(string, object)` helper that shows an `EditorUtility.DisplayDialog("Overwrite Template?", …)` when the name collides, then defers to the existing `Save`.
- Routed both "Save as Template…" call sites (UIToolkit `SerializeReferenceField` and IMGUI `SerializeReferenceIMGUIPropertyDrawer`) through `SaveConfirmed`.

## Notes for review

- The prompt already trims the name (`SerializeReferenceNamePrompt.Confirm` calls `_value.Trim()`), so the `Contains` check matches the trimmed name that `Save` persists — no off-by-trim mismatch.
- `Save` stays public/unchanged for callers that intentionally replace; only the user-initiated UI paths gained the confirm gate.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448944932
