### PR TITLE
Extract YAML asset-editing engine into an internal assembly

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dacaf7afcfc54fc2ad76fb2533213aa4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2a422d094104109a79a6e91ff366e4b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c5f8fb106fc47c8b045fc20a9bb6a76
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/Aspid.FastTools.Unity.Editor.Yaml.Tests.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/Aspid.FastTools.Unity.Editor.Yaml.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Aspid.FastTools.Unity.Editor.Yaml.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Aspid.FastTools.Unity.Editor.Yaml"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/Aspid.FastTools.Unity.Editor.Yaml.Tests.asmdef.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/Aspid.FastTools.Unity.Editor.Yaml.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76947bb0ef7e41bea90f2e7ce45112db
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorHardeningTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorHardeningTests.cs
@@ -1,0 +1,166 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Hardening coverage for the destructive write paths of <see cref="SerializeReferenceYamlEditor"/>: a file that is
+    /// not a Unity-serialized YAML asset (no <c>%TAG !u!</c> directive) or whose target entry uses unexpected (tab /
+    /// mixed) indentation must never be rewritten. The line-scanning editor relies on Unity's space-only indentation
+    /// invariant; outside it the <c>IndentOf</c> measure and the <c>"- rid:"</c> <c>\s*</c> regex can disagree on where
+    /// an entry ends, so the writers bail (no-op) rather than risk a mis-bounded, non-undoable edit.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorHardeningTests
+    {
+        // The single object-document file id shared by the fixtures below.
+        private const long FileId = 11400000L;
+        private const long Rid = 1001L;
+
+        // A RefIds-shaped document that carries a Unity object header (so the document is locatable) but LACKS the
+        // "%YAML 1.1" / "%TAG !u! …" directive preamble Unity always writes. Without the sniff every writer below would
+        // find rid 1001 and rewrite it — so a successful no-op here proves the %TAG guard, not a missing target.
+        private const string MissingDirectivePreamble =
+@"--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}
+  m_Name: NotAUnityAsset
+  _weapon:
+    rid: 1001
+  references:
+    version: 2
+    RefIds:
+    - rid: 1001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 10
+";
+
+        // A genuine Unity asset (full %YAML / %TAG preamble, so it passes the sniff) whose RefIds entry is TAB-indented.
+        // Built with explicit \t/\n so the indentation is unambiguous in source. The "- rid:" \s* regex still matches the
+        // tab-indented header, so the writers reach the bounding step — where the space-only-indent guard must stop them.
+        private const string TabIndentedUnityAsset =
+            "%YAML 1.1\n" +
+            "%TAG !u! tag:unity3d.com,2011:\n" +
+            "--- !u!114 &11400000\n" +
+            "MonoBehaviour:\n" +
+            "\tm_ObjectHideFlags: 0\n" +
+            "\tm_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}\n" +
+            "\tm_Name: TabIndentedAsset\n" +
+            "\t_weapon:\n" +
+            "\t\trid: 1001\n" +
+            "\treferences:\n" +
+            "\t\tversion: 2\n" +
+            "\t\tRefIds:\n" +
+            "\t\t- rid: 1001\n" +
+            "\t\t  type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}\n" +
+            "\t\t  data:\n" +
+            "\t\t\t_damage: 10\n";
+
+        private static readonly ManagedTypeName SomeType = new ManagedTypeName(
+            "Aspid.FastTools.Samples.SerializeReferences",
+            "Aspid.FastTools.Samples.SerializeReferences",
+            "Shotgun");
+
+        // ---- %TAG !u! sniff: a non-Unity YAML file is never rewritten -------------------------------------------------
+
+        [Test]
+        public void TryComputeRewrite_MissingDirectivePreamble_ReturnsFalse()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryComputeRewrite(path, FileId, Rid, SomeType, out var edit),
+                    "A file without Unity's %TAG directive must not even be offered as a rewrite candidate.");
+                Assert.IsFalse(edit.IsValid, "No edit should be produced for a non-Unity file.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRewriteType_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRewriteType(path, FileId, Rid, SomeType));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused rewrite must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRemoveEntry_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRemoveEntry(path, FileId, Rid));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused remove must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_MissingDirectivePreamble_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(MissingDirectivePreamble);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(path, FileId, Rid));
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        // ---- indent bail: a tab-indented entry block is never destructively rewritten ---------------------------------
+
+        [Test]
+        public void TryRemoveEntry_TabIndentedEntry_BailsBeforeWrite_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(TabIndentedUnityAsset);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRemoveEntry(path, FileId, Rid),
+                    "A tab-indented entry can be mis-bounded — the remover must bail rather than write.");
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused remove must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_TabIndentedEntry_BailsBeforeWrite_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(TabIndentedUnityAsset);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(path, FileId, Rid),
+                    "A tab-indented entry block can be mis-bounded — the nuller must bail before writing.");
+                Assert.AreEqual(before, File.ReadAllText(path), "A refused null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        // ---- positive control: the guards do NOT regress a well-formed, space-indented Unity asset --------------------
+
+        [Test]
+        public void WellFormedUnityAsset_PassesGuards_RemoveEntrySucceeds()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryRemoveEntry(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid),
+                    "A canonical Unity asset (%TAG present, space-indented) must still be editable after hardening.");
+                StringAssert.DoesNotContain("Shotgun", File.ReadAllText(path));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorHardeningTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorHardeningTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbedf8e601524a36ba3a342f900b23d1

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorNullReferenceTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorNullReferenceTests.cs
@@ -1,0 +1,191 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="SerializeReferenceYamlEditor.TryNullReference"/> — the most surgery-heavy, non-undoable
+    /// write path: it nulls every pointer to a rid (to <c>-2</c>), removes the now-orphaned <c>RefIds</c> entry, and
+    /// inserts Unity's shared null-sentinel entry exactly once when a null pointer was introduced. Also covers the
+    /// companion <see cref="SerializeReferenceYamlEditor.CountPointersTo"/>, whose count the clear-confirmation dialog
+    /// names so an aliased reference doesn't silently null sibling slots. These tests pin that contract against temp
+    /// files so a refactor cannot silently change null-vs-real-rid semantics or drift the dialog count off the rewrite.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorNullReferenceTests
+    {
+        // The empty type identity Unity writes for the null-sentinel RefIds entry — unique to the sentinel, so its
+        // occurrence count is the number of sentinels in the file.
+        private const string NullSentinelType = "type: {class: , ns: , asm: }";
+
+        [Test]
+        public void TryNullReference_ListElement_NullsPointer_RemovesEntry_AddsSentinel()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+
+                var after = File.ReadAllText(path);
+
+                // The broken entry (type + data) is gone, and exactly one null sentinel was inserted.
+                StringAssert.DoesNotContain("GhostPistol", after);
+                Assert.AreEqual(1, CountOccurrences(after, NullSentinelType),
+                    "Nulling a reference must insert the shared null sentinel exactly once.");
+
+                // Sibling references are untouched.
+                StringAssert.Contains("Railgun", after);
+                StringAssert.Contains("Shotgun", after);
+
+                // The reader now sees the nulled slot as the null id (-2).
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var rid));
+                Assert.AreEqual(-2, rid);
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_SecondNull_ReusesSentinel_DoesNotAddAnother()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid)); // creates the sentinel
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid));     // must reuse it
+
+                var after = File.ReadAllText(path);
+                Assert.AreEqual(1, CountOccurrences(after, NullSentinelType),
+                    "The null sentinel is a shared singleton — a second null must not add another.");
+                StringAssert.DoesNotContain("GhostPistol", after);
+                StringAssert.DoesNotContain("Shotgun", after);
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_UnknownRid_ReturnsFalse_LeavesFileUnchanged()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                var before = File.ReadAllText(path);
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, 987654));
+                Assert.AreEqual(before, File.ReadAllText(path), "A no-op null must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryNullReference_AliasedRid_NullsEverySharedSlot_LeavesSiblingIntact()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // The missing rid is aliased across _primaryWeapon and _sidearms[0]; clearing it must null both.
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_primaryWeapon", out var primary));
+                Assert.AreEqual(-2, primary, "The first aliased slot must read the null id after the clear.");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var sidearm0));
+                Assert.AreEqual(-2, sidearm0, "The second aliased slot must read the null id after the clear.");
+
+                // The singly-pointed sibling that did NOT share the rid keeps its reference.
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[1]", out var sidearm1));
+                Assert.AreEqual(YamlFixtures.ShotgunRid, sidearm1, "A slot that didn't alias the rid must be untouched.");
+
+                var after = File.ReadAllText(path);
+                StringAssert.DoesNotContain("GhostPistol", after);
+                Assert.AreEqual(1, CountOccurrences(after, NullSentinelType),
+                    "Two nulled aliases still share Unity's single null sentinel.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_AliasedRid_CountsEverySharedSlot()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // _primaryWeapon + _sidearms[0] both point at the rid; the RefIds entry header is NOT a pointer.
+                Assert.AreEqual(2, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_SingleSlotMissingRid_ReturnsOne()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                // The missing rid is pointed at by exactly one slot (_sidearms[0]) in this fixture.
+                Assert.AreEqual(1, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_MatchesPointersNulledByTryNullReference()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AliasedMissingTypePrefab);
+            try
+            {
+                // The count the dialog shows must equal the number of "rid: -2" pointers the rewrite introduces, so the
+                // confirmation can never under- or over-state the damage. The fixture starts with no null pointers.
+                var before = File.ReadAllText(path);
+                Assert.AreEqual(0, CountOccurrences(before, "rid: -2"), "Fixture sanity: no null pointers before the clear.");
+
+                var count = SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid);
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryNullReference(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid));
+
+                // The introduced null pointers are the field pointers (the inserted sentinel ENTRY header is "- rid: -2"
+                // at the entry indent, so subtract that one occurrence to compare against the field-pointer count).
+                var after = File.ReadAllText(path);
+                Assert.AreEqual(count, CountOccurrences(after, "rid: -2") - 1,
+                    "CountPointersTo must equal the number of field pointers TryNullReference nulls.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void CountPointersTo_UnknownRid_ReturnsZero()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                Assert.AreEqual(0, SerializeReferenceYamlEditor.CountPointersTo(
+                    path, YamlFixtures.MonoBehaviourFileId, 987654));
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            for (var i = haystack.IndexOf(needle, System.StringComparison.Ordinal);
+                 i >= 0;
+                 i = haystack.IndexOf(needle, i + needle.Length, System.StringComparison.Ordinal))
+            {
+                count++;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorNullReferenceTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorNullReferenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e5ab8e404424099b538960b0900665e

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Edge-case read coverage the happy-path tests miss: the <c>-2</c> null-sentinel contract of
+    /// <see cref="SerializeReferenceYamlEditor.TryReadReferenceId"/>, the single-document anchor fallback and
+    /// multi-document write confinement of the internal <c>FindDocumentRange</c>, and the single-quoted generic
+    /// class round-trip (the risk-register generic case) through the reader.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorReadEdgeTests
+    {
+        [Test]
+        public void TryReadReferenceId_NullSentinelSlots_ReturnMinusTwo()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.EmptyFieldsPrefab);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_onHitEffect", out var top));
+                Assert.AreEqual(-2, top, "A cleared top-level [SerializeReference] field reads as the null id (-2).");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[1]", out var listElement));
+                Assert.AreEqual(-2, listElement, "A null list element reads as the null id (-2).");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.MonoBehaviourFileId, "_primaryWeapon._chargeEffect", out var nested));
+                Assert.AreEqual(-2, nested, "A cleared nested field reads as the null id (-2).");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryReadReferenceId_SingleDocAsset_FallsBackWhenFileIdDoesNotMatch()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.AllUnassignedAsset);
+            try
+            {
+                // A fileId matching no anchor still resolves in a single-object asset (the ScriptableObject case).
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(path, fileId: 0, "_weapon", out var rid));
+                Assert.AreEqual(-2, rid);
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRewriteType_MultiDocAsset_WrongFileId_NoOp()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+            try
+            {
+                var before = File.ReadAllText(path);
+                var newType = new ManagedTypeName("Asm", "Ns", "Pistol");
+
+                // A fileId matching neither document in a multi-object asset must not rewrite anything.
+                Assert.IsFalse(SerializeReferenceYamlEditor.TryRewriteType(
+                    path, fileId: 123456789, YamlFixtures.GhostPistolRid, newType));
+                Assert.AreEqual(before, File.ReadAllText(path),
+                    "A rewrite against an absent document must leave the file byte-identical.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryReadReferenceId_ListOfStructElement_ResolvesNestedRid()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.ListOfStructAsset);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.ListOfStructFileId, "_slots.Array.data[0]._weapon", out var first));
+                Assert.AreEqual(3001, first, "First List<struct> element's nested managed reference must resolve.");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.ListOfStructFileId, "_slots.Array.data[1]._weapon", out var second));
+                Assert.AreEqual(3002, second, "Second List<struct> element's nested managed reference must resolve.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryReadStoredType_QuotedGenericType_ParsesClassIntact()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.QuotedGenericAsset);
+            try
+            {
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadStoredType(
+                    path, YamlFixtures.QuotedGenericFileId, "_modifier", out var rid, out var type));
+                Assert.AreEqual(YamlFixtures.QuotedGenericRid, rid);
+                Assert.AreEqual(YamlFixtures.QuotedGenericClass, type.Class,
+                    "The single-quoted generic class identity must round-trip un-quoted.");
+                Assert.AreEqual("Aspid.FastTools.Samples.SerializeReferences", type.Namespace);
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb9b063eb7b74be283dbba7cd7f5f67b

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorRewriteTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorRewriteTests.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Round-trip and confinement coverage for <see cref="SerializeReferenceYamlEditor.TryRewriteType"/> — the highest
+    /// risk write path. Asserts the rewrite re-points the correct rid and touches exactly one line, so the regression
+    /// guard locks in that no other YAML is disturbed.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorRewriteTests
+    {
+        private string _path;
+
+        [SetUp]
+        public void SetUp() => _path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+
+        [TearDown]
+        public void TearDown() => YamlFixtures.Delete(_path);
+
+        [Test]
+        public void TryRewriteType_RepointsRid_AndChangesExactlyOneLine()
+        {
+            var before = File.ReadAllLines(_path);
+            var newType = new ManagedTypeName(
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Pistol");
+
+            var rewritten = SerializeReferenceYamlEditor.TryRewriteType(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType);
+            Assert.IsTrue(rewritten, "Rewrite of a present rid must succeed.");
+
+            var after = File.ReadAllLines(_path);
+            Assert.AreEqual(before.Length, after.Length, "A type rewrite must not add or remove lines.");
+
+            var changed = Enumerable.Range(0, before.Length).Where(i => before[i] != after[i]).ToArray();
+            Assert.AreEqual(1, changed.Length, "Exactly one line (the type mapping) should change.");
+
+            var line = after[changed[0]];
+            StringAssert.Contains("class: Pistol", line);
+            StringAssert.Contains("type:", line);
+            StringAssert.Contains("GhostPistol", before[changed[0]]);
+        }
+
+        [Test]
+        public void TryRewriteType_RoundTrips_ReadBackReportsNewType()
+        {
+            var newType = new ManagedTypeName(
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Pistol");
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryRewriteType(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType));
+
+            // Reading back also exercises the probe cache being invalidated by the writer (TryRewriteType clears it).
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadStoredType(
+                _path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var rid, out var type));
+            Assert.AreEqual(YamlFixtures.GhostPistolRid, rid);
+            Assert.AreEqual("Pistol", type.Class);
+        }
+
+        [Test]
+        public void TryRewriteType_UnknownRid_ReturnsFalse_AndLeavesFileUnchanged()
+        {
+            var before = File.ReadAllText(_path);
+            var newType = new ManagedTypeName("Asm", "Ns", "Pistol");
+
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryRewriteType(
+                _path, YamlFixtures.MonoBehaviourFileId, 999999, newType));
+            Assert.AreEqual(before, File.ReadAllText(_path), "A no-op rewrite must leave the file byte-identical.");
+        }
+
+        [Test]
+        public void TryRemoveEntry_RemovesOnlyTheTargetEntry()
+        {
+            var beforeLines = File.ReadAllLines(_path).Length;
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryRemoveEntry(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid));
+
+            var after = File.ReadAllText(_path);
+
+            // The Shotgun entry (type line + its data) is gone...
+            StringAssert.DoesNotContain("Shotgun", after);
+            StringAssert.DoesNotContain("_pellets", after);
+            StringAssert.DoesNotContain("_spreadAngle", after);
+
+            // ...every other RefIds entry is intact...
+            StringAssert.Contains("Railgun", after);
+            StringAssert.Contains("GhostPistol", after);
+            StringAssert.Contains("FreezeEffect", after);
+            StringAssert.Contains("BurnEffect", after);
+
+            // ...and exactly the entry's five lines were removed.
+            Assert.AreEqual(beforeLines - 5, File.ReadAllLines(_path).Length);
+        }
+
+        [Test]
+        public void TryRemoveEntry_UnknownRid_ReturnsFalse_AndLeavesFileUnchanged()
+        {
+            var before = File.ReadAllText(_path);
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryRemoveEntry(_path, YamlFixtures.MonoBehaviourFileId, 424242));
+            Assert.AreEqual(before, File.ReadAllText(_path), "A no-op remove must leave the file byte-identical.");
+        }
+
+        [Test]
+        public void TryComputeRewrite_PreviewEqualsApplied()
+        {
+            var newType = new ManagedTypeName(
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Aspid.FastTools.Samples.SerializeReferences",
+                "Pistol");
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryComputeRewrite(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType, out var edit));
+            StringAssert.Contains("GhostPistol", edit.OldLine);
+            StringAssert.Contains("class: Pistol", edit.NewLine);
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryRewriteType(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType));
+
+            // The preview promised edit.NewLine at edit.LineNumber — the applied file must match exactly.
+            var after = File.ReadAllLines(_path);
+            Assert.AreEqual(edit.NewLine, after[edit.LineNumber], "Applied line must equal the previewed NewLine.");
+        }
+
+        [Test]
+        public void TryRewriteType_PreservesLfLineEndings()
+        {
+            // Unity writes its YAML with LF on every platform; a one-line rewrite must not introduce CR.
+            var lf = YamlFixtures.MissingTypePrefab.Replace("\r\n", "\n");
+            var path = YamlFixtures.WriteTemp(lf);
+            try
+            {
+                var newType = new ManagedTypeName(
+                    "Aspid.FastTools.Samples.SerializeReferences",
+                    "Aspid.FastTools.Samples.SerializeReferences",
+                    "Pistol");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryRewriteType(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType));
+
+                StringAssert.DoesNotContain("\r", File.ReadAllText(path),
+                    "An LF asset must stay LF after a rewrite (no CRLF churn).");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
+        public void TryRewriteType_PreservesCrlfLineEndings()
+        {
+            // A CRLF asset must keep CRLF — the writer must not collapse it to Environment.NewLine (LF on the dev box).
+            var crlf = YamlFixtures.MissingTypePrefab.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            var path = YamlFixtures.WriteTemp(crlf);
+            try
+            {
+                var newType = new ManagedTypeName(
+                    "Aspid.FastTools.Samples.SerializeReferences",
+                    "Aspid.FastTools.Samples.SerializeReferences",
+                    "Pistol");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryRewriteType(
+                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, newType));
+
+                var raw = File.ReadAllText(path);
+                Assert.IsTrue(raw.Contains("\r\n"), "A CRLF asset must keep CRLF after a rewrite.");
+                Assert.IsFalse(raw.Replace("\r\n", "").Contains("\n"),
+                    "Every newline in a CRLF file must remain CRLF (no lone LF introduced).");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorRewriteTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorRewriteTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1728f7079fa1248e6aabf3b6f206848d

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorTests.cs
@@ -1,0 +1,112 @@
+using System;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Read-side coverage for the YAML engine: missing-type discovery, propertyPath -> rid resolution (top-level,
+    /// list-element and nested managed chains), stored-type reading, and field-name parsing. All tests drive the public
+    /// static methods on the internal <see cref="SerializeReferenceYamlEditor"/> against temp files — no asset import,
+    /// no SerializedObject — so they exercise the parser in isolation.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlEditorTests
+    {
+        private string _path;
+
+        // A stored type is "resolvable" unless its class name starts with "Ghost" — the fixture's deliberately-missing
+        // GhostPistol. This keeps the test independent of which types actually load in the test domain.
+        private static bool Resolves(ManagedTypeName type) =>
+            !type.Class.StartsWith("Ghost", StringComparison.Ordinal);
+
+        [SetUp]
+        public void SetUp() => _path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
+
+        [TearDown]
+        public void TearDown() => YamlFixtures.Delete(_path);
+
+        [Test]
+        public void FindMissingReferences_ReportsOnlyUnresolvableEntry()
+        {
+            var missing = SerializeReferenceYamlEditor.FindMissingReferences(_path, Resolves);
+
+            Assert.AreEqual(1, missing.Count, "Only GhostPistol should be reported as missing.");
+            Assert.AreEqual(YamlFixtures.GhostPistolRid, missing[0].Rid);
+            Assert.AreEqual(YamlFixtures.MonoBehaviourFileId, missing[0].FileId);
+            Assert.AreEqual("GhostPistol", missing[0].StoredType.Class);
+        }
+
+        [Test]
+        public void FindMissingReferences_AllResolvable_ReturnsEmpty()
+        {
+            var missing = SerializeReferenceYamlEditor.FindMissingReferences(_path, _ => true);
+            Assert.AreEqual(0, missing.Count);
+        }
+
+        [Test]
+        public void TryReadReferenceId_SingleField_ResolvesRid()
+        {
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                _path, YamlFixtures.MonoBehaviourFileId, "_primaryWeapon", out var rid));
+            Assert.AreEqual(YamlFixtures.RailgunRid, rid);
+        }
+
+        [Test]
+        public void TryReadReferenceId_ListElement_ResolvesRid()
+        {
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                _path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var first));
+            Assert.AreEqual(YamlFixtures.GhostPistolRid, first);
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                _path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[1]", out var second));
+            Assert.AreEqual(YamlFixtures.ShotgunRid, second);
+        }
+
+        [Test]
+        public void TryReadReferenceId_NestedManagedChain_ResolvesRid()
+        {
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                _path, YamlFixtures.MonoBehaviourFileId, "_primaryWeapon._chargeEffect", out var rid));
+            Assert.AreEqual(YamlFixtures.BurnEffectRid, rid);
+        }
+
+        [Test]
+        public void TryReadReferenceId_UnknownPath_ReturnsFalse()
+        {
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryReadReferenceId(
+                _path, YamlFixtures.MonoBehaviourFileId, "_doesNotExist", out _));
+        }
+
+        [Test]
+        public void TryReadStoredType_ReturnsRidAndType()
+        {
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryReadStoredType(
+                _path, YamlFixtures.MonoBehaviourFileId, "_sidearms.Array.data[0]", out var rid, out var type));
+            Assert.AreEqual(YamlFixtures.GhostPistolRid, rid);
+            Assert.AreEqual("GhostPistol", type.Class);
+            Assert.AreEqual("Aspid.FastTools.Samples.SerializeReferences", type.Namespace);
+        }
+
+        [Test]
+        public void GetReferenceFieldNames_ReturnsTopLevelDataKeys()
+        {
+            var pistolFields = SerializeReferenceYamlEditor.GetReferenceFieldNames(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid);
+            CollectionAssert.AreEquivalent(new[] { "_damage", "_magazineSize" }, pistolFields);
+
+            // Railgun's data has a nested managed ref (_chargeEffect -> rid); only the top-level keys are reported.
+            var railgunFields = SerializeReferenceYamlEditor.GetReferenceFieldNames(
+                _path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.RailgunRid);
+            CollectionAssert.AreEquivalent(new[] { "_chargeTime", "_chargeEffect" }, railgunFields);
+        }
+
+        [Test]
+        public void ParseTopLevelFieldNames_SkipsIndentedAndSequenceLines()
+        {
+            var names = SerializeReferenceYamlEditor.ParseTopLevelFieldNames(
+                "_damage: 15\n_magazineSize: 12\n  _nested: 3\n- 7\n");
+            CollectionAssert.AreEqual(new[] { "_damage", "_magazineSize" }, names);
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlEditorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92ba11e56ef0e4d7699bad728d7e24e6

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlProbeCacheTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlProbeCacheTests.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Behavioural coverage for <see cref="SerializeReferenceYamlProbeCache"/>: it serves a cached copy while the file's
+    /// last-write-time is unchanged, re-reads when the timestamp moves, and drops everything on <see cref="ClearCache"/>.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializeReferenceYamlProbeCacheTests
+    {
+        private string _path;
+
+        [SetUp]
+        public void SetUp()
+        {
+            SerializeReferenceYamlProbeCache.ClearCache();
+            _path = YamlFixtures.WriteTemp("alpha\n");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SerializeReferenceYamlProbeCache.ClearCache();
+            YamlFixtures.Delete(_path);
+        }
+
+        [Test]
+        public void ReadAllLines_ReturnsFileContent()
+        {
+            var lines = SerializeReferenceYamlProbeCache.ReadAllLines(_path);
+            Assert.AreEqual(1, lines.Length);
+            Assert.AreEqual("alpha", lines[0]);
+        }
+
+        [Test]
+        public void ReadAllLines_SameTimestamp_ServesCachedContent()
+        {
+            // Pin an explicit write time on BOTH the warm read and the post-edit read. Capturing the OS-written stamp
+            // instead would be unreliable: Mono's SetLastWriteTimeUtc can store a lower-precision value than
+            // GetLastWriteTimeUtc returned, so the cached key would never match. Setting the same value twice is
+            // deterministic regardless of the platform's timestamp resolution.
+            var pinned = new System.DateTime(2020, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+
+            File.SetLastWriteTimeUtc(_path, pinned);
+            var first = SerializeReferenceYamlProbeCache.ReadAllLines(_path);
+            Assert.AreEqual("alpha", first[0]);
+
+            // Change the content but restore the same pinned write time: the cache key is (path, write-time), so the
+            // stale copy is served by design until the timestamp moves or the cache is cleared.
+            File.WriteAllText(_path, "beta\n");
+            File.SetLastWriteTimeUtc(_path, pinned);
+
+            var cached = SerializeReferenceYamlProbeCache.ReadAllLines(_path);
+            Assert.AreEqual("alpha", cached[0], "Unchanged write-time must serve the cached copy.");
+        }
+
+        [Test]
+        public void ReadAllLines_NewerTimestamp_ReReads()
+        {
+            SerializeReferenceYamlProbeCache.ReadAllLines(_path); // warm
+
+            File.WriteAllText(_path, "beta\n");
+            File.SetLastWriteTimeUtc(_path, File.GetLastWriteTimeUtc(_path).AddSeconds(5));
+
+            var reread = SerializeReferenceYamlProbeCache.ReadAllLines(_path);
+            Assert.AreEqual("beta", reread[0], "A newer write-time must bust the cache.");
+        }
+
+        [Test]
+        public void ClearCache_ForcesReRead()
+        {
+            var stamp = File.GetLastWriteTimeUtc(_path);
+            SerializeReferenceYamlProbeCache.ReadAllLines(_path); // warm
+
+            File.WriteAllText(_path, "beta\n");
+            File.SetLastWriteTimeUtc(_path, stamp); // keep timestamp so only ClearCache can bust it
+
+            SerializeReferenceYamlProbeCache.ClearCache();
+
+            var reread = SerializeReferenceYamlProbeCache.ReadAllLines(_path);
+            Assert.AreEqual("beta", reread[0], "ClearCache must force a fresh read.");
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlProbeCacheTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/SerializeReferenceYamlProbeCacheTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cab17ef1b22d64962adf79a1e370e2ce

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs
@@ -1,0 +1,429 @@
+using System;
+using System.IO;
+
+namespace Aspid.FastTools.SerializeReferences.Editors.Tests
+{
+    /// <summary>
+    /// Real-format Unity YAML fixtures and temp-file helpers for the <see cref="SerializeReferenceYamlEditor"/> tests.
+    /// The prefab text is copied verbatim from the <c>Samples~/SerializeReferences</c> demo so the parser is exercised
+    /// against Unity's exact indentation, <c>references:</c>/<c>RefIds:</c>/<c>data:</c> layout and field-pointer shapes
+    /// (single managed ref, list of managed refs, nested managed ref). The strings are written at column 0 inside the
+    /// verbatim literal — their leading whitespace IS the YAML indentation and must not be reflowed.
+    /// </summary>
+    internal static class YamlFixtures
+    {
+        // The MonoBehaviour document's local file id (its "--- !u!114 &<fileID>" anchor).
+        public const long MonoBehaviourFileId = 6500000000000000003L;
+
+        // RefIds present in the fixture, by stored type.
+        public const long RailgunRid = 1001;      // _primaryWeapon         (resolvable)
+        public const long GhostPistolRid = 1002;  // _sidearms[0]           (MISSING — class starts with "Ghost")
+        public const long ShotgunRid = 1003;      // _sidearms[1]           (resolvable)
+        public const long FreezeEffectRid = 1004; // _onHitEffect           (resolvable)
+        public const long BurnEffectRid = 1005;   // _primaryWeapon._chargeEffect (resolvable, nested in Railgun)
+
+        // A MonoBehaviour with one missing managed reference (GhostPistol), a single ref field, a list of refs, and a
+        // nested ref (Railgun -> _chargeEffect -> BurnEffect).
+        public const string MissingTypePrefab =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6500000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6500000000000000002}
+  - component: {fileID: 6500000000000000003}
+  m_Layer: 0
+  m_Name: LoadoutMissingType
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &6500000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6500000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Aspid.FastTools.Samples.SerializeReferences::Aspid.FastTools.Samples.SerializeReferences.Loadout
+  _primaryWeapon:
+    rid: 1001
+  _sidearms:
+  - rid: 1002
+  - rid: 1003
+  _onHitEffect:
+    rid: 1004
+  references:
+    version: 2
+    RefIds:
+    - rid: 1001
+      type: {class: Railgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _chargeTime: 2
+        _chargeEffect:
+          rid: 1005
+    - rid: 1002
+      type: {class: GhostPistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 15
+        _magazineSize: 12
+    - rid: 1003
+      type: {class: Shotgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _pellets: 8
+        _spreadAngle: 25
+    - rid: 1004
+      type: {class: FreezeEffect, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _duration: 2.5
+        _slowPercent: 40
+    - rid: 1005
+      type: {class: BurnEffect, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _duration: 3
+        _damagePerSecond: 5
+";
+
+        // A MonoBehaviour where the MISSING reference (GhostPistol, rid 1002) is ALIASED across two slots — both
+        // _primaryWeapon and _sidearms[0] point at the one rid — alongside a singly-pointed sibling (Shotgun, rid 1003,
+        // _sidearms[1]) and a healthy effect (rid 1004). Pins the all-pointer-null behaviour and the pointer-count helper:
+        // clearing rid 1002 must null BOTH aliased slots (count 2) while leaving the Shotgun slot intact. Same indentation
+        // and layout as MissingTypePrefab; reuses MonoBehaviourFileId / GhostPistolRid / ShotgunRid.
+        public const string AliasedMissingTypePrefab =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6500000000000000001
+GameObject:
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6500000000000000003}
+  m_Name: LoadoutAliasedMissing
+--- !u!114 &6500000000000000003
+MonoBehaviour:
+  m_GameObject: {fileID: 6500000000000000001}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name:
+  _primaryWeapon:
+    rid: 1002
+  _sidearms:
+  - rid: 1002
+  - rid: 1003
+  _onHitEffect:
+    rid: 1004
+  references:
+    version: 2
+    RefIds:
+    - rid: 1002
+      type: {class: GhostPistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 15
+        _magazineSize: 12
+    - rid: 1003
+      type: {class: Shotgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _pellets: 8
+        _spreadAngle: 25
+    - rid: 1004
+      type: {class: FreezeEffect, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _duration: 2.5
+        _slowPercent: 40
+";
+
+        // RefIds present in the empty-fields fixture below.
+        public const long EmptyRailgunRid = 1001;  // _primaryWeapon  (resolvable, holds a cleared nested _chargeEffect)
+        public const long EmptyPistolRid = 1002;   // _sidearms[0]    (resolvable)
+
+        // A MonoBehaviour exercising unassigned (null-sentinel) [SerializeReference] slots written by Unity as
+        // "rid: -2" (ManagedReferenceUtility.RefIdNull): a cleared top-level field (_onHitEffect), a null list element
+        // (_sidearms[1]) and a cleared nested field (Railgun._chargeEffect), alongside assigned references so the
+        // RefIds block still exists. Same indentation / layout Unity emits, copied from the demo shape.
+        public const string EmptyFieldsPrefab =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6500000000000000001
+GameObject:
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6500000000000000003}
+  m_Name: LoadoutEmptyFields
+--- !u!114 &6500000000000000003
+MonoBehaviour:
+  m_GameObject: {fileID: 6500000000000000001}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name:
+  _primaryWeapon:
+    rid: 1001
+  _sidearms:
+  - rid: 1002
+  - rid: -2
+  _onHitEffect:
+    rid: -2
+  references:
+    version: 2
+    RefIds:
+    - rid: 1001
+      type: {class: Railgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _chargeTime: 2
+        _chargeEffect:
+          rid: -2
+    - rid: 1002
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 15
+        _magazineSize: 12
+";
+
+        // A ScriptableObject whose only [SerializeReference] fields are all unassigned: a single null field (_weapon)
+        // and an empty list (_alternates), so the RefIds block holds nothing but Unity's shared null sentinel
+        // ("- rid: -2"). It carries zero real nodes yet one field pointer, so the scanner must still surface it (one
+        // "<None>" root) rather than dropping the whole document as "no managed references". Mirrors the demo's
+        // BrokenWeaponPreset after its broken reference is cleared to <None>.
+        public const string AllUnassignedAsset =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}
+  m_Name: BrokenWeaponPreset
+  _weapon:
+    rid: -2
+  _alternates: []
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+";
+
+        // The single-object document file id, the rid and the exact (un-quoted) class identity of the generic fixture below.
+        public const long QuotedGenericFileId = 11400000L;
+        public const long QuotedGenericRid = 2001L;
+        public const string QuotedGenericClass = "Modifier`1[[System.Single, mscorlib]]";
+
+        // A ScriptableObject whose single [SerializeReference] field stores a CLOSED GENERIC type, written by Unity with
+        // a single-quoted `Name`N[[arg, asm]]` class identity (the form Unity emits for generics like Foo`1[[...]]).
+        // Exercises the quoted-class parse branch of the reader — the generic round-trip the risk register calls out.
+        public const string QuotedGenericAsset =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7874533c7294db1b8aa77e7d4102c9f, type: 3}
+  m_Name: GenericModifierAsset
+  _modifier:
+    rid: 2001
+  references:
+    version: 2
+    RefIds:
+    - rid: 2001
+      type: {class: 'Modifier`1[[System.Single, mscorlib]]', ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _value: 1.5
+";
+
+        // The single-object document file id of the List-of-struct fixture below.
+        public const long ListOfStructFileId = 7700000000000000003L;
+
+        // A MonoBehaviour with a List of a PLAIN serializable struct (a "slot") that itself holds a [SerializeReference]
+        // managed reference. Exercises ResolveSequenceItem's container branch — descending a sequence-of-mappings element
+        // into a nested managed reference (`_slots.Array.data[i]._weapon`), the List<Struct> path the reader advertises.
+        public const string ListOfStructAsset =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &7700000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name: SlottedLoadoutAsset
+  _slots:
+  - _weapon:
+      rid: 3001
+    label: primary
+  - _weapon:
+      rid: 3002
+    label: backup
+  references:
+    version: 2
+    RefIds:
+    - rid: 3001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 10
+        _magazineSize: 7
+    - rid: 3002
+      type: {class: Shotgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _pellets: 6
+        _spreadAngle: 20
+";
+
+        // Script guids for the scene required-field fixtures below. The first maps (via the test's injected resolver) to
+        // RequiredTestObject's required fields; the second is an "unknown" script the resolver returns no fields for.
+        public const string RequiredSceneScriptGuid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        public const string UnknownScriptGuid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        // MonoBehaviour document file ids in the scene fixtures (the "--- !u!114 &<fileID>" anchors).
+        public const long RequiredSceneMonoFileId = 101L;
+        public const long RequiredSceneOtherFileId = 201L;
+
+        // A scene with one MonoBehaviour whose required managed reference (requiredRef) and required string field
+        // (requiredString) are both left unset — the managed reference at Unity's null id (-2), the string empty. Exact
+        // .unity layout: a GameObject document followed by its MonoBehaviour, m_Script carrying the script guid.
+        public const string RequiredSceneUnset =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+  requiredRef:
+    rid: -2
+  requiredString:
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+";
+
+        // The same scene with both required fields set: the managed reference points at a real rid, the string holds an
+        // assembly-qualified name. No violations expected.
+        public const string RequiredSceneSet =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+  requiredRef:
+    rid: 5001
+  requiredString: 'Aspid.FastTools.Samples.SerializeReferences.Pistol, Aspid.FastTools.Samples.SerializeReferences'
+  references:
+    version: 2
+    RefIds:
+    - rid: 5001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 5
+";
+
+        // The same scene where BOTH required keys are ABSENT from the MonoBehaviour — the shape Unity writes when the
+        // object was last saved before the [TypeSelector(Required = true)] fields were added (also stripped / nested-prefab
+        // docs). Reserializing fills the defaults; until then the gate must NOT flag the missing keys, so no violations
+        // are expected. Same .unity layout as RequiredSceneUnset, minus the requiredRef / requiredString lines.
+        public const string RequiredSceneAbsentKeys =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+";
+
+        // A two-MonoBehaviour scene: the first (guid aaaa…, fileID 101) has requiredRef SET but requiredString EMPTY
+        // (one violation); the second (guid bbbb…, fileID 201) leaves both unset but its script is unknown to the
+        // resolver, so it must be skipped entirely. Proves per-document resolution and the unknown-script skip.
+        public const string RequiredSceneMixedUnknownScript =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+  requiredRef:
+    rid: 5001
+  requiredString:
+  references:
+    version: 2
+    RefIds:
+    - rid: 5001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 5
+--- !u!1 &200
+GameObject:
+  m_Component:
+  - component: {fileID: 201}
+  m_Name: Other
+--- !u!114 &201
+MonoBehaviour:
+  m_GameObject: {fileID: 200}
+  m_Script: {fileID: 11500000, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 3}
+  m_Name:
+  requiredRef:
+    rid: -2
+  requiredString:
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+";
+
+        /// <summary>Writes <paramref name="yaml"/> to a fresh temp file (never under <c>Assets/</c>) and returns its path.</summary>
+        public static string WriteTemp(string yaml)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "aspid-sr-tests");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".prefab");
+            File.WriteAllText(path, yaml);
+            return path;
+        }
+
+        /// <summary>Deletes a temp fixture file if present.</summary>
+        public static void Delete(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort cleanup; a leftover temp file is harmless.
+            }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs
@@ -10,7 +10,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
     /// (single managed ref, list of managed refs, nested managed ref). The strings are written at column 0 inside the
     /// verbatim literal — their leading whitespace IS the YAML indentation and must not be reflowed.
     /// </summary>
-    internal static class YamlFixtures
+    // Public (not internal) because the SerializeReference editor test assembly references this test assembly to reuse
+    // these fixtures in its SR+YAML integration tests, which live outside Aspid.FastTools.Unity.Editor.Yaml.Tests.
+    public static class YamlFixtures
     {
         // The MonoBehaviour document's local file id (its "--- !u!114 &<fileID>" anchor).
         public const long MonoBehaviourFileId = 6500000000000000003L;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Yaml/YamlFixtures.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4430a873bfd5648d583dca1b1c02a532

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 429e20dd7b624fe7beb2595b63e6b16a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/Aspid.FastTools.Unity.Editor.Yaml.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/Aspid.FastTools.Unity.Editor.Yaml.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Aspid.FastTools.Unity.Editor.Yaml",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/Aspid.FastTools.Unity.Editor.Yaml.asmdef.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/Aspid.FastTools.Unity.Editor.Yaml.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b34d17e1e1bc481f8e9e6c697fb9f9ba
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// The YAML asset-editing engine ships as internal infrastructure: its types are an implementation detail shared with
+// the SerializeReference editor feature (currently the sole consumer) and exercised by its own test assembly. Kept
+// internal — rather than promoted to a public API surface — until a second consumer justifies it (see PLAN.md item 8).
+[assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor")]
+[assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor.Yaml.Tests")]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs
@@ -5,3 +5,6 @@ using System.Runtime.CompilerServices;
 // internal — rather than promoted to a public API surface — until a second consumer justifies it (see PLAN.md item 8).
 [assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor")]
 [assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor.Yaml.Tests")]
+// The SerializeReference editor test assembly keeps a couple of integration tests that couple SR-specific code to this
+// engine (FindUnsetRequiredFields, ManagedTypeName); they reach the same internals as the production consumer above.
+[assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor.Tests")]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c5edebc830a4b6e87b10075287af86d

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// The shared, parser-free YAML-scan toolkit for Unity's managed-reference (<c>RefIds</c>) serialization, used by
+    /// both the repair flow (<see cref="SerializeReferenceYamlEditor"/>) and the graph window
+    /// (<see cref="SerializeReferenceGraphScanner"/>). Single-sourcing these primitives keeps the two readers in
+    /// agreement about Unity's RefIds shape — quoting, indentation and the document/inline-type grammar — so a fix to
+    /// one cannot silently diverge from the other.
+    /// </summary>
+    internal static class SerializeReferenceYaml
+    {
+        // "--- !u!114 &11400000" — object document header carrying the local file id as its YAML anchor and the
+        // class id ("!u!114") used as a best-effort fallback label when the live type name is unavailable.
+        public static readonly Regex DocumentHeader = new(@"^--- !u!(?<class>\d+) &(?<id>\d+)", RegexOptions.Compiled);
+
+        // "  RefIds:" — the managed-reference id list of an object document.
+        public static readonly Regex RefIdsKey = new(@"^\s*RefIds:\s*$", RegexOptions.Compiled);
+
+        // The inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping, honouring the single-quoted class names
+        // Unity writes for closed generics (e.g. 'Modifier`1[[…]]').
+        public static readonly Regex InlineType = new(
+            @"class:\s*(?:'(?<class>(?:[^']|'')*)'|(?<class>[^,}]*?))\s*,\s*ns:\s*(?<ns>[^,}]*?)\s*,\s*asm:\s*(?<asm>[^,}]*?)\s*$",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses the inline <c>class: X, ns: Y, asm: Z</c> body of a <c>RefIds</c> type mapping into a
+        /// <see cref="ManagedTypeName"/>, honouring the single-quoted class names Unity writes for closed generics
+        /// (e.g. <c>'Modifier`1[[…]]'</c>). Returns <see langword="false"/> for a malformed or empty type body.
+        /// </summary>
+        public static bool TryParseInlineType(string body, out ManagedTypeName type)
+        {
+            type = default;
+
+            var match = InlineType.Match(body);
+            if (!match.Success) return false;
+
+            var className = match.Groups["class"].Value.Replace("''", "'");
+            type = new ManagedTypeName(match.Groups["asm"].Value, match.Groups["ns"].Value, className);
+            return !type.IsEmpty;
+        }
+
+        /// <summary>
+        /// Index of the <c>RefIds:</c> key line within <c>[start, end)</c>, or <c>-1</c> when the document has no
+        /// managed references.
+        /// </summary>
+        public static int FindRefIdsStart(string[] lines, int start, int end)
+        {
+            for (var i = start; i < end; i++)
+                if (RefIdsKey.IsMatch(lines[i]))
+                    return i;
+
+            return -1;
+        }
+
+        /// <summary>
+        /// The exclusive end line of a <c>RefIds</c> entry that begins at <paramref name="headerIndex"/>: the entry runs
+        /// until the next list item at its own indent, or until the block dedents out of it (blank lines are spanned).
+        /// </summary>
+        public static int FindEntryEnd(string[] lines, int headerIndex, int end, int entryIndent)
+        {
+            for (var j = headerIndex + 1; j < end; j++)
+            {
+                if (lines[j].Trim().Length == 0) continue;
+
+                var indent = IndentOf(lines[j]);
+                if (indent < entryIndent || (indent == entryIndent && lines[j].TrimStart().StartsWith("- ")))
+                    return j;
+            }
+
+            return end;
+        }
+
+        /// <summary>
+        /// Leading-indentation width of a line, counting each space or tab as one unit. Unity always indents its YAML
+        /// with spaces, but the <c>"- rid:"</c> / <c>"type:"</c> indent regexes capture leading whitespace with
+        /// <c>\s*</c> (which counts tabs too). Counting tabs here keeps this measure aligned with those regexes: a
+        /// tab-indented line would otherwise read as indent 0 here while a regex sees it as N, and
+        /// <see cref="FindEntryEnd"/> would mis-bound the entry. Alignment, not visual tab width, is what matters —
+        /// both measures count one unit per character.
+        /// </summary>
+        public static int IndentOf(string line)
+        {
+            var count = 0;
+            while (count < line.Length && (line[count] == ' ' || line[count] == '\t')) count++;
+            return count;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 // ReSharper disable once CheckNamespace
@@ -86,6 +87,27 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var count = 0;
             while (count < line.Length && (line[count] == ' ' || line[count] == '\t')) count++;
             return count;
+        }
+
+        // The project-asset extensions whose Unity-YAML text can host managed references (RefIds). Single source of
+        // truth: SerializeReference's own scanners layer settings-based folder exclusion on top of this set.
+        public static readonly string[] ScanExtensions = { ".prefab", ".asset", ".unity" };
+
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="path"/> is a project asset (under <c>Assets/</c>) whose
+        /// extension can host managed references. This is the engine-level, settings-agnostic candidate test; callers
+        /// that must honour the user's excluded-folder settings combine it with their own exclusion check.
+        /// </summary>
+        public static bool IsCandidateAssetPath(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/", StringComparison.Ordinal))
+                return false;
+
+            foreach (var extension in ScanExtensions)
+                if (path.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+            return false;
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYaml.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6d77b54a8bd4fd2aa6e71758aad6835

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlEditor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlEditor.cs
@@ -1,0 +1,1352 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// Identity of a managed-reference type as it is stored in Unity's serialized YAML
+    /// (<c>type: {class: …, ns: …, asm: …}</c>). Used to repair a reference whose type went missing by
+    /// rewriting that line directly, since Unity's serialization API cannot reassign a missing type.
+    /// </summary>
+    internal readonly struct ManagedTypeName
+    {
+        public readonly string Assembly;
+        public readonly string Namespace;
+        public readonly string Class;
+
+        public ManagedTypeName(string assembly, string @namespace, string className)
+        {
+            Assembly = assembly ?? string.Empty;
+            Namespace = @namespace ?? string.Empty;
+            Class = className ?? string.Empty;
+        }
+
+        public bool IsEmpty =>
+            string.IsNullOrEmpty(Assembly) && string.IsNullOrEmpty(Namespace) && string.IsNullOrEmpty(Class);
+
+        /// <summary>
+        /// Human-readable <c>Namespace.Class</c> identity (the class alone when there is no namespace), or an empty
+        /// string when this is the empty type. The single source of truth for the missing-type caption shown in the
+        /// repair dialog, the project audit list and the graph header, so nested (<c>Outer/Inner</c>) or generic
+        /// class-name display fixes land in one place.
+        /// </summary>
+        public string DisplayName
+        {
+            get
+            {
+                if (IsEmpty) return string.Empty;
+                return string.IsNullOrEmpty(Namespace) ? Class : $"{Namespace}.{Class}";
+            }
+        }
+
+        /// <summary>
+        /// Full <c>Namespace.Class, Assembly</c> identity built on top of <see cref="DisplayName"/>, for tooltips that
+        /// need the assembly too. Empty for the empty type.
+        /// </summary>
+        public string FullName
+        {
+            get
+            {
+                if (IsEmpty) return string.Empty;
+                return string.IsNullOrEmpty(Assembly) ? DisplayName : $"{DisplayName}, {Assembly}";
+            }
+        }
+
+        /// <summary>
+        /// Builds the YAML type identity for a resolved <see cref="Type"/>, including the
+        /// <c>Name`N[[arg, asm],…]</c> shape Unity uses for closed generics.
+        /// </summary>
+        public static ManagedTypeName FromType(Type type)
+        {
+            if (type is null) return default;
+
+            var root = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+            // Unity stores a nested type's class identity with its declaring types joined by '/' (e.g. Outer/Inner);
+            // reflection's Type.Name is only the leaf, so prefix the declaring chain here — the mirror of the read side's
+            // '/'->'+' mapping in SerializeReferenceHelpers.StoredTypeResolves. Without this, repairing a reference to a
+            // nested type would write `class: Inner`, which Unity cannot resolve (it re-breaks the reference).
+            return new ManagedTypeName(root.Assembly.GetName().Name, root.Namespace, NestedPrefix(type) + BuildClassName(type));
+        }
+
+        // The "Outer/" (or "Outer/Middle/") prefix Unity prepends to a nested type's class identity; empty for a
+        // top-level type. Walks the declaring-type chain from the outermost inward.
+        private static string NestedPrefix(Type type)
+        {
+            if (type.DeclaringType is null) return string.Empty;
+
+            var prefix = string.Empty;
+            for (var declaring = type.DeclaringType; declaring is not null; declaring = declaring.DeclaringType)
+                prefix = declaring.Name + "/" + prefix;
+
+            return prefix;
+        }
+
+        private static string BuildClassName(Type type)
+        {
+            if (!type.IsGenericType) return type.Name;
+
+            var definition = type.GetGenericTypeDefinition();
+            var arguments = type.GetGenericArguments().Select(BuildGenericArgumentName);
+            return $"{definition.Name}[[{string.Join("],[", arguments)}]]";
+        }
+
+        private static string BuildGenericArgumentName(Type type) =>
+            $"{BuildFullClassName(type)}, {type.Assembly.GetName().Name}";
+
+        private static string BuildFullClassName(Type type)
+        {
+            if (!type.IsGenericType) return type.FullName;
+
+            var definition = type.GetGenericTypeDefinition();
+            var prefix = string.IsNullOrEmpty(definition.Namespace) ? string.Empty : $"{definition.Namespace}.";
+            return $"{prefix}{BuildClassName(type)}";
+        }
+
+        /// <summary>Renders the inline YAML mapping Unity writes for a managed-reference type entry.</summary>
+        public string ToYamlType() =>
+            $"{{class: {EscapeInline(Class)}, ns: {EscapeInline(Namespace)}, asm: {EscapeInline(Assembly)}}}";
+
+        // A flow-scalar containing any of , [ ] { } would break the inline mapping, so single-quote it
+        // (doubling embedded quotes) exactly as Unity does for generic class names like Foo`1[[…]].
+        private static string EscapeInline(string value)
+        {
+            if (string.IsNullOrEmpty(value) || value.IndexOfAny(YamlReservedChars) < 0)
+                return value ?? string.Empty;
+
+            return $"'{value.Replace("'", "''")}'";
+        }
+
+        private static readonly char[] YamlReservedChars = { ',', '[', ']', '{', '}' };
+    }
+
+    /// <summary>
+    /// Rewrites the stored type of a managed reference directly in an asset's YAML text. This is the only way
+    /// to re-point a <c>[SerializeReference]</c> whose type can no longer be loaded (renamed / moved / deleted),
+    /// because Unity drops missing references to <see langword="null"/> through the serialization API and never
+    /// exposes them for reassignment. Parser-free: the document and the target <c>RefIds</c> entry are located by
+    /// line scanning, and only the inline <c>{ … }</c> on the entry's <c>type:</c> line is replaced.
+    /// </summary>
+    /// <summary>
+    /// A single orphaned managed-reference entry found in an asset's YAML: the document it lives in
+    /// (<see cref="FileId"/>), its <c>RefIds</c> id and the stored (unresolvable) type. Surfaced by the
+    /// asset-level repair tool, which finds every such entry regardless of nesting depth or child object.
+    /// </summary>
+    internal readonly struct MissingReferenceEntry
+    {
+        public readonly long FileId;
+        public readonly long Rid;
+        public readonly ManagedTypeName StoredType;
+
+        public MissingReferenceEntry(long fileId, long rid, ManagedTypeName storedType)
+        {
+            FileId = fileId;
+            Rid = rid;
+            StoredType = storedType;
+        }
+    }
+
+    /// <summary>A single computed line change for the bulk-fix diff preview: where it lands and the before/after text.</summary>
+    internal readonly struct RewriteEdit
+    {
+        public readonly string AssetPath;
+        public readonly int LineNumber;
+        public readonly string OldLine;
+        public readonly string NewLine;
+
+        public RewriteEdit(string assetPath, int lineNumber, string oldLine, string newLine)
+        {
+            AssetPath = assetPath;
+            LineNumber = lineNumber;
+            OldLine = oldLine;
+            NewLine = newLine;
+        }
+
+        public bool IsValid => LineNumber >= 0 && !string.IsNullOrEmpty(AssetPath);
+    }
+
+    /// <summary>
+    /// A serialized field that opts into the <c>[TypeSelector(Required = true)]</c> check, captured for the pure-YAML
+    /// scene scan: the YAML field key and whether it is a <c>string</c> type field (vs a <c>[SerializeReference]</c>
+    /// managed reference). Produced by reflection in <see cref="SerializeReferenceRequiredGate.GetRequiredFields"/> and
+    /// consumed by <see cref="SerializeReferenceYamlEditor.FindUnsetRequiredFields"/>, which stays reflection-free.
+    /// </summary>
+    internal readonly struct RequiredFieldDescriptor
+    {
+        public readonly string FieldName;
+        public readonly bool IsString;
+
+        public RequiredFieldDescriptor(string fieldName, bool isString)
+        {
+            FieldName = fieldName;
+            IsString = isString;
+        }
+    }
+
+    /// <summary>
+    /// One unset required field found by the pure-YAML scene scan: the owning object document (<see cref="FileId"/>),
+    /// the field's YAML key and — for a managed reference — the null id it read (<c>-2</c>); <c>0</c> for a string field.
+    /// </summary>
+    internal readonly struct RequiredViolationEntry
+    {
+        public readonly long FileId;
+        public readonly string FieldName;
+        public readonly long Rid;
+
+        public RequiredViolationEntry(long fileId, string fieldName, long rid)
+        {
+            FileId = fileId;
+            FieldName = fieldName;
+            Rid = rid;
+        }
+    }
+
+    internal static class SerializeReferenceYamlEditor
+    {
+        // The object document header ("--- !u!114 &11400000") and the RefIds-block lookup are single-sourced in
+        // SerializeReferenceYaml so this repair flow and the graph scanner read Unity's RefIds shape identically.
+        private static Regex DocumentHeader => SerializeReferenceYaml.DocumentHeader;
+
+        // "--- !u!114 &11400000" — a MonoBehaviour document header (class id 114), the only kind that carries m_Script
+        // and serialized user fields, so the scene required-field scan iterates these alone.
+        private static readonly Regex MonoBehaviourHeader = new(@"^--- !u!114 &(\d+)", RegexOptions.Compiled);
+
+        // "  m_Script: {fileID: 11500000, guid: <guid>, type: 3}" — the script reference whose guid maps to the C# type;
+        // its indent is the document's top-level field indent (every direct field of the MonoBehaviour aligns with it).
+        private static readonly Regex ScriptGuidPattern =
+            new(@"^(?<indent>\s*)m_Script:\s*\{.*\bguid:\s*(?<guid>[0-9a-fA-F]+).*\}", RegexOptions.Compiled);
+
+        // "  references:" — the managed-reference block; the object's own serialized fields all precede it.
+        private static readonly Regex ReferencesKey = new(@"^\s*references:\s*$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Scans every object document in the asset and returns each <c>RefIds</c> entry whose stored type fails
+        /// the <paramref name="resolves"/> predicate. Because <c>RefIds</c> is a flat per-object list, this finds
+        /// missing references at any nesting depth and on any child object — without navigating the Inspector.
+        /// </summary>
+        public static List<MissingReferenceEntry> FindMissingReferences(string assetPath, Func<ManagedTypeName, bool> resolves)
+        {
+            var result = new List<MissingReferenceEntry>();
+
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return result;
+
+                var lines = File.ReadAllLines(assetPath);
+
+                var headers = new List<(long fileId, int start)>();
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var match = DocumentHeader.Match(lines[i]);
+                    if (match.Success && long.TryParse(match.Groups["id"].Value, out var fileId))
+                        headers.Add((fileId, i));
+                }
+
+                var ridPattern = new Regex(@"^\s*-\s+rid:\s*(-?\d+)\s*$");
+                var typePattern = new Regex(@"^\s*type:\s*\{(?<body>.*)\}\s*$");
+
+                for (var h = 0; h < headers.Count; h++)
+                {
+                    var (fileId, start) = headers[h];
+                    var end = h + 1 < headers.Count ? headers[h + 1].start : lines.Length;
+
+                    var refIdsStart = FindRefIdsStart(lines, start, end);
+                    if (refIdsStart < 0) continue;
+
+                    for (var i = refIdsStart + 1; i < end; i++)
+                    {
+                        var ridMatch = ridPattern.Match(lines[i]);
+                        if (!ridMatch.Success || !long.TryParse(ridMatch.Groups[1].Value, out var rid)) continue;
+
+                        for (var j = i + 1; j < end && j <= i + 4; j++)
+                        {
+                            var typeMatch = typePattern.Match(lines[j]);
+                            if (!typeMatch.Success) continue;
+
+                            if (TryParseInlineType(typeMatch.Groups["body"].Value, out var type) &&
+                                !type.IsEmpty && !resolves(type))
+                            {
+                                result.Add(new MissingReferenceEntry(fileId, rid, type));
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Best effort — a parse failure simply yields no repair candidates.
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Pure-YAML scan for unset <c>[TypeSelector(Required = true)]</c> fields — the scene-safe counterpart of the
+        /// object-load required check, which cannot read scene objects (<see cref="SerializeReferenceHelpers.IsScene"/>).
+        /// Walks every MonoBehaviour document, resolves its required fields through <paramref name="requiredFieldsForScript"/>
+        /// (keyed by the <c>m_Script</c> guid, so this method stays reflection-free), and reports each top-level required
+        /// field that is <em>present but empty</em>: a managed reference at the null id (<c>-2</c>), or an empty string field.
+        /// A present managed reference (<c>rid &gt;= 0</c>) counts as set even when its type is missing — that mirrors
+        /// <see cref="SerializeReferenceRequiredGate.IsViolation"/>, where a missing type is the missing-type gate's
+        /// concern, not a required violation. A field whose key is <em>absent</em> from the document is NOT a violation:
+        /// Unity omits a serialized field from YAML when the object was last saved before the field was added (and for
+        /// stripped / nested-prefab docs), so flagging it would fail a project that is valid once reopened/reserialized.
+        /// Required fields nested inside serializable containers are not covered here (the field keys are read at the
+        /// document's top level only).
+        /// </summary>
+        public static List<RequiredViolationEntry> FindUnsetRequiredFields(
+            string assetPath, Func<string, IReadOnlyList<RequiredFieldDescriptor>> requiredFieldsForScript)
+        {
+            var result = new List<RequiredViolationEntry>();
+            if (requiredFieldsForScript is null) return result;
+
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return result;
+
+                // One-shot bulk read like FindMissingReferences — bypass the probe cache so large scene files don't evict
+                // the interactive per-property entries (see SerializeReferenceYamlProbeCache remarks).
+                var lines = File.ReadAllLines(assetPath);
+
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var header = MonoBehaviourHeader.Match(lines[i]);
+                    if (!header.Success || !long.TryParse(header.Groups[1].Value, out var fileId)) continue;
+
+                    var docEnd = NextDocumentStart(lines, i + 1);
+                    if (!TryReadScriptGuid(lines, i + 1, docEnd, out var guid, out var fieldIndent)) continue;
+
+                    var required = requiredFieldsForScript(guid);
+                    if (required is null || required.Count == 0) continue;
+
+                    var fieldsEnd = FindFieldsEnd(lines, i + 1, docEnd);
+
+                    foreach (var descriptor in required)
+                    {
+                        // An absent key is not a violation — the field was added after the last save (or this is a
+                        // stripped / nested-prefab doc); reserializing fills its default and the object-load path judges
+                        // it. Only a key that is present but empty is reported here.
+                        if (descriptor.IsString)
+                        {
+                            if (IsStringFieldUnset(lines, i + 1, fieldsEnd, fieldIndent, descriptor.FieldName) == FieldState.PresentUnset)
+                                result.Add(new RequiredViolationEntry(fileId, descriptor.FieldName, 0));
+                        }
+                        else if (IsManagedReferenceUnset(lines, i + 1, fieldsEnd, fieldIndent, descriptor.FieldName, out var rid) == FieldState.PresentUnset)
+                        {
+                            result.Add(new RequiredViolationEntry(fileId, descriptor.FieldName, rid));
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Best effort — a parse failure simply yields no violations (matches FindMissingReferences).
+            }
+
+            return result;
+        }
+
+        // The line index of the next "--- " document separator at or after `from`, or the line count when none follows.
+        private static int NextDocumentStart(string[] lines, int from)
+        {
+            for (var i = from; i < lines.Length; i++)
+                if (lines[i].StartsWith("--- ", StringComparison.Ordinal))
+                    return i;
+
+            return lines.Length;
+        }
+
+        // Reads the m_Script guid (and the document's top-level field indent) within [start, end). False for a stripped
+        // component or any document carrying no script reference.
+        private static bool TryReadScriptGuid(string[] lines, int start, int end, out string guid, out int fieldIndent)
+        {
+            guid = null;
+            fieldIndent = 0;
+
+            for (var i = start; i < end; i++)
+            {
+                var match = ScriptGuidPattern.Match(lines[i]);
+                if (!match.Success) continue;
+
+                guid = match.Groups["guid"].Value;
+                fieldIndent = match.Groups["indent"].Length;
+                return true;
+            }
+
+            return false;
+        }
+
+        // The exclusive end of a MonoBehaviour's own serialized fields: the "references:" line, or the document end when
+        // the object holds no managed references. Confines field lookups so a key inside a RefIds data block is never read.
+        private static int FindFieldsEnd(string[] lines, int start, int end)
+        {
+            for (var i = start; i < end; i++)
+                if (ReferencesKey.IsMatch(lines[i]))
+                    return i;
+
+            return end;
+        }
+
+        // Whether a required field key was found in the document and, if so, whether it carries a value. An absent key is
+        // distinguished from a present-but-empty one so the gate never flags a field Unity simply hasn't written yet
+        // (object saved before the field was added, or a stripped / nested-prefab doc) — that needs a reserialize, not a
+        // build failure.
+        private enum FieldState { Absent, PresentSet, PresentUnset }
+
+        // Classifies the top-level managed-reference field `name`: PresentUnset when its pointer is the null id (-2) or it
+        // carries no rid, PresentSet when a real rid (>= 0) points at a reference, Absent when the key is not in the doc.
+        // `rid` returns the read id (or -2 when present-unset/absent).
+        private static FieldState IsManagedReferenceUnset(string[] lines, int start, int end, int fieldIndent, string name, out long rid)
+        {
+            rid = NullRid;
+            var pattern = new Regex($@"^(?<indent>\s*){Regex.Escape(name)}:\s*(?<inline>.*)$");
+
+            for (var i = start; i < end; i++)
+            {
+                var field = pattern.Match(lines[i]);
+                if (!field.Success || field.Groups["indent"].Length != fieldIndent) continue;
+
+                // Inline pointer (e.g. "_weapon: {rid: 5}") — Unity writes the block form, but tolerate either.
+                var inline = Regex.Match(field.Groups["inline"].Value, @"rid:\s*(-?\d+)");
+                if (inline.Success && long.TryParse(inline.Groups[1].Value, out var inlineRid))
+                {
+                    rid = inlineRid;
+                    return inlineRid == NullRid ? FieldState.PresentUnset : FieldState.PresentSet;
+                }
+
+                // Block form: the rid scalar is the field's first indented child.
+                for (var j = i + 1; j < end; j++)
+                {
+                    if (lines[j].Trim().Length == 0) continue;
+                    if (IndentOf(lines[j]) <= fieldIndent) break; // dedented out of the field without a rid
+
+                    var child = Regex.Match(lines[j].Trim(), @"^rid:\s*(-?\d+)$");
+                    if (child.Success && long.TryParse(child.Groups[1].Value, out var childRid))
+                    {
+                        rid = childRid;
+                        return childRid == NullRid ? FieldState.PresentUnset : FieldState.PresentSet;
+                    }
+
+                    break; // first child is not a rid scalar — not a recognised managed-reference pointer
+                }
+
+                return FieldState.PresentUnset; // field present but no rid — treat as unset
+            }
+
+            return FieldState.Absent; // field absent — not a violation (needs reserialize)
+        }
+
+        // Classifies the top-level string field `name`: PresentUnset when empty or an empty quoted scalar ('' / ""),
+        // PresentSet when it holds a value, Absent when the key is not in the doc.
+        private static FieldState IsStringFieldUnset(string[] lines, int start, int end, int fieldIndent, string name)
+        {
+            var pattern = new Regex($@"^(?<indent>\s*){Regex.Escape(name)}:\s*(?<value>.*)$");
+
+            for (var i = start; i < end; i++)
+            {
+                var field = pattern.Match(lines[i]);
+                if (!field.Success || field.Groups["indent"].Length != fieldIndent) continue;
+
+                var value = field.Groups["value"].Value.Trim();
+                return value.Length == 0 || value == "''" || value == "\"\""
+                    ? FieldState.PresentUnset
+                    : FieldState.PresentSet;
+            }
+
+            return FieldState.Absent; // field absent — not a violation (needs reserialize)
+        }
+
+        /// <summary>
+        /// Replaces the <c>type:</c> mapping of the <c>RefIds</c> entry identified by <paramref name="rid"/> within
+        /// the object document anchored at <paramref name="fileId"/>. Returns <see langword="true"/> when the file
+        /// was rewritten; the caller is responsible for reimporting the asset.
+        /// </summary>
+        public static bool TryRewriteType(string assetPath, long fileId, long rid, ManagedTypeName newType)
+        {
+            // Single scan shared with the diff preview: compute the edit, then apply exactly that line so the preview
+            // and the applied result can never diverge.
+            if (!TryComputeRewrite(assetPath, fileId, rid, newType, out var edit)) return false;
+
+            try
+            {
+                var lines = File.ReadAllLines(assetPath);
+                if (edit.LineNumber < 0 || edit.LineNumber >= lines.Length || lines[edit.LineNumber] != edit.OldLine)
+                    return false; // the file changed since the edit was computed — abort rather than write a stale line
+
+                lines[edit.LineNumber] = edit.NewLine;
+                WritePreservingNewlines(assetPath, lines);
+                // Same-tick writes can leave the modification-time key unchanged, so bust the probe cache explicitly.
+                SerializeReferenceYamlProbeCache.ClearCache();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[TypeSelector] Failed to rewrite managed-reference type in '{assetPath}': {exception}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Writes <paramref name="lines"/> back to <paramref name="assetPath"/> preserving the file's original newline
+        /// style and trailing-newline state. <see cref="File.WriteAllLines(string,IEnumerable{string})"/> would re-emit
+        /// every line with <see cref="Environment.NewLine"/> (CRLF on Windows) — Unity writes its YAML with LF on every
+        /// platform, so that would churn the whole file LF→CRLF for a one-line edit. Sniffing the source newline keeps a
+        /// surgical edit to just the intended line(s).
+        /// </summary>
+        private static void WritePreservingNewlines(string assetPath, IReadOnlyList<string> lines)
+        {
+            var original = File.ReadAllText(assetPath);
+            var newline = DominantNewline(original);
+
+            var builder = new StringBuilder(original.Length);
+            for (var i = 0; i < lines.Count; i++)
+            {
+                builder.Append(lines[i]);
+                if (i < lines.Count - 1) builder.Append(newline);
+            }
+
+            // Re-add the trailing terminator only if the source had one (Unity assets always do).
+            if (original.Length > 0 && original[original.Length - 1] == '\n') builder.Append(newline);
+
+            File.WriteAllText(assetPath, builder.ToString());
+        }
+
+        // The newline to re-emit when rewriting an asset: the style that dominates the source by line count, not "any
+        // CRLF wins". Picking by majority keeps a one-line edit on a mixed- or lone-CR file from flipping every other
+        // line's terminator (a whole-file diff for a one-line change). CRLF wins ties only when it is the strict
+        // majority; otherwise LF — Unity's invariant terminator — is used. Counts CRLF and lone-LF (an LF not preceded
+        // by CR); a lone CR (classic Mac) maps to LF, since this writer only emits "\r\n" or "\n".
+        private static string DominantNewline(string text)
+        {
+            var crlf = 0;
+            var loneLf = 0;
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (text[i] != '\n') continue;
+                if (i > 0 && text[i - 1] == '\r') crlf++;
+                else loneLf++;
+            }
+
+            return crlf > loneLf ? "\r\n" : "\n";
+        }
+
+        /// <summary>
+        /// Computes — without writing — the single line change a <see cref="TryRewriteType"/> would make to re-point the
+        /// <paramref name="rid"/> entry to <paramref name="newType"/>. Drives the bulk-fix diff preview; the rewrite
+        /// applies the returned edit verbatim, so what the preview shows is exactly what is written.
+        /// </summary>
+        public static bool TryComputeRewrite(string assetPath, long fileId, long rid, ManagedTypeName newType, out RewriteEdit edit)
+        {
+            edit = default;
+
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
+
+                var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never offer (or apply) a rewrite on a non-Unity YAML file
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return false;
+
+                // Field pointers ("_sidearms:\n  - rid: 1002") share the "- rid:" shape with RefIds entries, so confine
+                // the search to the RefIds block — the entries are the only ones with a following type:.
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return false;
+
+                var ridPattern = new Regex($@"^\s*-\s+rid:\s*{rid}\s*$");
+                var typePattern = new Regex(@"^(?<indent>\s*type:\s*)\{.*\}\s*$");
+
+                for (var i = refIdsStart; i < end; i++)
+                {
+                    if (!ridPattern.IsMatch(lines[i])) continue;
+
+                    // The type mapping follows the rid line; scan a few lines to tolerate formatting variance.
+                    for (var j = i + 1; j < end && j <= i + 4; j++)
+                    {
+                        var match = typePattern.Match(lines[j]);
+                        if (!match.Success) continue;
+
+                        edit = new RewriteEdit(assetPath, j, lines[j], match.Groups["indent"].Value + newType.ToYamlType());
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                return false;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[TypeSelector] Failed to compute managed-reference rewrite in '{assetPath}': {exception}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes a whole <c>- rid: N</c> entry (its type and data block) from the <c>RefIds</c> list of the document
+        /// anchored at <paramref name="fileId"/>. Used to drop an orphaned managed-reference payload that no field points
+        /// at. Confined to the <c>RefIds</c> block so a same-shaped field pointer is never touched. Returns whether an
+        /// entry was removed. The edit is not undoable — callers confirm first.
+        /// </summary>
+        public static bool TryRemoveEntry(string assetPath, long fileId, long rid)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
+
+                var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never rewrite a non-Unity YAML file
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return false;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return false;
+
+                var ridPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
+
+                for (var i = refIdsStart; i < end; i++)
+                {
+                    var match = ridPattern.Match(lines[i]);
+                    if (!match.Success) continue;
+
+                    // The entry runs until the next list item at its own indent, or until the block dedents out of it —
+                    // the same bounding rule the data-block reader uses.
+                    var entryIndent = match.Groups["indent"].Length;
+                    var entryEnd = FindEntryEnd(lines, i, end, entryIndent);
+
+                    // Unexpected (tab / mixed) indentation in the entry block means IndentOf and the "- rid:" \s* regex
+                    // can disagree on where the block ends — bail rather than write a possibly mis-bounded deletion.
+                    if (!BlockIndentIsTrusted(lines, i, entryEnd)) return false;
+
+                    var remaining = new List<string>(lines.Length - (entryEnd - i));
+                    for (var k = 0; k < i; k++) remaining.Add(lines[k]);
+                    for (var k = entryEnd; k < lines.Length; k++) remaining.Add(lines[k]);
+
+                    WritePreservingNewlines(assetPath, remaining);
+                    SerializeReferenceYamlProbeCache.ClearCache();
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[Aspid FastTools] Failed to remove RefIds entry rid {rid} in '{assetPath}': {exception}");
+                return false;
+            }
+        }
+
+        // The null managed-reference id Unity stores for an unassigned [SerializeReference] field
+        // (UnityEngine.Serialization.ManagedReferenceUtility.RefIdNull).
+        private const long NullRid = -2;
+
+        // The inline type mapping Unity writes for the null sentinel RefIds entry — an empty type identity.
+        private const string NullSentinelType = "type: {class: , ns: , asm: }";
+
+        /// <summary>
+        /// Nulls a managed reference in the document anchored at <paramref name="fileId"/>: every field / array-element
+        /// pointer that holds <paramref name="rid"/> is rewritten to the null id (<c>-2</c>), the now-orphaned
+        /// <c>RefIds</c> entry is removed, and — when a null pointer was introduced — the <c>RefIds</c> null sentinel
+        /// entry (<c>- rid: -2 / type: {class: , ns: , asm: }</c>) is added if absent. This reproduces exactly what Unity
+        /// writes when a <c>[SerializeReference]</c> field is set to <see langword="null"/>: an array element cannot be
+        /// dropped, so it must point at <c>-2</c>, and that pointer is only valid when the sentinel entry exists —
+        /// without it the load errors "serialized array … is missing entry for Refid -2". Removing the broken entry
+        /// clears the object's missing-types flag. Not undoable: the broken payload is discarded. Returns whether the
+        /// file was rewritten.
+        /// </summary>
+        public static bool TryNullReference(string assetPath, long fileId, long rid)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
+
+                var lines = File.ReadAllLines(assetPath);
+                if (!LooksLikeUnityYaml(lines)) return false; // never rewrite a non-Unity YAML file
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return false;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return false;
+
+                // RefIds entry headers sit at the shallowest "- rid:" indent under RefIds; a pointer to the rid lives
+                // anywhere else — a field/array element before "references:" or a nested reference inside another entry's
+                // data block. The header for this rid is removed; every pointer to it becomes the null id.
+                var entryIndent = FindRefIdsEntryIndent(lines, refIdsStart, end);
+                if (entryIndent < 0) return false;
+
+                var headerPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
+                var pointerToken = BuildPointerPattern(rid);
+
+                var headerIndex = -1;
+                var pointerNulled = false;
+
+                for (var i = start; i < end; i++)
+                {
+                    // This rid's own RefIds entry header (a "- rid: N" under RefIds at the entry indent) is removed
+                    // below, not nulled — skip it so it isn't rewritten to the null id.
+                    if (headerIndex < 0 && i > refIdsStart)
+                    {
+                        var header = headerPattern.Match(lines[i]);
+                        if (header.Success && header.Groups["indent"].Length == entryIndent)
+                        {
+                            headerIndex = i;
+                            continue;
+                        }
+                    }
+
+                    // Null every pointer to the rid — a "- rid: N" array element, a "rid: N" scalar field or an inline
+                    // "{rid: N}" — so no dangling pointer survives the entry's removal (which errors on array fields).
+                    // The anchored pattern preserves each pointer's structural prefix/suffix and only rewrites the id.
+                    if (pointerToken.IsMatch(lines[i]))
+                    {
+                        lines[i] = pointerToken.Replace(lines[i], $"${{prefix}}rid: {NullRid}${{suffix}}");
+                        pointerNulled = true;
+                    }
+                }
+
+                // Nothing referenced or stored this rid — leave the file untouched. (When an entry exists but is already
+                // unreferenced this still drops it; when only a dangling pointer remains this still nulls it.)
+                if (headerIndex < 0 && !pointerNulled) return false;
+
+                var blockStart = headerIndex;
+                var blockEnd = headerIndex >= 0 ? FindEntryEnd(lines, headerIndex, end, entryIndent) : -1;
+
+                // The entry block we're about to drop must use Unity's space-only indentation; a tab / mixed prefix can
+                // mis-bound it (IndentOf vs the "- rid:" \s* regex), so bail before this non-undoable rewrite. (Pointer
+                // nulling above is line-local and indent-agnostic, so no write has reached disk yet.)
+                if (headerIndex >= 0 && !BlockIndentIsTrusted(lines, blockStart, blockEnd)) return false;
+
+                // A "- rid: -2" pointer is valid only while the RefIds list carries Unity's null sentinel entry; add it
+                // when we just introduced a null pointer and the document does not already have one (a shared singleton).
+                var needsNullEntry = pointerNulled && !HasNullSentinelEntry(lines, refIdsStart, end, entryIndent);
+                var dash = new string(' ', entryIndent);
+                var typeIndent = new string(' ', entryIndent + 2);
+
+                var result = new List<string>(lines.Length + 2);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    if (headerIndex >= 0 && i >= blockStart && i < blockEnd) continue; // drop the broken entry block
+
+                    result.Add(lines[i]);
+
+                    // Insert the sentinel as the RefIds list's first entry, mirroring where Unity writes it.
+                    if (needsNullEntry && i == refIdsStart)
+                    {
+                        result.Add($"{dash}- rid: {NullRid}");
+                        result.Add($"{typeIndent}{NullSentinelType}");
+                    }
+                }
+
+                WritePreservingNewlines(assetPath, result);
+                SerializeReferenceYamlProbeCache.ClearCache();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[Aspid FastTools] Failed to null managed-reference rid {rid} in '{assetPath}': {exception}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Counts how many field / array-element pointers in the document anchored at <paramref name="fileId"/> hold
+        /// <paramref name="rid"/> — the number of slots a <see cref="TryNullReference"/> would null. A missing reference
+        /// can be aliased across several slots (all sharing one rid); clearing it nulls every one of them, so the confirm
+        /// dialog calls this first to name the count before the irreversible rewrite. The rid's own <c>RefIds</c> entry
+        /// header is excluded (it is the entry, not a pointer to it). Returns <c>0</c> when the document / <c>RefIds</c>
+        /// list / entry indent cannot be located — the same guards <see cref="TryNullReference"/> uses — so a non-positive
+        /// result means "count unknown" and the caller can fall back to unnumbered wording.
+        /// </summary>
+        public static int CountPointersTo(string assetPath, long fileId, long rid)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return 0;
+
+                var lines = File.ReadAllLines(assetPath);
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return 0;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return 0;
+
+                var entryIndent = FindRefIdsEntryIndent(lines, refIdsStart, end);
+                if (entryIndent < 0) return 0;
+
+                var headerPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
+                var pointerToken = BuildPointerPattern(rid);
+
+                var headerSkipped = false;
+                var count = 0;
+
+                for (var i = start; i < end; i++)
+                {
+                    // Skip this rid's own RefIds entry header exactly once (the "- rid: N" at the entry indent under
+                    // RefIds): it is the entry being removed, not a pointer that gets nulled. Mirrors the header skip in
+                    // TryNullReference so the count equals the number of pointers that path would rewrite.
+                    if (!headerSkipped && i > refIdsStart)
+                    {
+                        var header = headerPattern.Match(lines[i]);
+                        if (header.Success && header.Groups["indent"].Length == entryIndent)
+                        {
+                            headerSkipped = true;
+                            continue;
+                        }
+                    }
+
+                    if (pointerToken.IsMatch(lines[i])) count++;
+                }
+
+                return count;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[Aspid FastTools] Failed to count managed-reference pointers to rid {rid} in '{assetPath}': {exception}");
+                return 0;
+            }
+        }
+
+        // An anchored matcher for a real "rid: N" pointer to a specific id — never a bare "rid: N" substring buried in a
+        // string field value (e.g. _note: 'see rid: 5'). Only Unity's three pointer shapes match: a line-anchored
+        // "- rid: N" sequence item, a line-anchored "rid: N" scalar child, or an inline "{rid: N}" mapping. The
+        // structural prefix/suffix (indent + dash, or the surrounding braces) are captured so a null-rewrite can keep
+        // them and replace only the id — mirroring the reader's knownRids validation, which is what keeps its same
+        // "rid:" scan from corrupting unrelated data.
+        private static Regex BuildPointerPattern(long rid) => new(
+            $@"(?<prefix>^\s*(?:-\s+)?)rid:\s*{rid}(?<suffix>\s*$)|(?<prefix>\{{\s*)rid:\s*{rid}(?<suffix>\s*\}})");
+
+        // Whether the RefIds list already carries Unity's null sentinel entry ("- rid: -2"). The sentinel is a shared
+        // singleton — at most one per object — so a second null pointer reuses it rather than adding another.
+        private static bool HasNullSentinelEntry(string[] lines, int refIdsStart, int end, int entryIndent)
+        {
+            var sentinel = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{NullRid}\s*$");
+            for (var i = refIdsStart + 1; i < end; i++)
+            {
+                var match = sentinel.Match(lines[i]);
+                if (match.Success && match.Groups["indent"].Length == entryIndent) return true;
+            }
+
+            return false;
+        }
+
+        // The exclusive end line of a RefIds entry that begins at headerIndex (see SerializeReferenceYaml.FindEntryEnd).
+        private static int FindEntryEnd(string[] lines, int headerIndex, int end, int entryIndent) =>
+            SerializeReferenceYaml.FindEntryEnd(lines, headerIndex, end, entryIndent);
+
+        // The indent of the RefIds list's entry headers: the first "- rid:" line under RefIds. Entries sit at this
+        // shallowest dash indent; nested reference pointers inside their data blocks are deeper. -1 when the block is empty.
+        private static int FindRefIdsEntryIndent(string[] lines, int refIdsStart, int end)
+        {
+            var entry = new Regex(@"^(?<indent>\s*)-\s+rid:\s*-?\d+\s*$");
+            for (var i = refIdsStart + 1; i < end; i++)
+            {
+                var match = entry.Match(lines[i]);
+                if (match.Success) return match.Groups["indent"].Length;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads the managed-reference id (<c>rid</c>) stored at <paramref name="propertyPath"/> within the object
+        /// document anchored at <paramref name="fileId"/>. Needed because Unity reports an invalid id for a property
+        /// whose type is missing — the real id only survives in the YAML. Resolves the path at any depth, walking each
+        /// segment either into a managed reference's <c>RefIds</c> data block (a <c>rid:</c> pointer) or down through a
+        /// plain serializable container (a nested struct/class mapping or a <c>List&lt;T&gt;</c> of them), so paths
+        /// such as <c>_weapon._chargeEffect</c>, <c>_config._weapon</c> and <c>_slots.Array.data[0]._weapon</c> all
+        /// resolve. An unresolvable segment returns <see langword="false"/> so the caller can fall back.
+        /// </summary>
+        public static bool TryReadReferenceId(string assetPath, long fileId, string propertyPath, out long rid)
+        {
+            rid = 0;
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return false;
+
+                var lines = SerializeReferenceYamlProbeCache.ReadAllLines(assetPath);
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return false;
+
+                // Field pointers (and the object's inline serializable data) live before the "references:" block; the
+                // RefIds entries and the nested data each managed reference stores live after it.
+                var fieldsEnd = end;
+                var references = new Regex(@"^\s*references:\s*$");
+                for (var i = start; i < end; i++)
+                    if (references.IsMatch(lines[i])) { fieldsEnd = i; break; }
+
+                var segments = ParsePathSegments(propertyPath.Replace(".Array.data", string.Empty));
+                if (segments is null) return false;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+
+                // Cursor over the lines the current segment is resolved against. It starts on the object's own field
+                // block, then for each segment either descends into a plain serializable container (a nested mapping
+                // or sequence item, by indent) or jumps into a managed reference's RefIds data block (by rid).
+                var cursorStart = start;
+                var cursorEnd = fieldsEnd;
+                var cursorIndent = -1; // the object's top-level fields: match at any indent
+
+                for (var s = 0; s < segments.Count; s++)
+                {
+                    var kind = ResolveSegment(lines, cursorStart, cursorEnd, cursorIndent, segments[s],
+                        out var segmentRid, out var valueStart, out var valueEnd, out var valueIndent);
+
+                    if (kind == SegmentKind.NotFound) return false;
+
+                    if (s == segments.Count - 1)
+                    {
+                        if (kind != SegmentKind.Reference) return false;
+                        rid = segmentRid;
+                        return true;
+                    }
+
+                    if (kind == SegmentKind.Reference)
+                    {
+                        if (refIdsStart < 0) return false;
+                        if (!TryGetDataBlockRange(lines, refIdsStart, end, segmentRid, out cursorStart, out cursorEnd, out cursorIndent))
+                            return false;
+                    }
+                    else
+                    {
+                        cursorStart = valueStart;
+                        cursorEnd = valueEnd;
+                        cursorIndent = valueIndent;
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        // A single managed-reference path segment: a field name with an optional sequence index ("_alternates[3]").
+        private readonly struct PathSegment
+        {
+            public readonly string Name;
+            public readonly bool HasIndex;
+            public readonly int Index;
+
+            public PathSegment(string name, bool hasIndex, int index)
+            {
+                Name = name;
+                HasIndex = hasIndex;
+                Index = index;
+            }
+        }
+
+        // Splits a normalised property path ("_weapon._chargeEffect", "_alternates[3]") into ordered segments.
+        private static List<PathSegment> ParsePathSegments(string path)
+        {
+            var result = new List<PathSegment>();
+            foreach (var raw in path.Split('.'))
+            {
+                var match = Regex.Match(raw, @"^(?<name>[^\[\]\.]+)(\[(?<idx>\d+)\])?$");
+                if (!match.Success) return null;
+
+                var hasIndex = match.Groups["idx"].Success;
+                result.Add(new PathSegment(match.Groups["name"].Value, hasIndex, hasIndex ? int.Parse(match.Groups["idx"].Value) : -1));
+            }
+
+            return result.Count > 0 ? result : null;
+        }
+
+        // What a resolved segment points at: a managed reference (a "rid:" pointer) or a plain serializable container
+        // (a nested mapping/sequence to descend into), or nothing.
+        private enum SegmentKind { NotFound, Reference, Container }
+
+        // Resolves one path segment within [rangeStart, rangeEnd). For a plain field the value is either a managed
+        // reference (its sole child is a "rid:" scalar) or a container to descend into; for an indexed field it is the
+        // segment.Index-th sequence item, itself either a "- rid:" reference or a "- field:" mapping container. When
+        // requiredIndent is non-negative only a field at exactly that effective indent matches (a leading "- " counts
+        // toward the indent so a sequence-of-mappings item's fields align with their dashless siblings), which keeps
+        // resolution on a block's direct children instead of descending into a deeper object that reuses the name.
+        private static SegmentKind ResolveSegment(string[] lines, int rangeStart, int rangeEnd, int requiredIndent,
+            PathSegment segment, out long rid, out int valueStart, out int valueEnd, out int valueIndent)
+        {
+            rid = 0;
+            valueStart = valueEnd = valueIndent = -1;
+
+            var fieldPattern = new Regex($@"^(?<lead>\s*)(?<dash>-\s+)?{Regex.Escape(segment.Name)}:\s*(?<inline>.*)$");
+
+            for (var i = rangeStart; i < rangeEnd; i++)
+            {
+                var field = fieldPattern.Match(lines[i]);
+                if (!field.Success) continue;
+
+                var fieldIndent = field.Groups["lead"].Length + field.Groups["dash"].Length;
+                if (requiredIndent >= 0 && fieldIndent != requiredIndent) continue;
+
+                return segment.HasIndex
+                    ? ResolveSequenceItem(lines, i + 1, rangeEnd, segment.Index, out rid, out valueStart, out valueEnd, out valueIndent)
+                    : ClassifyValue(lines, i, fieldIndent, field.Groups["inline"].Value, rangeEnd, out rid, out valueStart, out valueEnd, out valueIndent);
+            }
+
+            return SegmentKind.NotFound;
+        }
+
+        // Classifies the value of a plain (non-indexed) field at line i with effective indent fieldIndent: a managed
+        // reference when the value is a lone "rid:" scalar (inline or as the only following child), otherwise the
+        // indented mapping block to descend into.
+        private static SegmentKind ClassifyValue(string[] lines, int i, int fieldIndent, string inline, int rangeEnd,
+            out long rid, out int valueStart, out int valueEnd, out int valueIndent)
+        {
+            rid = 0;
+            valueStart = valueEnd = valueIndent = -1;
+
+            var inlineMatch = Regex.Match(inline, @"rid:\s*(-?\d+)");
+            if (inlineMatch.Success)
+                return long.TryParse(inlineMatch.Groups[1].Value, out rid) ? SegmentKind.Reference : SegmentKind.NotFound;
+
+            // Gather the indented value block (lines more indented than the field).
+            var blockStart = i + 1;
+            var blockEnd = rangeEnd;
+            var firstChild = -1;
+            for (var j = blockStart; j < rangeEnd; j++)
+            {
+                if (lines[j].Trim().Length == 0) continue;
+                if (IndentOf(lines[j]) <= fieldIndent) { blockEnd = j; break; }
+                if (firstChild < 0) firstChild = j;
+            }
+
+            if (firstChild < 0) return SegmentKind.NotFound; // scalar/empty field: no managed reference here
+
+            // A managed reference's value block is exactly a "rid:" scalar; anything else is a container.
+            var ridScalar = Regex.Match(lines[firstChild].Trim(), @"^rid:\s*(-?\d+)$");
+            if (ridScalar.Success)
+                return long.TryParse(ridScalar.Groups[1].Value, out rid) ? SegmentKind.Reference : SegmentKind.NotFound;
+
+            valueStart = blockStart;
+            valueEnd = blockEnd;
+            valueIndent = IndentOf(lines[firstChild]);
+            return SegmentKind.Container;
+        }
+
+        // Locates the index-th "- " item of a sequence whose items begin at [itemsStart, rangeEnd). A "- rid: N" item
+        // is a managed reference; a "- field: …" item is a mapping container whose fields begin on the dash line.
+        private static SegmentKind ResolveSequenceItem(string[] lines, int itemsStart, int rangeEnd, int index,
+            out long rid, out int valueStart, out int valueEnd, out int valueIndent)
+        {
+            rid = 0;
+            valueStart = valueEnd = valueIndent = -1;
+
+            var itemPattern = new Regex(@"^(?<lead>\s*)-\s");
+            var itemIndent = -1;
+            var count = 0;
+
+            for (var j = itemsStart; j < rangeEnd; j++)
+            {
+                if (lines[j].Trim().Length == 0) continue;
+
+                var item = itemPattern.Match(lines[j]);
+                if (!item.Success)
+                {
+                    if (itemIndent >= 0 && IndentOf(lines[j]) <= itemIndent) break; // dedented out of the sequence
+                    continue;
+                }
+
+                var indent = item.Groups["lead"].Length;
+                if (itemIndent < 0) itemIndent = indent;
+                else if (indent < itemIndent) break;    // dedented out of the sequence
+                else if (indent > itemIndent) continue; // item of a nested sequence, not ours
+
+                if (count == index)
+                {
+                    var ridMatch = Regex.Match(lines[j].TrimStart(), @"^-\s+rid:\s*(-?\d+)\s*$");
+                    if (ridMatch.Success)
+                        return long.TryParse(ridMatch.Groups[1].Value, out rid) ? SegmentKind.Reference : SegmentKind.NotFound;
+
+                    // Mapping item: it runs until the next sibling "- " or a dedent; its fields start one "- " past
+                    // the item indent.
+                    var itemEnd = rangeEnd;
+                    for (var k = j + 1; k < rangeEnd; k++)
+                    {
+                        if (lines[k].Trim().Length == 0) continue;
+                        var ind = IndentOf(lines[k]);
+                        if (ind < itemIndent || (ind == itemIndent && itemPattern.IsMatch(lines[k]))) { itemEnd = k; break; }
+                    }
+
+                    valueStart = j;
+                    valueEnd = itemEnd;
+                    valueIndent = itemIndent + 2;
+                    return SegmentKind.Container;
+                }
+
+                count++;
+            }
+
+            return SegmentKind.NotFound;
+        }
+
+        // Locates the RefIds entry for rid and returns the line range of its "data:" block plus the indent of that
+        // block's direct children, so a nested segment can be resolved within the right scope.
+        private static bool TryGetDataBlockRange(string[] lines, int refIdsStart, int docEnd, long rid, out int blockStart, out int blockEnd, out int childIndent)
+        {
+            blockStart = blockEnd = childIndent = -1;
+            var ridPattern = new Regex($@"^(?<indent>\s*)-\s+rid:\s*{rid}\s*$");
+            var dataPattern = new Regex(@"^\s*data:\s*$");
+
+            for (var i = refIdsStart; i < docEnd; i++)
+            {
+                var match = ridPattern.Match(lines[i]);
+                if (!match.Success) continue;
+
+                // The entry runs until the next list item at its own indent, or until the block dedents out of it.
+                var entryIndent = match.Groups["indent"].Length;
+                var entryEnd = docEnd;
+                for (var j = i + 1; j < docEnd; j++)
+                {
+                    if (lines[j].Trim().Length == 0) continue;
+                    var indent = IndentOf(lines[j]);
+                    if (indent < entryIndent || (indent == entryIndent && lines[j].TrimStart().StartsWith("- "))) { entryEnd = j; break; }
+                }
+
+                for (var j = i + 1; j < entryEnd; j++)
+                {
+                    if (!dataPattern.IsMatch(lines[j])) continue;
+
+                    blockStart = j + 1;
+                    blockEnd = entryEnd;
+                    for (var k = blockStart; k < blockEnd; k++)
+                        if (lines[k].Trim().Length > 0) { childIndent = IndentOf(lines[k]); break; }
+
+                    return blockStart < blockEnd && childIndent >= 0;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        // Leading-indentation width of a line, counting each space or tab as one unit (see SerializeReferenceYaml.IndentOf).
+        private static int IndentOf(string line) => SerializeReferenceYaml.IndentOf(line);
+
+        // A line whose leading indentation is spaces only — Unity's invariant for serialized YAML. Returns false when
+        // the indent begins with a tab or any other whitespace, the case where IndentOf and the "- rid:" \s* regexes
+        // can still measure the same nesting differently (a single tab vs a run of spaces). Callers about to delete a
+        // bounded block bail on such a line rather than risk a mis-bounded, non-undoable write.
+        private static bool IndentIsSpaceOnly(string line)
+        {
+            for (var i = 0; i < line.Length; i++)
+            {
+                if (line[i] == ' ') continue;            // a space is fine — keep scanning the indent
+                if (char.IsWhiteSpace(line[i])) return false; // a tab / other whitespace in the indent: untrusted
+                return true;                             // first content char reached: the indent was spaces only
+            }
+
+            return true;
+        }
+
+        // Whether every line in [start, end) is indented with spaces only — the precondition the block-removing writes
+        // verify before touching the file, so an asset with unexpected (tab / mixed) indentation is left untouched.
+        private static bool BlockIndentIsTrusted(string[] lines, int start, int end)
+        {
+            for (var i = Math.Max(start, 0); i < end && i < lines.Length; i++)
+                if (!IndentIsSpaceOnly(lines[i])) return false;
+
+            return true;
+        }
+
+        // Whether the text looks like a Unity-serialized YAML asset: its directive preamble (everything before the
+        // first document "---") must carry Unity's signature "%TAG !u! tag:unity3d.com,2011:" directive. Guards the
+        // destructive writes so a hand-authored or foreign YAML file — which this line-scanning parser was never
+        // designed for — can never be surgically rewritten.
+        private static bool LooksLikeUnityYaml(string[] lines)
+        {
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = (i == 0 ? StripByteOrderMark(lines[i]) : lines[i]).TrimStart();
+                if (line.Length == 0) continue;
+                if (line.StartsWith("%TAG !u!", StringComparison.Ordinal)) return true;
+                if (line.StartsWith("---", StringComparison.Ordinal)) return false; // first document reached without the %TAG marker
+            }
+
+            return false;
+        }
+
+        // File.ReadAllLines strips a UTF-8 BOM in practice, but guard the first line defensively so the %TAG sniff is
+        // never thrown off by a leading byte-order mark.
+        private static string StripByteOrderMark(string line) =>
+            line.Length > 0 && line[0] == '\uFEFF' ? line.Substring(1) : line;
+
+        /// <summary>
+        /// Reads the managed-reference id stored at <paramref name="propertyPath"/> and the type recorded for it in
+        /// the <c>RefIds</c> block, in a single pass over the asset YAML. This is how a missing reference is found
+        /// even when Unity has dropped it from the live object (notably on prefabs / GameObjects): the orphaned
+        /// id, type identity and payload all survive in the file.
+        /// </summary>
+        public static bool TryReadStoredType(string assetPath, long fileId, string propertyPath, out long rid, out ManagedTypeName type)
+        {
+            rid = 0;
+            type = default;
+
+            if (!TryReadReferenceId(assetPath, fileId, propertyPath, out rid)) return false;
+
+            try
+            {
+                var lines = SerializeReferenceYamlProbeCache.ReadAllLines(assetPath);
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return false;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return false;
+
+                var ridPattern = new Regex($@"^\s*-\s+rid:\s*{rid}\s*$");
+                var typePattern = new Regex(@"^\s*type:\s*\{(?<body>.*)\}\s*$");
+
+                for (var i = refIdsStart; i < end; i++)
+                {
+                    if (!ridPattern.IsMatch(lines[i])) continue;
+
+                    for (var j = i + 1; j < end && j <= i + 4; j++)
+                    {
+                        var match = typePattern.Match(lines[j]);
+                        if (!match.Success) continue;
+
+                        return TryParseInlineType(match.Groups["body"].Value, out type);
+                    }
+
+                    return false;
+                }
+
+                return false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        // Parses the inline "class: X, ns: Y, asm: Z" body of a RefIds type mapping (see SerializeReferenceYaml.TryParseInlineType).
+        private static bool TryParseInlineType(string body, out ManagedTypeName type) =>
+            SerializeReferenceYaml.TryParseInlineType(body, out type);
+
+        // Returns the [start, end) line range of the document whose anchor equals fileId. Falls back to the single
+        // document of a one-object asset (the common ScriptableObject case) when the anchor cannot be matched.
+        private static (int start, int end) FindDocumentRange(string[] lines, long fileId)
+        {
+            var start = -1;
+            var end = lines.Length;
+            var headerCount = 0;
+            var firstHeader = -1;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var match = DocumentHeader.Match(lines[i]);
+                if (!match.Success) continue;
+
+                headerCount++;
+                if (firstHeader < 0) firstHeader = i;
+
+                if (start >= 0)
+                {
+                    end = i;
+                    break;
+                }
+
+                if (long.TryParse(match.Groups["id"].Value, out var anchor) && anchor == fileId)
+                    start = i;
+            }
+
+            if (start >= 0) return (start, end);
+            if (headerCount == 1) return (firstHeader, lines.Length);
+            return (-1, -1);
+        }
+
+        // Index of the "RefIds:" key line within [start, end) (see SerializeReferenceYaml.FindRefIdsStart).
+        private static int FindRefIdsStart(string[] lines, int start, int end) =>
+            SerializeReferenceYaml.FindRefIdsStart(lines, start, end);
+
+        /// <summary>
+        /// Reads the top-level serialized field names recorded for the managed reference <paramref name="rid"/> within
+        /// the object document anchored at <paramref name="fileId"/> — the direct keys of the entry's <c>data:</c>
+        /// block. Used by the Smart Fix suggestion's field-shape heuristic to compare the orphaned payload's shape
+        /// against a candidate type's serialized fields. Nested mappings and sequences are reported by their key only.
+        /// </summary>
+        public static List<string> GetReferenceFieldNames(string assetPath, long fileId, long rid)
+        {
+            var result = new List<string>();
+
+            try
+            {
+                if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return result;
+
+                var lines = SerializeReferenceYamlProbeCache.ReadAllLines(assetPath);
+                var (start, end) = FindDocumentRange(lines, fileId);
+                if (start < 0) return result;
+
+                var refIdsStart = FindRefIdsStart(lines, start, end);
+                if (refIdsStart < 0) return result;
+
+                if (!TryGetDataBlockRange(lines, refIdsStart, end, rid, out var blockStart, out var blockEnd, out var childIndent))
+                    return result;
+
+                CollectTopLevelKeys(lines, blockStart, blockEnd, childIndent, result);
+            }
+            catch (Exception)
+            {
+                // Best effort — an unreadable block simply yields no field-shape signal.
+            }
+
+            return result;
+        }
+
+        // Collects the keys of "name: …" entries at exactly childIndent within [blockStart, blockEnd), skipping the
+        // deeper lines of nested mappings/sequences so only the block's own top-level fields are reported.
+        private static void CollectTopLevelKeys(string[] lines, int blockStart, int blockEnd, int childIndent, List<string> result)
+        {
+            var keyPattern = new Regex(@"^(?<indent>\s*)(?<key>[^\s:][^:]*):(\s.*|\s*)$");
+
+            for (var i = blockStart; i < blockEnd; i++)
+            {
+                if (lines[i].Trim().Length == 0) continue;
+                if (IndentOf(lines[i]) != childIndent) continue; // a nested line, not a direct field of this block
+
+                var match = keyPattern.Match(lines[i]);
+                if (!match.Success) continue;
+                if (match.Groups["indent"].Length != childIndent) continue;
+
+                var key = match.Groups["key"].Value.Trim();
+                if (key.Length > 0 && key != "-") result.Add(key);
+            }
+        }
+
+        /// <summary>
+        /// Parses the top-level field names from the flat YAML payload Unity exposes for an in-memory missing reference
+        /// (<see cref="UnityEditor.SerializationUtility.GetManagedReferencesWithMissingTypes"/>
+        /// <c>serializedData</c>). Mirrors the in-memory data-recovery parser: only top-level <c>key: value</c> scalars
+        /// (and mapping/sequence headers) are reported; indented and sequence-item lines are skipped.
+        /// </summary>
+        public static List<string> ParseTopLevelFieldNames(string serializedData)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(serializedData)) return result;
+
+            foreach (var raw in serializedData.Split('\n'))
+            {
+                var line = raw.TrimEnd('\r');
+                if (line.Length == 0 || char.IsWhiteSpace(line[0]) || line[0] == '-') continue;
+
+                var separator = line.IndexOf(':');
+                if (separator <= 0) continue;
+
+                var key = line[..separator].Trim();
+                if (key.Length > 0) result.Add(key);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlEditor.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 365226302fbb14e7b9e4fda086d9f0a5

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCache.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCache.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// Caches the raw lines of an asset's YAML keyed by (path, last-write-time) so the per-property missing/stored-type
+    /// probe — which runs on every IMGUI repaint via <see cref="SerializeReferenceYamlEditor.TryReadStoredType"/> /
+    /// <see cref="SerializeReferenceYamlEditor.TryReadReferenceId"/> — does not hit the disk every frame. The
+    /// modification-time component auto-invalidates an out-of-band edit; writers and repair sites additionally call
+    /// <see cref="ClearCache"/> so a same-frame rewrite is never served stale. Mirrors the FIFO-capped cache pattern of
+    /// <see cref="SerializeReferenceRepairSuggestions"/>.
+    /// </summary>
+    /// <remarks>
+    /// The one-shot project sweep (<see cref="SerializeReferenceYamlEditor.FindMissingReferences"/>) deliberately bypasses
+    /// this cache: it reads every candidate once behind a progress bar and would otherwise bloat the cache with large,
+    /// never-reused scene files.
+    /// </remarks>
+    internal static class SerializeReferenceYamlProbeCache
+    {
+        private const int CacheCapacity = 64;
+
+        private static readonly Dictionary<string, (DateTime writeTimeUtc, string[] lines)> Cache =
+            new(StringComparer.Ordinal);
+
+        private static readonly Queue<string> CacheOrder = new();
+
+        /// <summary>
+        /// Returns the asset's lines from the cache when the file's last-write-time is unchanged, otherwise reads them
+        /// from disk and stores them. Returns an empty array for a missing/empty path. The returned array is shared —
+        /// callers must treat it as read-only.
+        /// </summary>
+        public static string[] ReadAllLines(string assetPath)
+        {
+            if (string.IsNullOrEmpty(assetPath) || !File.Exists(assetPath)) return Array.Empty<string>();
+
+            var writeTimeUtc = File.GetLastWriteTimeUtc(assetPath);
+            if (Cache.TryGetValue(assetPath, out var cached) && cached.writeTimeUtc == writeTimeUtc)
+                return cached.lines;
+
+            var lines = File.ReadAllLines(assetPath);
+
+            // A re-read at a newer write-time replaces the entry in place without re-enqueuing it; only a genuinely new
+            // key grows the FIFO order, so the cap counts distinct assets, not reads.
+            if (!Cache.ContainsKey(assetPath)) CacheOrder.Enqueue(assetPath);
+            Cache[assetPath] = (writeTimeUtc, lines);
+
+            while (CacheOrder.Count > CacheCapacity)
+            {
+                var evicted = CacheOrder.Dequeue();
+                Cache.Remove(evicted);
+            }
+
+            return lines;
+        }
+
+        /// <summary>Drops every cached file — called after a rewrite and from the import post-processor.</summary>
+        public static void ClearCache()
+        {
+            Cache.Clear();
+            CacheOrder.Clear();
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCache.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef492d217580f47fbb083c08abf3c2a9

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using UnityEditor;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// Coarsely clears <see cref="SerializeReferenceYamlProbeCache"/> whenever a managed-reference-bearing asset is
+    /// imported, deleted or moved, so the per-property probe never serves content from before an import. Mirrors the
+    /// import-post-processor strategy of the Id system's cache invalidator.
+    /// </summary>
+    internal sealed class SerializeReferenceYamlProbeCacheInvalidator : AssetPostprocessor
+    {
+        private static void OnPostprocessAllAssets(string[] imported, string[] deleted, string[] moved, string[] movedFrom)
+        {
+            if (HasCandidate(imported) || HasCandidate(deleted) || HasCandidate(moved))
+                SerializeReferenceYamlProbeCache.ClearCache();
+        }
+
+        private static bool HasCandidate(string[] paths) =>
+            paths.Any(SerializeReferenceHelpers.IsScanCandidate);
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs
@@ -19,6 +19,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         private static bool HasCandidate(string[] paths) =>
-            paths.Any(SerializeReferenceHelpers.IsScanCandidate);
+            paths.Any(SerializeReferenceYaml.IsCandidateAssetPath);
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Yaml/SerializeReferenceYamlProbeCacheInvalidator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4cbc7bd5fbb594609a558a86b369df33


### PR DESCRIPTION
## Summary

- Move the self-contained, parser-free Unity-YAML managed-reference editor (`SerializeReferenceYaml`, `SerializeReferenceYamlEditor` with its `ManagedTypeName`/`RefIds` parsing, the probe cache and its import invalidator) plus its six engine-level tests into a dedicated **internal** editor assembly `Aspid.FastTools.Unity.Editor.Yaml` (and a `…Yaml.Tests` assembly).
- The assembly has **no Aspid references** (only UnityEngine/UnityEditor), so it compiles standalone on top of `main`. Types stay `internal`, exposed to the consuming editor assembly and the test assembly via `InternalsVisibleTo`.
- Pure code move + assembly split — **no behavior change, no public API added**. Isolates the YAML engine so it can land on `main` independently of the large SerializeReference feature branch, and can later be promoted to a standalone feature once a second consumer (e.g. `m_Script` GUID repair) appears.

## Notes for review

- The engine is editor-only and feature-agnostic: it has zero inbound dependencies on SerializeReference code (verified — only doc-comments and `[TypeSelector]` log literals mention it).
- Doc-comment `<see cref="…"/>` references to SerializeReference-specific types (e.g. `SerializeReferenceHelpers`, `SerializeReferenceGraphScanner`) are intentionally left as-is; Unity does not emit XML docs for asmdefs, so they do not warn. They will be cleaned up when the engine's names are genericized.
- Integration tests that couple to SerializeReference code (`RequiredYamlTests`, `ManagedTypeNameTests`) deliberately remain on the feature branch; the six tests here exercise the engine in isolation.
- The branch is based directly on `main`. The `feature/serialize-reference-dropdown` branch will pick this up and delete its now-duplicated copies (and wire an asmdef reference) in a follow-up rewire.