### PR TITLE
Clamp AspidHoverGradientOverlay Steps to ushort mesh limit

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidHoverGradientOverlays/AspidHoverGradientOverlay.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidHoverGradientOverlays/AspidHoverGradientOverlay.cs
@@ -20,6 +20,10 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         private const float DefaultLerpRate = 0.12f;
         private const float DefaultAlphaScale = 0.35f;
 
+        // Each step emits 6 indices, so steps must stay at or below 65535 / 6 = 10922 to keep the
+        // (ushort)(i * 2 + 3) index math from wrapping past the 65535 ushort mesh-index limit.
+        private const int MaxSteps = ushort.MaxValue / 6;
+
         private const string StyleSheetPath = "UI/Components/Aspid-FastTools-AspidHoverGradientOverlay";
 
         private readonly AspidHoverGradientOverlayColorStyle _color;
@@ -112,7 +116,7 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
             var rect = contentRect;
             if (rect.width <= 0f || rect.height <= 0f) return;
 
-            var steps = Mathf.Max(1, _metrics.Steps);
+            var steps = Mathf.Clamp(_metrics.Steps, 1, MaxSteps);
             var alphaScale = _metrics.AlphaScale;
             var baseColor = _color.Value;
 


### PR DESCRIPTION
## Summary

- Clamp `AspidHoverGradientOverlay.Steps` to an upper bound in `DrawOverlay`, replacing the lower-only `Mathf.Max(1, …)` with `Mathf.Clamp(…, 1, MaxSteps)`.
- `MaxSteps` is `ushort.MaxValue / 6` (10922), the largest step count whose `steps * 6` index buffer and `(ushort)(i * 2 + …)` casts stay within the 65535 `ushort` mesh-index limit, preventing index wrap on absurdly large authored `Steps` values.

## Notes for review

- The cap also keeps the vertex count `(steps + 1) * 2` (≤ 21846) well within `ushort`; the index count is the tighter constraint, so it drives the bound.
- `Steps` remains freely settable via UXML/USS; only the per-draw mesh-sizing path is clamped, so no API or default behavior changes for sane values.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448944976
