### PR TITLE
Filter nested generic definitions by all generic constraints

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeSelectorView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeSelectorView.cs
@@ -1012,8 +1012,10 @@ namespace Aspid.FastTools.Types.Editors
                 (_argumentFilter?.Invoke(candidate) ?? true);
 
             // Offer open generic definitions as arguments too, so the user can nest generics (e.g. choose
-            // Modifier<T> for T) — picking one resolves its own arguments before it is used here.
-            var nested = GenericTypeResolver.GetAssignableGenericDefinitions(constraintType);
+            // Modifier<T> for T) — picking one resolves its own arguments before it is used here. Pass every
+            // constraint base type (not just the collapsed single one) so a multi-constraint parameter narrows
+            // the nested definitions by all of them up front, instead of offering defs that fail every later pick.
+            var nested = GenericTypeResolver.GetAssignableGenericDefinitions(baseTypes[0], baseTypes);
             var hierarchy = HierarchyBuilder.Build(baseTypes, TypeAllow.None, filter, nested, includeNoneOption: false);
 
             return new PickerPage


### PR DESCRIPTION
## Summary

- Fix `BuildParamPage` over-broadening the nested open-generic list for a type parameter with multiple base constraints (`where T : Base, IFoo`).
- Instead of collapsing the constraints to a single type (or `object`) before fetching nested definitions, pass the full `baseTypes` to `GetAssignableGenericDefinitions` so the candidate defs are narrowed by every constraint up front — no more dead-end picks that end in an inline "Cannot construct…" error.

## Notes for review

- `GetAssignableGenericDefinitions(fieldType, params Type[] narrowTypes)` checks closeability against `fieldType` and each narrowing type; `GetConstraintBaseTypes` never returns an empty array (it falls back to `{ typeof(object) }`), so `baseTypes[0]` is safe and `object` entries are ignored by the narrowing filter.
- `constraintType` is left untouched — it still backs the `PickerPage.ConstraintType` used downstream.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448944953
