### PR TITLE
Extract shared YAML-scan helper for scanner and editor

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceGraphScanner.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceGraphScanner.cs
@@ -132,23 +132,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// <summary>
     /// Builds, per asset path, a document-per-component managed-reference graph from the raw YAML — independent of
     /// the live serialization API, so it sees nested, orphaned and missing references the Inspector cannot navigate
-    /// to. Parsing is local to this scanner: it reuses <see cref="ManagedTypeName"/> /
-    /// <see cref="SerializeReferenceHelpers.StoredTypeResolves"/> for type identity only, and does not depend on the
-    /// repair-flow helpers in <see cref="SerializeReferenceYamlEditor"/>.
+    /// to. The low-level YAML-scan primitives (document headers, the <c>RefIds</c> lookup, the inline-type grammar,
+    /// indentation and entry bounding) are shared with the repair flow through <see cref="SerializeReferenceYaml"/>,
+    /// so the graph window and <see cref="SerializeReferenceYamlEditor"/> cannot disagree about Unity's RefIds shape;
+    /// type identity reuses <see cref="ManagedTypeName"/> / <see cref="SerializeReferenceHelpers.StoredTypeResolves"/>.
     /// </summary>
     internal static class SerializeReferenceGraphScanner
     {
-        // "--- !u!114 &11400000" — object document header carrying the local file id as its YAML anchor and the
-        // class id ("!u!114") used as a best-effort fallback label when the live type name is unavailable.
-        private static readonly Regex DocumentHeader = new(@"^--- !u!(?<class>\d+) &(?<id>\d+)", RegexOptions.Compiled);
+        // Document headers, the RefIds-key lookup and the inline-type grammar are single-sourced in
+        // SerializeReferenceYaml so this scanner and the repair flow read Unity's RefIds shape identically.
         private static readonly Regex ReferencesKey = new(@"^\s*references:\s*$", RegexOptions.Compiled);
-        private static readonly Regex RefIdsKey = new(@"^\s*RefIds:\s*$", RegexOptions.Compiled);
         private static readonly Regex EntryRid = new(@"^(?<indent>\s*)-\s+rid:\s*(?<id>-?\d+)\s*$", RegexOptions.Compiled);
         private static readonly Regex TypeLine = new(@"^\s*type:\s*\{(?<body>.*)\}\s*$", RegexOptions.Compiled);
         private static readonly Regex DataKey = new(@"^\s*data:\s*$", RegexOptions.Compiled);
-        private static readonly Regex InlineType = new(
-            @"class:\s*(?:'(?<class>(?:[^']|'')*)'|(?<class>[^,}]*?))\s*,\s*ns:\s*(?<ns>[^,}]*?)\s*,\s*asm:\s*(?<asm>[^,}]*?)\s*$",
-            RegexOptions.Compiled);
 
         // A "rid:" pointer anywhere in a body/data line (inline "{rid: N}", "- rid: N", or a bare "rid: N" scalar).
         // The leading non-word lookbehind keeps a field whose name ends in "rid" (e.g. "_hybrid: 5") from matching;
@@ -207,7 +203,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var referencesStart = FindKey(lines, ReferencesKey, start, end);
             var bodyEnd = referencesStart >= 0 ? referencesStart : end;
 
-            var refIdsStart = FindKey(lines, RefIdsKey, start, end);
+            var refIdsStart = SerializeReferenceYaml.FindRefIdsStart(lines, start, end);
             if (refIdsStart < 0) return null;
 
             var document = new ReferenceGraphDocument { FileId = fileId };
@@ -250,7 +246,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     if (!typeMatch.Success) continue;
 
                     // On a parse failure type stays default/empty (and the node renders as just "rid N").
-                    if (!TryParseInlineType(typeMatch.Groups["body"].Value, out type))
+                    if (!SerializeReferenceYaml.TryParseInlineType(typeMatch.Groups["body"].Value, out type))
                         type = default;
                     break;
                 }
@@ -302,7 +298,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (parent < 0) continue; // a sentinel entry carries no data block of its own
 
                 var entryIndent = ridMatch.Groups["indent"].Length;
-                var entryEnd = FindEntryEnd(lines, i + 1, end, entryIndent);
+                var entryEnd = SerializeReferenceYaml.FindEntryEnd(lines, i, end, entryIndent);
 
                 var dataStart = FindKey(lines, DataKey, i + 1, entryEnd);
                 if (dataStart < 0) continue;
@@ -388,7 +384,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // relative; the view joins it onto the parent's full path. Empty when no key is found (the view then keeps the
         // parent path alone).
         private static string BuildEdgePath(string[] lines, int pointerLine, int dataStart) =>
-            BuildPath(lines, pointerLine, floor: dataStart, stopIndent: IndentOf(lines[dataStart]));
+            BuildPath(lines, pointerLine, floor: dataStart, stopIndent: SerializeReferenceYaml.IndentOf(lines[dataStart]));
 
         // Builds a dotted field path by walking up from the rid pointer on <paramref name="pointerLine"/>, collecting
         // mapping keys (with a "[index]" suffix on any list key crossed), until it climbs out of the enclosing scope.
@@ -410,7 +406,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // YAML nesting is finite; the counter only guards a malformed file from looping the walk forever.
             for (var safety = 0; line > floor && safety < 256; safety++)
             {
-                var indent = IndentOf(lines[line]);
+                var indent = SerializeReferenceYaml.IndentOf(lines[line]);
                 int next;
 
                 if (lines[line].TrimStart().StartsWith("- "))
@@ -428,7 +424,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     {
                         if (lines[j].Trim().Length == 0) continue;
 
-                        var jIndent = IndentOf(lines[j]);
+                        var jIndent = SerializeReferenceYaml.IndentOf(lines[j]);
                         if (jIndent > indent) continue;                          // nested detail of an earlier sibling
                         if (jIndent < indent) break;                             // dedented out of the list
                         if (lines[j].TrimStart().StartsWith("- ")) { index++; continue; }
@@ -443,7 +439,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     if (!ownerKey.Success || IsStructuralKey(ownerKey.Groups["key"].Value)) break;
 
                     segments.Add($"{ownerKey.Groups["key"].Value}[{index}]");
-                    next = ParentLine(lines, ownerLine, floor, IndentOf(lines[ownerLine]));
+                    next = ParentLine(lines, ownerLine, floor, SerializeReferenceYaml.IndentOf(lines[ownerLine]));
                 }
                 else
                 {
@@ -456,7 +452,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     next = ParentLine(lines, line, floor, indent);
                 }
 
-                if (next < 0 || IndentOf(lines[next]) <= stopIndent) break; // climbed out of the enclosing scope
+                if (next < 0 || SerializeReferenceYaml.IndentOf(lines[next]) <= stopIndent) break; // climbed out of the enclosing scope
                 line = next;
             }
 
@@ -473,7 +469,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             for (var j = from - 1; j >= start; j--)
             {
                 if (lines[j].Trim().Length == 0) continue;
-                if (IndentOf(lines[j]) < indent) return j;
+                if (SerializeReferenceYaml.IndentOf(lines[j]) < indent) return j;
             }
 
             return -1;
@@ -488,7 +484,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var headers = new List<(long, int, int)>();
             for (var i = 0; i < lines.Length; i++)
             {
-                var match = DocumentHeader.Match(lines[i]);
+                var match = SerializeReferenceYaml.DocumentHeader.Match(lines[i]);
                 if (match.Success &&
                     long.TryParse(match.Groups["id"].Value, out var fileId) &&
                     int.TryParse(match.Groups["class"].Value, out var classId))
@@ -541,43 +537,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (key.IsMatch(lines[i])) return i;
 
             return -1;
-        }
-
-        // A RefIds entry runs until the next list item at its own indent, or until the block dedents out of it.
-        private static int FindEntryEnd(string[] lines, int from, int end, int entryIndent)
-        {
-            for (var j = from; j < end; j++)
-            {
-                if (lines[j].Trim().Length == 0) continue;
-
-                var indent = IndentOf(lines[j]);
-                if (indent < entryIndent) return j;
-                if (indent == entryIndent && lines[j].TrimStart().StartsWith("- ")) return j;
-            }
-
-            return end;
-        }
-
-        private static int IndentOf(string line)
-        {
-            var count = 0;
-            while (count < line.Length && line[count] == ' ') count++;
-            return count;
-        }
-
-        // Parses the inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping, honouring the single-quoted
-        // class names Unity writes for closed generics (e.g. 'Modifier`1[[…]]'). Mirrors the parser in
-        // SerializeReferenceYamlEditor but kept local so the scanner owns its parsing.
-        private static bool TryParseInlineType(string body, out ManagedTypeName type)
-        {
-            type = default;
-
-            var match = InlineType.Match(body);
-            if (!match.Success) return false;
-
-            var className = match.Groups["class"].Value.Replace("''", "'");
-            type = new ManagedTypeName(match.Groups["asm"].Value, match.Groups["ns"].Value, className);
-            return !type.IsEmpty;
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYaml.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYaml.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// The shared, parser-free YAML-scan toolkit for Unity's managed-reference (<c>RefIds</c>) serialization, used by
+    /// both the repair flow (<see cref="SerializeReferenceYamlEditor"/>) and the graph window
+    /// (<see cref="SerializeReferenceGraphScanner"/>). Single-sourcing these primitives keeps the two readers in
+    /// agreement about Unity's RefIds shape — quoting, indentation and the document/inline-type grammar — so a fix to
+    /// one cannot silently diverge from the other.
+    /// </summary>
+    internal static class SerializeReferenceYaml
+    {
+        // "--- !u!114 &11400000" — object document header carrying the local file id as its YAML anchor and the
+        // class id ("!u!114") used as a best-effort fallback label when the live type name is unavailable.
+        public static readonly Regex DocumentHeader = new(@"^--- !u!(?<class>\d+) &(?<id>\d+)", RegexOptions.Compiled);
+
+        // "  RefIds:" — the managed-reference id list of an object document.
+        public static readonly Regex RefIdsKey = new(@"^\s*RefIds:\s*$", RegexOptions.Compiled);
+
+        // The inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping, honouring the single-quoted class names
+        // Unity writes for closed generics (e.g. 'Modifier`1[[…]]').
+        public static readonly Regex InlineType = new(
+            @"class:\s*(?:'(?<class>(?:[^']|'')*)'|(?<class>[^,}]*?))\s*,\s*ns:\s*(?<ns>[^,}]*?)\s*,\s*asm:\s*(?<asm>[^,}]*?)\s*$",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses the inline <c>class: X, ns: Y, asm: Z</c> body of a <c>RefIds</c> type mapping into a
+        /// <see cref="ManagedTypeName"/>, honouring the single-quoted class names Unity writes for closed generics
+        /// (e.g. <c>'Modifier`1[[…]]'</c>). Returns <see langword="false"/> for a malformed or empty type body.
+        /// </summary>
+        public static bool TryParseInlineType(string body, out ManagedTypeName type)
+        {
+            type = default;
+
+            var match = InlineType.Match(body);
+            if (!match.Success) return false;
+
+            var className = match.Groups["class"].Value.Replace("''", "'");
+            type = new ManagedTypeName(match.Groups["asm"].Value, match.Groups["ns"].Value, className);
+            return !type.IsEmpty;
+        }
+
+        /// <summary>
+        /// Index of the <c>RefIds:</c> key line within <c>[start, end)</c>, or <c>-1</c> when the document has no
+        /// managed references.
+        /// </summary>
+        public static int FindRefIdsStart(string[] lines, int start, int end)
+        {
+            for (var i = start; i < end; i++)
+                if (RefIdsKey.IsMatch(lines[i]))
+                    return i;
+
+            return -1;
+        }
+
+        /// <summary>
+        /// The exclusive end line of a <c>RefIds</c> entry that begins at <paramref name="headerIndex"/>: the entry runs
+        /// until the next list item at its own indent, or until the block dedents out of it (blank lines are spanned).
+        /// </summary>
+        public static int FindEntryEnd(string[] lines, int headerIndex, int end, int entryIndent)
+        {
+            for (var j = headerIndex + 1; j < end; j++)
+            {
+                if (lines[j].Trim().Length == 0) continue;
+
+                var indent = IndentOf(lines[j]);
+                if (indent < entryIndent || (indent == entryIndent && lines[j].TrimStart().StartsWith("- ")))
+                    return j;
+            }
+
+            return end;
+        }
+
+        /// <summary>
+        /// Leading-indentation width of a line, counting each space or tab as one unit. Unity always indents its YAML
+        /// with spaces, but the <c>"- rid:"</c> / <c>"type:"</c> indent regexes capture leading whitespace with
+        /// <c>\s*</c> (which counts tabs too). Counting tabs here keeps this measure aligned with those regexes: a
+        /// tab-indented line would otherwise read as indent 0 here while a regex sees it as N, and
+        /// <see cref="FindEntryEnd"/> would mis-bound the entry. Alignment, not visual tab width, is what matters —
+        /// both measures count one unit per character.
+        /// </summary>
+        public static int IndentOf(string line)
+        {
+            var count = 0;
+            while (count < line.Length && (line[count] == ' ' || line[count] == '\t')) count++;
+            return count;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYaml.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYaml.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6d77b54a8bd4fd2aa6e71758aad6835

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
@@ -181,8 +181,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
     internal static class SerializeReferenceYamlEditor
     {
-        // "--- !u!114 &11400000" — object document header carrying the local file id as its YAML anchor.
-        private static readonly Regex DocumentHeader = new(@"^--- !u!\d+ &(\d+)", RegexOptions.Compiled);
+        // The object document header ("--- !u!114 &11400000") and the RefIds-block lookup are single-sourced in
+        // SerializeReferenceYaml so this repair flow and the graph scanner read Unity's RefIds shape identically.
+        private static Regex DocumentHeader => SerializeReferenceYaml.DocumentHeader;
 
         // "--- !u!114 &11400000" — a MonoBehaviour document header (class id 114), the only kind that carries m_Script
         // and serialized user fields, so the scene required-field scan iterates these alone.
@@ -215,7 +216,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 for (var i = 0; i < lines.Length; i++)
                 {
                     var match = DocumentHeader.Match(lines[i]);
-                    if (match.Success && long.TryParse(match.Groups[1].Value, out var fileId))
+                    if (match.Success && long.TryParse(match.Groups["id"].Value, out var fileId))
                         headers.Add((fileId, i));
                 }
 
@@ -763,20 +764,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return false;
         }
 
-        // The exclusive end line of a RefIds entry that begins at headerIndex: the entry runs until the next list item at
-        // its own indent, or until the block dedents out of it (blank lines are spanned). Shared by the entry removers.
-        private static int FindEntryEnd(string[] lines, int headerIndex, int end, int entryIndent)
-        {
-            for (var j = headerIndex + 1; j < end; j++)
-            {
-                if (lines[j].Trim().Length == 0) continue;
-                var indent = IndentOf(lines[j]);
-                if (indent < entryIndent || (indent == entryIndent && lines[j].TrimStart().StartsWith("- ")))
-                    return j;
-            }
-
-            return end;
-        }
+        // The exclusive end line of a RefIds entry that begins at headerIndex (see SerializeReferenceYaml.FindEntryEnd).
+        private static int FindEntryEnd(string[] lines, int headerIndex, int end, int entryIndent) =>
+            SerializeReferenceYaml.FindEntryEnd(lines, headerIndex, end, entryIndent);
 
         // The indent of the RefIds list's entry headers: the first "- rid:" line under RefIds. Entries sit at this
         // shallowest dash indent; nested reference pointers inside their data blocks are deeper. -1 when the block is empty.
@@ -1066,17 +1056,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return false;
         }
 
-        // Leading-indentation width of a line, counting each space or tab as one unit. Unity always indents its YAML
-        // with spaces, but the "- rid:" / "type:" indent regexes capture leading whitespace with \s* (which counts
-        // tabs too). Counting tabs here keeps this measure aligned with those regexes: a tab-indented line would
-        // otherwise read as indent 0 here while a regex sees it as N, and FindEntryEnd would mis-bound the entry.
-        // Alignment, not visual tab width, is what matters — both measures count one unit per character.
-        private static int IndentOf(string line)
-        {
-            var count = 0;
-            while (count < line.Length && (line[count] == ' ' || line[count] == '\t')) count++;
-            return count;
-        }
+        // Leading-indentation width of a line, counting each space or tab as one unit (see SerializeReferenceYaml.IndentOf).
+        private static int IndentOf(string line) => SerializeReferenceYaml.IndentOf(line);
 
         // A line whose leading indentation is spaces only — Unity's invariant for serialized YAML. Returns false when
         // the indent begins with a tab or any other whitespace, the case where IndentOf and the "- rid:" \s* regexes
@@ -1174,20 +1155,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
         }
 
-        // Parses the inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping, honouring single-quoted values
-        // (Unity quotes generic class names such as 'Modifier`1[[…]]').
-        private static bool TryParseInlineType(string body, out ManagedTypeName type)
-        {
-            type = default;
-
-            var match = Regex.Match(body,
-                @"class:\s*(?:'(?<class>(?:[^']|'')*)'|(?<class>[^,}]*?))\s*,\s*ns:\s*(?<ns>[^,}]*?)\s*,\s*asm:\s*(?<asm>[^,}]*?)\s*$");
-            if (!match.Success) return false;
-
-            var className = match.Groups["class"].Value.Replace("''", "'");
-            type = new ManagedTypeName(match.Groups["asm"].Value, match.Groups["ns"].Value, className);
-            return !type.IsEmpty;
-        }
+        // Parses the inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping (see SerializeReferenceYaml.TryParseInlineType).
+        private static bool TryParseInlineType(string body, out ManagedTypeName type) =>
+            SerializeReferenceYaml.TryParseInlineType(body, out type);
 
         // Returns the [start, end) line range of the document whose anchor equals fileId. Falls back to the single
         // document of a one-object asset (the common ScriptableObject case) when the anchor cannot be matched.
@@ -1212,7 +1182,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     break;
                 }
 
-                if (long.TryParse(match.Groups[1].Value, out var anchor) && anchor == fileId)
+                if (long.TryParse(match.Groups["id"].Value, out var anchor) && anchor == fileId)
                     start = i;
             }
 
@@ -1221,16 +1191,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return (-1, -1);
         }
 
-        // Index of the "RefIds:" key line within [start, end), or -1 when the document has no managed references.
-        private static int FindRefIdsStart(string[] lines, int start, int end)
-        {
-            var refIds = new Regex(@"^\s*RefIds:\s*$");
-            for (var i = start; i < end; i++)
-                if (refIds.IsMatch(lines[i]))
-                    return i;
-
-            return -1;
-        }
+        // Index of the "RefIds:" key line within [start, end) (see SerializeReferenceYaml.FindRefIdsStart).
+        private static int FindRefIdsStart(string[] lines, int start, int end) =>
+            SerializeReferenceYaml.FindRefIdsStart(lines, start, end);
 
         /// <summary>
         /// Reads the top-level serialized field names recorded for the managed reference <paramref name="rid"/> within


### PR DESCRIPTION
## Summary

- Extract the duplicated YAML-scan primitives shared by the graph scanner and the repair flow into one new `internal static SerializeReferenceYaml` helper: the `--- !u!N &id` document-header regex, the `RefIds:` block lookup, the inline `class/ns/asm` type grammar plus its `TryParseInlineType`, `IndentOf` and `FindEntryEnd`.
- `SerializeReferenceGraphScanner` and `SerializeReferenceYamlEditor` now both call the shared primitives, so the graph window and the missing-reference repair flow can no longer silently disagree about Unity's RefIds shape (quoting, indentation, sentinel handling).

## Notes for review

- The shared `IndentOf` counts tabs as well as spaces (matching the editor's existing implementation and both readers' `\s*` indent regexes). The scanner's old copy counted spaces only; since Unity always emits space-indented YAML this is behavior-neutral on real assets and removes a latent inconsistency with the scanner's own regexes.
- The shared `DocumentHeader` regex uses named groups (`class`/`id`); the editor's `FindMissingReferences` / `FindDocumentRange` were updated from `Groups[1]` to `Groups["id"]` to keep reading the file-id anchor (not the class id).
- `FindEntryEnd` is unified on the `headerIndex` signature; the scanner's single call site was adjusted from passing `i + 1` to `i` accordingly (same scanned range).
- The editor keeps thin private forwarders (`IndentOf`/`FindEntryEnd`/`FindRefIdsStart`/`TryParseInlineType`) delegating to the shared helper, so its many internal call sites stay untouched while the implementation is single-sourced.

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448945053
