### PR TITLE
Centralize managed-type display name on ManagedTypeName

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/BreakageReport.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/BreakageReport.cs
@@ -33,7 +33,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             TopSuggestion = topSuggestion;
         }
 
-        public string TypeName => StoredType.Class;
+        public string TypeName => StoredType.DisplayName;
     }
 
     /// <summary>The set of managed references that became missing since the last scan, grouped count metadata included.</summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceGraphScanner.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceGraphScanner.cs
@@ -31,19 +31,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             string.IsNullOrEmpty(StoredType.Class) ? $"rid {Rid}" : StoredType.Class;
 
         /// <summary>Full <c>Namespace.Class, Assembly</c> identity, for the row tooltip.</summary>
-        public string FullName
-        {
-            get
-            {
-                if (StoredType.IsEmpty) return string.Empty;
-
-                var name = string.IsNullOrEmpty(StoredType.Namespace)
-                    ? StoredType.Class
-                    : $"{StoredType.Namespace}.{StoredType.Class}";
-
-                return string.IsNullOrEmpty(StoredType.Assembly) ? name : $"{name}, {StoredType.Assembly}";
-            }
-        }
+        public string FullName => StoredType.FullName;
     }
 
     /// <summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
@@ -392,12 +392,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// Human-readable <c>Namespace.Class</c> of this property's missing type, for the dropdown caption and the
         /// warning message, or an empty string when the property is not a recognised missing reference.
         /// </summary>
-        public static string GetMissingTypeDisplayName(SerializedProperty property)
-        {
-            var name = GetMissingTypeName(property);
-            if (name.IsEmpty) return string.Empty;
-            return string.IsNullOrEmpty(name.Namespace) ? name.Class : $"{name.Namespace}.{name.Class}";
-        }
+        public static string GetMissingTypeDisplayName(SerializedProperty property) =>
+            GetMissingTypeName(property).DisplayName;
 
         /// <summary>
         /// Computes the best <b>Smart Fix</b> repair suggestion for this property's missing managed reference: the

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceYamlEditor.cs
@@ -32,6 +32,34 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             string.IsNullOrEmpty(Assembly) && string.IsNullOrEmpty(Namespace) && string.IsNullOrEmpty(Class);
 
         /// <summary>
+        /// Human-readable <c>Namespace.Class</c> identity (the class alone when there is no namespace), or an empty
+        /// string when this is the empty type. The single source of truth for the missing-type caption shown in the
+        /// repair dialog, the project audit list and the graph header, so nested (<c>Outer/Inner</c>) or generic
+        /// class-name display fixes land in one place.
+        /// </summary>
+        public string DisplayName
+        {
+            get
+            {
+                if (IsEmpty) return string.Empty;
+                return string.IsNullOrEmpty(Namespace) ? Class : $"{Namespace}.{Class}";
+            }
+        }
+
+        /// <summary>
+        /// Full <c>Namespace.Class, Assembly</c> identity built on top of <see cref="DisplayName"/>, for tooltips that
+        /// need the assembly too. Empty for the empty type.
+        /// </summary>
+        public string FullName
+        {
+            get
+            {
+                if (IsEmpty) return string.Empty;
+                return string.IsNullOrEmpty(Assembly) ? DisplayName : $"{DisplayName}, {Assembly}";
+            }
+        }
+
+        /// <summary>
         /// Builds the YAML type identity for a resolved <see cref="Type"/>, including the
         /// <c>Name`N[[arg, asm],…]</c> shape Unity uses for closed generics.
         /// </summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
@@ -996,9 +996,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             public int FileCount => _files.Count;
 
-            public string DisplayName => string.IsNullOrEmpty(StoredType.Namespace)
-                ? StoredType.Class
-                : $"{StoredType.Namespace}.{StoredType.Class}";
+            public string DisplayName => StoredType.DisplayName;
 
             public void Add(string assetPath, MissingReferenceEntry entry)
             {


### PR DESCRIPTION
## Summary

- Add `DisplayName` (`Namespace.Class`) and `FullName` (`Namespace.Class, Assembly`) members to `ManagedTypeName`, making it the single source of truth for the missing-type display string.
- Route the four hand-formatted copies through them: `ProjectGroup.DisplayName`, `SerializeReferenceHelpers.GetMissingTypeDisplayName`, `ReferenceGraphNode.FullName`, and `BreakageEntry.TypeName`.
- Future nested (`Outer/Inner`) or generic class-name display fixes now land in one place instead of four.

## Notes for review

- `BreakageEntry.TypeName` previously returned `StoredType.Class` (class only); it now returns `DisplayName` (`Namespace.Class`). The property has no current consumers, so this only aligns it with the centralized display string — no observable UI change.
- `DisplayName`/`FullName` preserve the prior per-site behavior: empty string for the empty type, class-only when there is no namespace, and the `, Assembly` suffix only on `FullName` (graph tooltip).

## Linked issues

Refs #49 - addresses review finding https://github.com/VPDPersonal/Aspid.FastTools/pull/49#discussion_r3448945096
