### PR TITLE
feat(enums): add typed EnumValues<TEnum, TValue> variant

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
@@ -521,6 +521,27 @@ In the Inspector, select the enum type in the `EnumValues` header, then assign a
 
 > The complete sample — `DamageDealer` / `DamageType` / `StatusEffect` — ships in the `EnumValues` sample (Package Manager → Aspid.FastTools → Samples).
 
+### EnumValues\<TEnum, TValue\>
+
+The typed counterpart of `EnumValues<TValue>` for the common case where the enum type is already known in code. The enum is fixed by the generic argument, so the Inspector shows no type picker and lookups are compile-time safe. Lookups are also boxing-free — keys are compared as cached numeric values — and `foreach` over either variant binds to a struct enumerator, so iteration does not allocate. Implements `IEnumerable<KeyValuePair<TEnum, TValue>>`.
+
+| Member | Description |
+|--------|-------------|
+| `TValue GetValue(TEnum enumValue)` | Returns the mapped value, or `_defaultValue` if not found |
+| `bool Equals(TEnum, TEnum)` | Equality check with proper `[Flags]` support |
+
+```csharp
+public sealed class HitEffect : MonoBehaviour
+{
+    // No type picker in the Inspector — the enum is fixed to DamageType.
+    [SerializeField] private EnumValues<DamageType, Color> _damageColors;
+
+    public Color GetColor(DamageType type) => _damageColors.GetValue(type);
+}
+```
+
+Lookup semantics (including `[Flags]` handling) are identical to `EnumValues<TValue>`, and the serialized layout is compatible — switching a field between the two variants keeps the existing data as long as the enum type matches.
+
 ---
 
 ## ID System (Beta)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
@@ -521,6 +521,27 @@ public sealed class DamageDealer : MonoBehaviour
 
 > Полный сэмпл — `DamageDealer` / `DamageType` / `StatusEffect` — поставляется в сэмпле `EnumValues` (Package Manager → Aspid.FastTools → Samples).
 
+### EnumValues\<TEnum, TValue\>
+
+Типизированный вариант `EnumValues<TValue>` для частого случая, когда тип перечисления уже известен в коде. Тип фиксируется generic-аргументом, поэтому в Inspector нет выбора типа, а обращения проверяются на этапе компиляции. Поиск при этом не использует boxing — ключи сравниваются как закэшированные числовые значения, — а `foreach` по обоим вариантам использует struct-энумератор и не аллоцирует. Реализует `IEnumerable<KeyValuePair<TEnum, TValue>>`.
+
+| Член | Описание |
+|------|----------|
+| `TValue GetValue(TEnum enumValue)` | Возвращает сопоставленное значение или `_defaultValue`, если не найдено |
+| `bool Equals(TEnum, TEnum)` | Проверка равенства с корректной поддержкой `[Flags]` |
+
+```csharp
+public sealed class HitEffect : MonoBehaviour
+{
+    // В Inspector нет выбора типа — перечисление зафиксировано как DamageType.
+    [SerializeField] private EnumValues<DamageType, Color> _damageColors;
+
+    public Color GetColor(DamageType type) => _damageColors.GetValue(type);
+}
+```
+
+Семантика поиска (включая обработку `[Flags]`) идентична `EnumValues<TValue>`, а сериализованный формат совместим — смена типа поля между двумя вариантами сохраняет существующие данные, пока тип перечисления совпадает.
+
 ---
 
 ## ID System (Beta)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08b540935ea624cf6a0df7959a1a8ef3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using NUnit.Framework;
+using Aspid.FastTools.Enums;
+using UnityEngine.TestTools.Constraints;
+using Is = UnityEngine.TestTools.Constraints.Is;
+
+namespace Aspid.FastTools.Enums.Tests
+{
+    internal enum Season
+    {
+        Winter,
+        Spring,
+        Summer,
+        Autumn,
+    }
+
+    [Flags]
+    internal enum Sides
+    {
+        None = 0,
+        Left = 1,
+        Right = 2,
+        Both = Left | Right,
+    }
+
+    // Exercises the 64-bit branch of the typed variant's numeric key conversion.
+    [Flags]
+    internal enum BigFlags : long
+    {
+        None = 0,
+        High = 1L << 40,
+        Top = 1L << 62,
+        All = High | Top,
+    }
+
+    // Exercises sign extension in the typed variant's numeric key conversion.
+    internal enum SignedValues : short
+    {
+        Negative = -5,
+        Positive = 7,
+    }
+
+    /// <summary>
+    /// Coverage for <see cref="EnumValues{TValue}"/> and <see cref="EnumValues{TEnum,TValue}"/>:
+    /// lookup semantics (regular + <c>[Flags]</c>), the typed variant's auto-stamped
+    /// <c>_enumType</c>, and the serialized-layout compatibility between the two variants.
+    /// All data is written through <see cref="SerializedObject"/> so the real
+    /// serialize/deserialize path (including <see cref="ISerializationCallbackReceiver"/>) runs.
+    /// </summary>
+    [TestFixture]
+    internal sealed class EnumValuesTests
+    {
+        private sealed class Host : ScriptableObject
+        {
+            [SerializeField] private EnumValues<int> _untyped = new();
+            [SerializeField] private EnumValues<Season, int> _seasons = new();
+            [SerializeField] private EnumValues<Sides, int> _sides = new();
+            [SerializeField] private EnumValues<BigFlags, int> _bigFlags = new();
+            [SerializeField] private EnumValues<SignedValues, int> _signed = new();
+
+            public EnumValues<int> Untyped => _untyped;
+
+            public EnumValues<Season, int> Seasons => _seasons;
+
+            public EnumValues<Sides, int> Sides => _sides;
+
+            public EnumValues<BigFlags, int> BigFlags => _bigFlags;
+
+            public EnumValues<SignedValues, int> Signed => _signed;
+        }
+
+        private Host _host;
+
+        [SetUp]
+        public void SetUp() => _host = ScriptableObject.CreateInstance<Host>();
+
+        [TearDown]
+        public void TearDown() => UnityEngine.Object.DestroyImmediate(_host);
+
+        private void AddEntry(string field, string key, int value, string enumType = null)
+        {
+            var serializedObject = new SerializedObject(_host);
+
+            if (enumType is not null)
+                serializedObject.FindProperty($"{field}._enumType").stringValue = enumType;
+
+            var values = serializedObject.FindProperty($"{field}._values");
+            values.arraySize++;
+
+            var element = values.GetArrayElementAtIndex(values.arraySize - 1);
+            element.FindPropertyRelative("_key").stringValue = key;
+            element.FindPropertyRelative("_value").intValue = value;
+
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        private void SetDefaultValue(string field, int value)
+        {
+            var serializedObject = new SerializedObject(_host);
+            serializedObject.FindProperty($"{field}._defaultValue").intValue = value;
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        [Test]
+        public void Typed_GetValue_ReturnsMappedValue()
+        {
+            AddEntry("_seasons", nameof(Season.Summer), 42);
+
+            Assert.AreEqual(42, _host.Seasons.GetValue(Season.Summer));
+        }
+
+        [Test]
+        public void Typed_GetValue_ReturnsDefaultWhenNoEntryMatches()
+        {
+            SetDefaultValue("_seasons", -1);
+            AddEntry("_seasons", nameof(Season.Summer), 42);
+
+            Assert.AreEqual(-1, _host.Seasons.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Typed_GetValue_DoesNotDependOnEnumTypeMirror()
+        {
+            // The typed variant must resolve TEnum from the generic argument alone — the
+            // serialized _enumType mirror is editor-only sugar for the drawers. Clear it
+            // (undoing the stamp AddEntry's serialize pass wrote) and the lookup must still work.
+            AddEntry("_seasons", nameof(Season.Autumn), 7);
+
+            var serializedObject = new SerializedObject(_host);
+            serializedObject.FindProperty("_seasons._enumType").stringValue = string.Empty;
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+
+            Assert.AreEqual(7, _host.Seasons.GetValue(Season.Autumn));
+        }
+
+        [Test]
+        public void Typed_Flags_ExactMatchWinsOverContainment()
+        {
+            AddEntry("_sides", nameof(Sides.Left), 1);
+            AddEntry("_sides", nameof(Sides.Both), 3);
+
+            Assert.AreEqual(3, _host.Sides.GetValue(Sides.Both));
+        }
+
+        [Test]
+        public void Typed_Flags_ContainmentMatchesWhenNoExactEntry()
+        {
+            AddEntry("_sides", nameof(Sides.Left), 1);
+
+            Assert.AreEqual(1, _host.Sides.GetValue(Sides.Both));
+        }
+
+        [Test]
+        public void Typed_Flags_ZeroOnlyMatchesZero()
+        {
+            SetDefaultValue("_sides", -1);
+            AddEntry("_sides", nameof(Sides.None), 100);
+
+            Assert.AreEqual(100, _host.Sides.GetValue(Sides.None));
+            Assert.AreEqual(-1, _host.Sides.GetValue(Sides.Left));
+        }
+
+        [Test]
+        public void Typed_Equals_UsesFlagsSemantics()
+        {
+            Assert.IsTrue(_host.Sides.Equals(Sides.Both, Sides.Left));
+            Assert.IsFalse(_host.Sides.Equals(Sides.Left, Sides.Both));
+            Assert.IsFalse(_host.Sides.Equals(Sides.Left, Sides.None));
+        }
+
+        [Test]
+        public void Typed_Enumerator_YieldsTypedConfiguredEntries()
+        {
+            AddEntry("_seasons", nameof(Season.Winter), 1);
+            AddEntry("_seasons", nameof(Season.Spring), 2);
+
+            var entries = _host.Seasons.ToArray();
+
+            Assert.AreEqual(2, entries.Length);
+            Assert.AreEqual(Season.Winter, entries[0].Key);
+            Assert.AreEqual(1, entries[0].Value);
+            Assert.AreEqual(Season.Spring, entries[1].Key);
+            Assert.AreEqual(2, entries[1].Value);
+        }
+
+        [Test]
+        public void Typed_Foreach_YieldsEntriesAndDoesNotAllocate()
+        {
+            AddEntry("_seasons", nameof(Season.Winter), 1);
+            AddEntry("_seasons", nameof(Season.Spring), 2);
+
+            var sum = 0;
+
+            // Warm-up: the first pass lazily resolves the keys (which allocates) — the
+            // steady-state foreach below must bind to the struct enumerator and stay clean.
+            foreach (var entry in _host.Seasons)
+                sum += entry.Value;
+
+            Assert.AreEqual(3, sum);
+
+            Assert.That(() =>
+            {
+                foreach (var entry in _host.Seasons)
+                    sum += entry.Value;
+            }, Is.Not.AllocatingGCMemory());
+
+            Assert.AreEqual(6, sum);
+        }
+
+        [Test]
+        public void Untyped_Foreach_YieldsEntriesAndDoesNotAllocate()
+        {
+            AddEntry("_untyped", nameof(Season.Winter), 1, typeof(Season).AssemblyQualifiedName);
+            AddEntry("_untyped", nameof(Season.Spring), 2);
+
+            var sum = 0;
+
+            foreach (var entry in _host.Untyped)
+                sum += entry.Value;
+
+            Assert.AreEqual(3, sum);
+
+            Assert.That(() =>
+            {
+                foreach (var entry in _host.Untyped)
+                    sum += entry.Value;
+            }, Is.Not.AllocatingGCMemory());
+
+            Assert.AreEqual(6, sum);
+        }
+
+        [Test]
+        public void Typed_OnBeforeSerialize_StampsEnumType()
+        {
+            // Creating a SerializedObject forces a serialize pass, which runs OnBeforeSerialize.
+            var serializedObject = new SerializedObject(_host);
+
+            Assert.AreEqual(
+                typeof(Season).AssemblyQualifiedName,
+                serializedObject.FindProperty("_seasons._enumType").stringValue);
+        }
+
+        [Test]
+        public void Typed_LayoutMatchesUntypedFieldPaths()
+        {
+            // Serialized-layout compatibility contract: both variants expose the same
+            // _enumType / _defaultValue / _values(_key, _value) property paths, so switching
+            // a field between them migrates existing data.
+            var serializedObject = new SerializedObject(_host);
+
+            foreach (var field in new[] { "_untyped", "_seasons" })
+            {
+                Assert.IsNotNull(serializedObject.FindProperty($"{field}._enumType"), field);
+                Assert.IsNotNull(serializedObject.FindProperty($"{field}._defaultValue"), field);
+                Assert.IsNotNull(serializedObject.FindProperty($"{field}._values"), field);
+            }
+        }
+
+        [Test]
+        public void Typed_Flags_LongUnderlyingType_HighBitsSurviveLookup()
+        {
+            SetDefaultValue("_bigFlags", -1);
+            AddEntry("_bigFlags", nameof(BigFlags.High), 1);
+            AddEntry("_bigFlags", nameof(BigFlags.All), 3);
+
+            Assert.AreEqual(3, _host.BigFlags.GetValue(BigFlags.All));
+            Assert.AreEqual(1, _host.BigFlags.GetValue(BigFlags.High));
+            Assert.AreEqual(-1, _host.BigFlags.GetValue(BigFlags.Top));
+        }
+
+        [Test]
+        public void Typed_NegativeUnderlyingValue_MatchesItsEntry()
+        {
+            SetDefaultValue("_signed", -1);
+            AddEntry("_signed", nameof(SignedValues.Negative), 5);
+
+            Assert.AreEqual(5, _host.Signed.GetValue(SignedValues.Negative));
+            Assert.AreEqual(-1, _host.Signed.GetValue(SignedValues.Positive));
+        }
+
+        [Test]
+        public void Untyped_GetValue_ReturnsMappedValue()
+        {
+            AddEntry("_untyped", nameof(Season.Summer), 42, typeof(Season).AssemblyQualifiedName);
+
+            Assert.AreEqual(42, _host.Untyped.GetValue(Season.Summer));
+        }
+
+        [Test]
+        public void Untyped_GetValue_ReturnsDefaultWhenNoEntryMatches()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Summer), 42, typeof(Season).AssemblyQualifiedName);
+
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Untyped_GetValue_DifferentEnumType_NeverMatchesNumericCollision()
+        {
+            SetDefaultValue("_untyped", -1);
+            // Season.Winter and Sides.None share the numeric value 0 — the type guard must
+            // keep a lookup with the wrong enum type from matching it.
+            AddEntry("_untyped", nameof(Season.Winter), 42, typeof(Season).AssemblyQualifiedName);
+
+            Assert.AreEqual(42, _host.Untyped.GetValue(Season.Winter));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Sides.None));
+        }
+
+        [Test]
+        public void Untyped_GetValue_NullLookup_ReturnsDefault()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 42, typeof(Season).AssemblyQualifiedName);
+
+            Assert.AreEqual(-1, _host.Untyped.GetValue(null));
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
@@ -4,6 +4,8 @@ using UnityEditor;
 using UnityEngine;
 using NUnit.Framework;
 using Aspid.FastTools.Enums;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
 using UnityEngine.TestTools.Constraints;
 using Is = UnityEngine.TestTools.Constraints.Is;
 
@@ -43,10 +45,19 @@ namespace Aspid.FastTools.Enums.Tests
         Positive = 7,
     }
 
+    // Exercises the ulong branch of the numeric key conversion (top bit set —
+    // the unchecked ulong→long reinterpretation must stay consistent on both sides).
+    internal enum UnsignedValues : ulong
+    {
+        Zero = 0,
+        Top = 1UL << 63,
+    }
+
     /// <summary>
     /// Coverage for <see cref="EnumValues{TValue}"/> and <see cref="EnumValues{TEnum,TValue}"/>:
     /// lookup semantics (regular + <c>[Flags]</c>), the typed variant's auto-stamped
-    /// <c>_enumType</c>, and the serialized-layout compatibility between the two variants.
+    /// <c>_enumType</c>, the serialized-layout compatibility between the two variants, and the
+    /// degrade paths (unconfigured/unresolvable enum type, unparseable entry keys).
     /// All data is written through <see cref="SerializedObject"/> so the real
     /// serialize/deserialize path (including <see cref="ISerializationCallbackReceiver"/>) runs.
     /// </summary>
@@ -60,6 +71,7 @@ namespace Aspid.FastTools.Enums.Tests
             [SerializeField] private EnumValues<Sides, int> _sides = new();
             [SerializeField] private EnumValues<BigFlags, int> _bigFlags = new();
             [SerializeField] private EnumValues<SignedValues, int> _signed = new();
+            [SerializeField] private EnumValues<UnsignedValues, int> _unsigned = new();
 
             public EnumValues<int> Untyped => _untyped;
 
@@ -70,6 +82,8 @@ namespace Aspid.FastTools.Enums.Tests
             public EnumValues<BigFlags, int> BigFlags => _bigFlags;
 
             public EnumValues<SignedValues, int> Signed => _signed;
+
+            public EnumValues<UnsignedValues, int> Unsigned => _unsigned;
         }
 
         private Host _host;
@@ -101,6 +115,13 @@ namespace Aspid.FastTools.Enums.Tests
         {
             var serializedObject = new SerializedObject(_host);
             serializedObject.FindProperty($"{field}._defaultValue").intValue = value;
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        private void SetEnumType(string field, string enumType)
+        {
+            var serializedObject = new SerializedObject(_host);
+            serializedObject.FindProperty($"{field}._enumType").stringValue = enumType;
             serializedObject.ApplyModifiedPropertiesWithoutUndo();
         }
 
@@ -282,6 +303,53 @@ namespace Aspid.FastTools.Enums.Tests
         }
 
         [Test]
+        public void Typed_ULongUnderlyingType_TopBitSurvivesLookup()
+        {
+            SetDefaultValue("_unsigned", -1);
+            AddEntry("_unsigned", nameof(UnsignedValues.Top), 5);
+
+            Assert.AreEqual(5, _host.Unsigned.GetValue(UnsignedValues.Top));
+            Assert.AreEqual(-1, _host.Unsigned.GetValue(UnsignedValues.Zero));
+        }
+
+        [Test]
+        public void Typed_Flags_ContainmentPrefersFirstSerializedEntry()
+        {
+            // Documented tie-break: with no exact entry, the first entry in serialized
+            // order whose bits are contained in the lookup value wins.
+            AddEntry("_sides", nameof(Sides.Right), 20);
+            AddEntry("_sides", nameof(Sides.Left), 10);
+
+            Assert.AreEqual(20, _host.Sides.GetValue(Sides.Both));
+        }
+
+        [Test]
+        public void Typed_Equals_RegularEnum_UsesExactEquality()
+        {
+            Assert.IsTrue(_host.Seasons.Equals(Season.Winter, Season.Winter));
+            Assert.IsFalse(_host.Seasons.Equals(Season.Winter, Season.Spring));
+        }
+
+        [Test]
+        public void Typed_UnparseableKey_LogsErrorAndEntryNeverMatches()
+        {
+            SetDefaultValue("_seasons", -1);
+            AddEntry("_seasons", nameof(Season.Winter), 1);
+            AddEntry("_seasons", "Bogus", 99);
+
+            LogAssert.Expect(LogType.Error, new Regex("Couldn't parse key 'Bogus'"));
+
+            Assert.AreEqual(1, _host.Seasons.GetValue(Season.Winter));
+            Assert.AreEqual(-1, _host.Seasons.GetValue(Season.Summer));
+
+            // The unresolved entry must be skipped by the enumerator too.
+            var entries = _host.Seasons.ToArray();
+
+            Assert.AreEqual(1, entries.Length);
+            Assert.AreEqual(Season.Winter, entries[0].Key);
+        }
+
+        [Test]
         public void Untyped_GetValue_ReturnsMappedValue()
         {
             AddEntry("_untyped", nameof(Season.Summer), 42, typeof(Season).AssemblyQualifiedName);
@@ -317,6 +385,120 @@ namespace Aspid.FastTools.Enums.Tests
             AddEntry("_untyped", nameof(Season.Winter), 42, typeof(Season).AssemblyQualifiedName);
 
             Assert.AreEqual(-1, _host.Untyped.GetValue(null));
+        }
+
+        [Test]
+        public void Untyped_NoEnumTypeConfigured_WarnsAndReturnsDefault()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 42);
+
+            LogAssert.Expect(LogType.Warning, new Regex("No enum type configured"));
+
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Untyped_UnresolvableEnumType_LogsErrorAndReturnsDefault()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 42, "Not.A.Real.Type, Fake.Assembly");
+
+            LogAssert.Expect(LogType.Error, new Regex("Couldn't resolve enum type"));
+
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Untyped_UnparseableKey_LogsErrorAndEntryNeverMatches()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 1, typeof(Season).AssemblyQualifiedName);
+            AddEntry("_untyped", "Bogus", 99);
+
+            LogAssert.Expect(LogType.Error, new Regex("Couldn't parse key 'Bogus'"));
+
+            Assert.AreEqual(1, _host.Untyped.GetValue(Season.Winter));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Summer));
+
+            // The unresolved entry must be skipped by the enumerator too.
+            var entries = _host.Untyped.ToArray();
+
+            Assert.AreEqual(1, entries.Length);
+            Assert.AreEqual(Season.Winter, entries[0].Key);
+        }
+
+        [Test]
+        public void Untyped_Equals_NullArgument_ReturnsFalse()
+        {
+            SetEnumType("_untyped", typeof(Season).AssemblyQualifiedName);
+
+            Assert.IsFalse(_host.Untyped.Equals(null, Season.Winter));
+            Assert.IsFalse(_host.Untyped.Equals(Season.Winter, null));
+            Assert.IsFalse(_host.Untyped.Equals(null, null));
+        }
+
+        [Test]
+        public void Untyped_Equals_DifferentEnumTypes_ReturnsFalse()
+        {
+            SetEnumType("_untyped", typeof(Season).AssemblyQualifiedName);
+
+            // Season.Winter and Sides.None share the numeric value 0 — never equal anyway.
+            Assert.IsFalse(_host.Untyped.Equals(Season.Winter, Sides.None));
+        }
+
+        [Test]
+        public void Untyped_Equals_RegularEnum_UsesExactEquality()
+        {
+            SetEnumType("_untyped", typeof(Season).AssemblyQualifiedName);
+
+            Assert.IsTrue(_host.Untyped.Equals(Season.Winter, Season.Winter));
+            Assert.IsFalse(_host.Untyped.Equals(Season.Winter, Season.Spring));
+        }
+
+        [Test]
+        public void Untyped_Equals_FlagsEnum_UsesFlagsSemantics()
+        {
+            // The flags semantics come from the configured enum type, not the arguments.
+            SetEnumType("_untyped", typeof(Sides).AssemblyQualifiedName);
+
+            Assert.IsTrue(_host.Untyped.Equals(Sides.Both, Sides.Left));
+            Assert.IsFalse(_host.Untyped.Equals(Sides.Left, Sides.Both));
+            Assert.IsFalse(_host.Untyped.Equals(Sides.Left, Sides.None));
+        }
+
+        [Test]
+        public void Untyped_Flags_LongUnderlyingType_HighBitsSurviveLookup()
+        {
+            // Exercises the boxed EnumInfo.ToInt64 Int64 branch (the typed variant
+            // goes through the separate EnumInfo<TEnum> converter).
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(BigFlags.High), 1, typeof(BigFlags).AssemblyQualifiedName);
+            AddEntry("_untyped", nameof(BigFlags.All), 3);
+
+            Assert.AreEqual(3, _host.Untyped.GetValue(BigFlags.All));
+            Assert.AreEqual(1, _host.Untyped.GetValue(BigFlags.High));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(BigFlags.Top));
+        }
+
+        [Test]
+        public void Untyped_NegativeUnderlyingValue_MatchesItsEntry()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(SignedValues.Negative), 5, typeof(SignedValues).AssemblyQualifiedName);
+
+            Assert.AreEqual(5, _host.Untyped.GetValue(SignedValues.Negative));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(SignedValues.Positive));
+        }
+
+        [Test]
+        public void Untyped_ULongUnderlyingType_TopBitSurvivesLookup()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(UnsignedValues.Top), 5, typeof(UnsignedValues).AssemblyQualifiedName);
+
+            Assert.AreEqual(5, _host.Untyped.GetValue(UnsignedValues.Top));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(UnsignedValues.Zero));
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9b11ddf8796844d0a42c42738813865

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
@@ -12,8 +12,8 @@ namespace Aspid.FastTools.Enums.Editors
     /// <summary>
     /// Property drawer for <see cref="EnumValue{TValue}"/>. Picks an EnumField/EnumFlagsField
     /// for the row's key based on the enum type configured on the parent
-    /// <see cref="EnumValues{TValue}"/>, and falls back to a raw string field when the type
-    /// can't be resolved.
+    /// <see cref="EnumValues{TValue}"/> / <see cref="EnumValues{TEnum,TValue}"/>, and falls back
+    /// to a raw string field when the type can't be resolved.
     /// </summary>
     [CustomPropertyDrawer(typeof(EnumValue<>))]
     internal sealed class EnumValuePropertyDrawer : PropertyDrawer

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuesPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuesPropertyDrawer.cs
@@ -3,6 +3,7 @@ using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
 using Aspid.FastTools.UIElements;
+using System.Collections.Generic;
 using Aspid.FastTools.UIElements.Editors;
 using Aspid.FastTools.UIElements.Manipulators;
 using Aspid.FastTools.UIElements.Editors.Internal;
@@ -11,11 +12,13 @@ using Aspid.FastTools.UIElements.Editors.Internal;
 namespace Aspid.FastTools.Enums.Editors
 {
     /// <summary>
-    /// Property drawer for <see cref="EnumValues{TValue}"/>. Renders a header with the enum-type
-    /// picker, the entries list, and the default-value field, and exposes a context-menu action
-    /// that fills in any missing enum members from the configured type.
+    /// Property drawer for <see cref="EnumValues{TValue}"/> and <see cref="EnumValues{TEnum,TValue}"/>.
+    /// Renders a header with the enum-type picker (untyped variant only — the typed variant fixes
+    /// the enum at compile time), the entries list, and the default-value field, and exposes a
+    /// context-menu action that fills in any missing enum members from the configured type.
     /// </summary>
     [CustomPropertyDrawer(typeof(EnumValues<>))]
+    [CustomPropertyDrawer(typeof(EnumValues<,>))]
     internal sealed class EnumValuesPropertyDrawer : PropertyDrawer
     {
         private const string StylesheetPath = "UI/Enums/Aspid-FastTools-EnumValues";
@@ -31,9 +34,21 @@ namespace Aspid.FastTools.Enums.Editors
             var enumTypePath = property.FindPropertyRelative("_enumType").propertyPath;
             var defaultValuePath = property.FindPropertyRelative("_defaultValue").propertyPath;
 
+            // The typed variant stamps _enumType itself on every serialize pass (and building this
+            // inspector's SerializedObject already forced one), so it needs no picker and no
+            // tracking — the enum type can never change.
+            var isTyped = IsTypedVariant();
+
             // Push the parent enum type into every existing entry up-front so already-serialized
             // arrays don't render with a stale per-element _enumType until the user re-edits.
             UpdateValues();
+
+            var header = new VisualElement()
+                .AddClass(HeaderClass)
+                .AddChild(new Label(property.displayName));
+
+            if (!isTyped)
+                header.AddChild(new PropertyField(serializedObject.FindProperty(enumTypePath), label: string.Empty));
 
             var root = new VisualElement()
                 .SetName($"enum-values-{property.name.ToKebabCase()}")
@@ -45,11 +60,7 @@ namespace Aspid.FastTools.Enums.Editors
                     enumType: enumTypePath,
                     defaultValue: defaultValuePath)
                 )
-                .AddChild(new VisualElement()
-                    .AddClass(HeaderClass)
-                    .AddChild(new Label(property.displayName))
-                    .AddChild(new PropertyField(serializedObject.FindProperty(enumTypePath), label: string.Empty))
-                )
+                .AddChild(header)
                 .AddChild(new VisualElement()
                     .AddClass(ContainerClass)
                     .AddChild(new PropertyField(serializedObject.FindProperty(valuesPath))
@@ -62,7 +73,9 @@ namespace Aspid.FastTools.Enums.Editors
             // picked type straight into the SerializedProperty — PropertyField only forwards
             // UI-driven ChangeEvents from custom drawers, so a SerializedPropertyChangeEvent
             // callback would never fire. Track the property itself instead.
-            root.TrackPropertyValue(serializedObject.FindProperty(enumTypePath), _ => UpdateValues());
+            // The typed variant's enum type never changes — nothing to track.
+            if (!isTyped)
+                root.TrackPropertyValue(serializedObject.FindProperty(enumTypePath), _ => UpdateValues());
 
             return root;
 
@@ -79,6 +92,23 @@ namespace Aspid.FastTools.Enums.Editors
                         enumTypeElement.SetStringAndApply(enumTypeValue);
                 }
             }
+        }
+
+        /// <summary>
+        /// Whether the drawn field is an <see cref="EnumValues{TEnum,TValue}"/> (directly, or as
+        /// an array/list element) — the variant with the enum fixed at compile time — rather than
+        /// the untyped <see cref="EnumValues{TValue}"/>.
+        /// </summary>
+        private bool IsTypedVariant()
+        {
+            var type = fieldInfo.FieldType;
+
+            if (type.IsArray)
+                type = type.GetElementType();
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+                type = type.GetGenericArguments()[0];
+
+            return type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(EnumValues<,>);
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumInfo.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System;
+using Unity.Collections.LowLevel.Unsafe;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.Enums
+{
+    /// <summary>
+    /// Numeric conversions for boxed <see cref="Enum"/> values — the runtime-typed counterpart
+    /// of <see cref="EnumInfo{TEnum}"/>, used where the enum type is only known at runtime.
+    /// </summary>
+    internal static class EnumInfo
+    {
+        /// <summary>
+        /// Converts a boxed enum value to its underlying integral value, widened to
+        /// <see cref="long"/> with the underlying type's own signedness.
+        /// Unboxes directly — no intermediate allocation.
+        /// </summary>
+        public static long ToInt64(Enum value) => Type.GetTypeCode(value.GetType()) switch
+        {
+            TypeCode.SByte => (sbyte)(object)value,
+            TypeCode.Byte => (byte)(object)value,
+            TypeCode.Int16 => (short)(object)value,
+            TypeCode.UInt16 => (ushort)(object)value,
+            TypeCode.Int32 => (int)(object)value,
+            TypeCode.UInt32 => (uint)(object)value,
+            TypeCode.Int64 => (long)(object)value,
+            TypeCode.UInt64 => unchecked((long)(ulong)(object)value),
+            _ => throw new InvalidOperationException(
+                $"Unsupported enum underlying type '{Enum.GetUnderlyingType(value.GetType())}'."),
+        };
+    }
+
+    /// <summary>
+    /// Per-enum-type reflection info cached once per closed generic, plus a boxing-free
+    /// conversion of <typeparamref name="TEnum"/> values to their underlying integral value.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type the info describes.</typeparam>
+    internal static class EnumInfo<TEnum> where TEnum : struct, Enum
+    {
+        /// <summary>
+        /// Whether <typeparamref name="TEnum"/> is a <c>[Flags]</c> enum.
+        /// </summary>
+        public static readonly bool IsFlags = typeof(TEnum).IsDefined(typeof(FlagsAttribute), false);
+
+        private static readonly TypeCode _underlyingTypeCode = Type.GetTypeCode(typeof(TEnum));
+
+        /// <summary>
+        /// Reinterprets <paramref name="value"/> as its underlying integral value without boxing,
+        /// widened to <see cref="long"/> with the underlying type's own signedness.
+        /// </summary>
+        public static long ToInt64(TEnum value) => _underlyingTypeCode switch
+        {
+            TypeCode.SByte => UnsafeUtility.As<TEnum, sbyte>(ref value),
+            TypeCode.Byte => UnsafeUtility.As<TEnum, byte>(ref value),
+            TypeCode.Int16 => UnsafeUtility.As<TEnum, short>(ref value),
+            TypeCode.UInt16 => UnsafeUtility.As<TEnum, ushort>(ref value),
+            TypeCode.Int32 => UnsafeUtility.As<TEnum, int>(ref value),
+            TypeCode.UInt32 => UnsafeUtility.As<TEnum, uint>(ref value),
+            TypeCode.Int64 => UnsafeUtility.As<TEnum, long>(ref value),
+            TypeCode.UInt64 => (long)UnsafeUtility.As<TEnum, ulong>(ref value),
+            _ => throw new InvalidOperationException(
+                $"Unsupported enum underlying type '{Enum.GetUnderlyingType(typeof(TEnum))}'."),
+        };
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumInfo.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f6a631b31bb44c99a46ce6628291904

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValue.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValue.cs
@@ -11,8 +11,9 @@ namespace Aspid.FastTools.Enums
     /// <typeparam name="TValue">The type of the value mapped to the enum member.</typeparam>
     /// <remarks>
     /// The enum key is stored as a string and resolved to an <see cref="Enum"/> instance
-    /// lazily via <see cref="Initialize"/>. This class is managed entirely by
-    /// <see cref="EnumValues{TValue}"/> and is not intended for direct instantiation.
+    /// (plus its numeric value for lookups) lazily via <see cref="Initialize"/>. This class is
+    /// managed entirely by <see cref="EnumValues{TValue}"/> / <see cref="EnumValues{TEnum,TValue}"/>
+    /// and is not intended for direct instantiation.
     /// </remarks>
     [Serializable]
     internal sealed class EnumValue<TValue>
@@ -32,10 +33,21 @@ namespace Aspid.FastTools.Enums
         public TValue Value => _value;
 
         /// <summary>
-        /// The resolved enum member. <see langword="null"/> until <see cref="Initialize"/>
-        /// has been called successfully.
+        /// The resolved enum member. Valid only when <see cref="IsResolved"/> is <see langword="true"/>.
         /// </summary>
         public Enum Key { get; private set; }
+
+        /// <summary>
+        /// The resolved key's underlying integral value (see <see cref="EnumInfo.ToInt64"/>).
+        /// Valid only when <see cref="IsResolved"/> is <see langword="true"/>.
+        /// </summary>
+        public long NumericKey { get; private set; }
+
+        /// <summary>
+        /// Whether <see cref="Initialize"/> successfully parsed the serialized key.
+        /// Unresolved entries never match a lookup.
+        /// </summary>
+        public bool IsResolved => Key is not null;
 
         /// <summary>
         /// Resolves the serialized string key to an <see cref="Enum"/> instance of the supplied type.
@@ -51,12 +63,14 @@ namespace Aspid.FastTools.Enums
                 if (Enum.TryParse(type, _key, out var parsedEnum))
                 {
                     Key = (Enum)parsedEnum;
+                    NumericKey = EnumInfo.ToInt64(Key);
                 }
                 else
                 {
-                    // A stale Key from a previous type would crash EnumValues.Equals (HasFlag
-                    // requires matching types), so reset it instead of leaving it as-is.
+                    // A stale Key from a previous type would silently keep matching lookups,
+                    // so reset the entry instead of leaving it as-is.
                     Key = null;
+                    NumericKey = 0L;
 
                     Debug.LogError($"[{nameof(EnumValue<TValue>)}] [{nameof(Initialize)}] " +
                         $"Couldn't parse key '{_key}' to Enum '{type.FullName}'");

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValueLookup.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValueLookup.cs
@@ -1,0 +1,46 @@
+#nullable enable
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.Enums
+{
+    /// <summary>
+    /// The lookup and <c>[Flags]</c>-equality core shared by <see cref="EnumValues{TValue}"/>
+    /// and <see cref="EnumValues{TEnum,TValue}"/> — the single place the matching semantics
+    /// live, so the two variants can never diverge.
+    /// </summary>
+    internal static class EnumValueLookup
+    {
+        /// <summary>
+        /// Flag-containment equality: <paramref name="value1"/> has all bits of
+        /// <paramref name="value2"/> set, with the additional rule that the zero
+        /// (<c>None</c>) value is only equal to another zero value.
+        /// </summary>
+        public static bool FlagsEquals(long value1, long value2) =>
+            (value1 & value2) == value2 && (value1 == 0L) == (value2 == 0L);
+
+        /// <summary>
+        /// Finds the value mapped to <paramref name="lookup"/>: an exact numeric match always
+        /// wins; for <c>[Flags]</c> enums, otherwise the first entry (in serialized order)
+        /// contained in the lookup value (see <see cref="FlagsEquals"/>) wins.
+        /// Unresolved entries never match.
+        /// </summary>
+        public static TValue Find<TValue>(EnumValue<TValue>[] values, long lookup, bool isFlags, TValue defaultValue)
+        {
+            foreach (var value in values)
+            {
+                if (value.IsResolved && value.NumericKey == lookup)
+                    return value.Value;
+            }
+
+            if (isFlags)
+            {
+                foreach (var value in values)
+                {
+                    if (value.IsResolved && FlagsEquals(lookup, value.NumericKey))
+                        return value.Value;
+                }
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValueLookup.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValueLookup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 157097fab126d4cfeb410ca01743bcc5

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
@@ -19,9 +19,11 @@ namespace Aspid.FastTools.Enums
     /// <para>
     /// The enum type is selected in the Inspector via a <see cref="TypeSelectorAttribute"/>
     /// and stored as an assembly-qualified name. All entries are initialized lazily on first access.
+    /// When the enum type is already known at compile time, prefer
+    /// <see cref="EnumValues{TEnum,TValue}"/> — it skips the Inspector type-picker entirely.
     /// </para>
     /// <para>
-    /// For <c>[Flags]</c> enums <see cref="Equals(Enum,Enum)"/> uses <c>HasFlag</c> semantics
+    /// For <c>[Flags]</c> enums <see cref="Equals(Enum,Enum)"/> uses flag-containment semantics
     /// with special handling for the zero (<c>None</c>) value — two values are considered equal
     /// only when both are zero or both are non-zero and one has all bits of the other set.
     /// </para>
@@ -51,15 +53,15 @@ namespace Aspid.FastTools.Enums
     [Serializable]
     public sealed class EnumValues<TValue> : IEnumerable<KeyValuePair<Enum, TValue>>, ISerializationCallbackReceiver
     {
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CS8618
         [TypeSelector(typeof(Enum), Required = true)]
         [SerializeField] private string _enumType;
 
         [SerializeField] private TValue _defaultValue;
         [SerializeField] private EnumValue<TValue>[] _values;
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning restore CS8618
 
-        private Enum? _zero;
+        private Type? _type;
         private bool _isFlag;
         private bool _isInitialized;
 
@@ -74,23 +76,42 @@ namespace Aspid.FastTools.Enums
                 _values ??= Array.Empty<EnumValue<TValue>>();
 
                 // Unconfigured field — degrade to "no entries match" instead of crashing.
+                // Reset the caches too: the type may have been configured before and cleared
+                // since (OnAfterDeserialize only resets _isInitialized).
                 if (string.IsNullOrWhiteSpace(_enumType))
                 {
                     Debug.LogWarning($"[{nameof(EnumValues<TValue>)}] [{nameof(Initialize)}] " +
                         "No enum type configured — GetValue will always return the default value.");
 
-                    _isInitialized = true;
+                    Degrade();
                     return;
                 }
 
-                var type = Type.GetType(_enumType, throwOnError: true);
+                // Unresolvable type (renamed/moved since the asset was saved) — degrade the same
+                // way instead of throwing on every lookup.
+                if (Type.GetType(_enumType, throwOnError: false) is not { } type)
+                {
+                    Debug.LogError($"[{nameof(EnumValues<TValue>)}] [{nameof(Initialize)}] " +
+                        $"Couldn't resolve enum type '{_enumType}' — GetValue will always return the default value.");
+
+                    Degrade();
+                    return;
+                }
 
                 foreach (var value in _values)
                     value.Initialize(type);
 
+                _type = type;
                 _isFlag = type.IsDefined(typeof(FlagsAttribute), false);
-                _zero = (Enum)Enum.ToObject(type, 0L);
+                _isInitialized = true;
 
+                return;
+            }
+
+            void Degrade()
+            {
+                _type = null;
+                _isFlag = false;
                 _isInitialized = true;
             }
         }
@@ -98,6 +119,7 @@ namespace Aspid.FastTools.Enums
         /// <summary>
         /// Returns the value mapped to <paramref name="enumValue"/>,
         /// or the configured default value if no mapping exists.
+        /// A value of a different enum type than the configured one never matches.
         /// </summary>
         /// <param name="enumValue">The enum member to look up.</param>
         /// <returns>The mapped value, or the default value when no entry matches.</returns>
@@ -109,26 +131,13 @@ namespace Aspid.FastTools.Enums
             {
                 Initialize();
 
-                if (_isFlag)
-                {
-                    // An exact match always wins over a broader "contains" match, regardless of
-                    // array order — otherwise a plain flag entry earlier in _values (e.g. from
-                    // "Populate Missing Enum Members", which orders ascending by value) would
-                    // shadow a more specific composite entry that's an exact match.
-                    foreach (var value in _values)
-                    {
-                        if (value.Key is not null && value.Key.Equals(enumValue))
-                            return value.Value;
-                    }
-                }
+                // Keys of another enum type could still collide numerically — never match them.
+                // A null lookup on an unconfigured/empty collection degrades to the default too.
+                if (enumValue is null || _type is null || enumValue.GetType() != _type)
+                    return _defaultValue;
 
-                foreach (var value in _values)
-                {
-                    if (Equals(enumValue, value.Key))
-                        return value.Value;
-                }
-
-                return _defaultValue;
+                var lookup = EnumInfo.ToInt64(enumValue);
+                return EnumValueLookup.Find(_values, lookup, _isFlag, _defaultValue);
             }
         }
 
@@ -142,7 +151,8 @@ namespace Aspid.FastTools.Enums
         /// For regular enums: <see langword="true"/> when both values are identical.<br/>
         /// For <c>[Flags]</c> enums: <see langword="true"/> when <paramref name="enumValue1"/>
         /// has all bits of <paramref name="enumValue2"/> set, with the additional rule that
-        /// the zero (<c>None</c>) value is only equal to another zero value.
+        /// the zero (<c>None</c>) value is only equal to another zero value.<br/>
+        /// Values of different enum types are never equal.
         /// </returns>
         public bool Equals(Enum enumValue1, Enum enumValue2)
         {
@@ -152,40 +162,34 @@ namespace Aspid.FastTools.Enums
             {
                 Initialize();
 
-                // Unresolved key (see EnumValue.Initialize) — never matches, instead of
-                // crashing HasFlag on a null argument.
-                if (enumValue2 is null)
+                // Unresolved key (see EnumValue.Initialize) — never matches.
+                if (enumValue1 is null || enumValue2 is null)
                     return false;
 
-                if (_isFlag)
-                {
-#if !ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED
-                    using (this.Marker().WithName("Equals.HasFlag"))
-#endif
-                    {
-                        if (!enumValue1.HasFlag(enumValue2)) return false;
-                        return enumValue1.Equals(_zero) == enumValue2.Equals(_zero);
-                    }
-                }
+                // Different enum types could still collide numerically — never equal.
+                if (enumValue1.GetType() != enumValue2.GetType())
+                    return false;
 
-                return enumValue1.Equals(enumValue2);
+                var value1 = EnumInfo.ToInt64(enumValue1);
+                var value2 = EnumInfo.ToInt64(enumValue2);
+
+                return _isFlag ? EnumValueLookup.FlagsEquals(value1, value2) : value1 == value2;
             }
         }
 
         /// <summary>
-        /// Yields the explicitly configured (key, value) pairs in serialized order.
+        /// Returns a struct enumerator over the explicitly configured (key, value) pairs in
+        /// serialized order — <c>foreach</c> binds to it directly and does not allocate.
         /// Does <b>not</b> include the default value or entries with an unresolved key.
         /// </summary>
-        public IEnumerator<KeyValuePair<Enum, TValue>> GetEnumerator()
+        public EnumValuesEnumerator<Enum, TValue> GetEnumerator()
         {
             Initialize();
-
-            foreach (var value in _values)
-            {
-                if (value.Key is null) continue;
-                yield return new KeyValuePair<Enum, TValue>(value.Key, value.Value);
-            }
+            return new EnumValuesEnumerator<Enum, TValue>(_values);
         }
+
+        IEnumerator<KeyValuePair<Enum, TValue>> IEnumerable<KeyValuePair<Enum, TValue>>.GetEnumerator() =>
+            GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() =>
             GetEnumerator();
@@ -199,5 +203,133 @@ namespace Aspid.FastTools.Enums
             _isInitialized = false;
 
         void ISerializationCallbackReceiver.OnBeforeSerialize() { }
+    }
+
+    /// <summary>
+    /// A serializable dictionary that maps members of <typeparamref name="TEnum"/> to values of
+    /// type <typeparamref name="TValue"/>. The typed counterpart of <see cref="EnumValues{TValue}"/>
+    /// for the common case where the enum type is known at compile time — no Inspector type-picker,
+    /// and lookups are compile-time safe.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type the entries are keyed by.</typeparam>
+    /// <typeparam name="TValue">The type of the value associated with each enum member.</typeparam>
+    /// <remarks>
+    /// <para>
+    /// Lookup semantics (including <c>[Flags]</c> handling) are identical to
+    /// <see cref="EnumValues{TValue}"/> — see its remarks for details. The entries are the same
+    /// <see cref="EnumValue{TValue}"/> instances, resolved once against
+    /// <typeparamref name="TEnum"/>; steady-state <see cref="GetValue"/>, <see cref="Equals"/>
+    /// and <c>foreach</c> (which binds to the struct <see cref="EnumValuesEnumerator{TKey,TValue}"/>)
+    /// never allocate.
+    /// </para>
+    /// <para>
+    /// In the editor the serialized layout is compatible with <see cref="EnumValues{TValue}"/>:
+    /// the enum type is still stored in a hidden editor-only <c>_enumType</c> field, auto-filled
+    /// with <typeparamref name="TEnum"/>'s assembly-qualified name on serialization. Switching a
+    /// field between the two variants therefore migrates existing data, as long as the configured
+    /// enum type matches <typeparamref name="TEnum"/>. Player builds strip the field — at runtime
+    /// the enum type comes from the generic argument alone.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Map a damage type to a color, with the enum fixed at compile time:
+    /// <code>
+    /// public class HitEffect : MonoBehaviour
+    /// {
+    ///     [SerializeField] private EnumValues&lt;DamageType, Color&gt; _damageColors;
+    ///
+    ///     public Color GetColor(DamageType type) =>
+    ///         _damageColors.GetValue(type);
+    /// }
+    /// </code>
+    /// </example>
+    [Serializable]
+    public sealed class EnumValues<TEnum, TValue> : IEnumerable<KeyValuePair<TEnum, TValue>>, ISerializationCallbackReceiver
+        where TEnum : struct, Enum
+    {
+#if UNITY_EDITOR
+        // Editor-only layout mirror of EnumValues<TValue>._enumType, auto-filled from TEnum on
+        // serialization — keeps the two variants layout-compatible in the editor (where variant
+        // switching happens) and feeds the per-element editor drawers. Never read at runtime
+        // (the enum type comes from the generic argument), so it is stripped from player builds.
+#pragma warning disable CS0414 // Field is assigned but its value is never used — read by the editor drawers via serialization.
+        [SerializeField] private string? _enumType;
+#pragma warning restore CS0414
+#endif
+
+#pragma warning disable CS8618
+        [SerializeField] private TValue _defaultValue;
+        [SerializeField] private EnumValue<TValue>[] _values;
+#pragma warning restore CS8618
+
+        private bool _isInitialized;
+
+        private void Initialize()
+        {
+            if (_isInitialized) return;
+
+#if !ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED
+            using (this.Marker())
+#endif
+            {
+                _values ??= Array.Empty<EnumValue<TValue>>();
+
+                foreach (var value in _values)
+                    value.Initialize(typeof(TEnum));
+
+                _isInitialized = true;
+            }
+        }
+
+        /// <inheritdoc cref="EnumValues{TValue}.GetValue"/>
+        public TValue GetValue(TEnum enumValue)
+        {
+#if !ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED
+            using (this.Marker())
+#endif
+            {
+                Initialize();
+
+                var lookup = EnumInfo<TEnum>.ToInt64(enumValue);
+                return EnumValueLookup.Find(_values, lookup, EnumInfo<TEnum>.IsFlags, _defaultValue);
+            }
+        }
+
+        /// <inheritdoc cref="EnumValues{TValue}.Equals(Enum,Enum)"/>
+        public bool Equals(TEnum enumValue1, TEnum enumValue2)
+        {
+            var value1 = EnumInfo<TEnum>.ToInt64(enumValue1);
+            var value2 = EnumInfo<TEnum>.ToInt64(enumValue2);
+
+            return EnumInfo<TEnum>.IsFlags ? EnumValueLookup.FlagsEquals(value1, value2) : value1 == value2;
+        }
+
+        /// <inheritdoc cref="EnumValues{TValue}.GetEnumerator"/>
+        public EnumValuesEnumerator<TEnum, TValue> GetEnumerator()
+        {
+            Initialize();
+            return new EnumValuesEnumerator<TEnum, TValue>(_values);
+        }
+
+        IEnumerator<KeyValuePair<TEnum, TValue>> IEnumerable<KeyValuePair<TEnum, TValue>>.GetEnumerator() =>
+            GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+
+        /// <summary>
+        /// Invalidates the resolved-key cache so the next lookup re-resolves it — otherwise
+        /// entries added via an Inspector edit (e.g. "Populate Missing Enum Members") would stay
+        /// unresolved.
+        /// </summary>
+        void ISerializationCallbackReceiver.OnAfterDeserialize() =>
+            _isInitialized = false;
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        {
+#if UNITY_EDITOR
+            _enumType = typeof(TEnum).AssemblyQualifiedName;
+#endif
+        }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+// ReSharper disable PossibleNullReferenceException
+// ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+namespace Aspid.FastTools.Enums
+{
+    /// <summary>
+    /// Allocation-free enumerator over the resolved entries of an <see cref="EnumValues{TValue}"/>
+    /// (<typeparamref name="TKey"/> = <see cref="Enum"/>) or an <see cref="EnumValues{TEnum,TValue}"/>
+    /// (<typeparamref name="TKey"/> = the enum type). Boxed only when consumed through the
+    /// <see cref="IEnumerable{T}"/> interface (e.g. LINQ).
+    /// </summary>
+    /// <typeparam name="TKey">The key type the entries are yielded as.</typeparam>
+    /// <typeparam name="TValue">The type of the value associated with each enum member.</typeparam>
+    public struct EnumValuesEnumerator<TKey, TValue> : IEnumerator<KeyValuePair<TKey, TValue>>
+    {
+        private int _index;
+        private KeyValuePair<TKey, TValue> _current;
+        private readonly EnumValue<TValue>[] _values;
+
+        internal EnumValuesEnumerator(EnumValue<TValue>[] values)
+        {
+            _index = 0;
+            _values = values;
+            _current = default;
+        }
+
+        public readonly KeyValuePair<TKey, TValue> Current => _current;
+
+        private readonly object IEnumerator.Current => _current;
+
+        public bool MoveNext()
+        {
+            while (_index < _values.Length)
+            {
+                var value = _values[_index++];
+                if (!value.IsResolved) continue;
+
+                // For a value-type TKey this unboxes the stored key, copying it out of the
+                // existing box; for TKey = Enum it is a plain reference cast — no allocation.
+                _current = new KeyValuePair<TKey, TValue>((TKey)(object)value.Key, value.Value);
+                return true;
+            }
+
+            return false;
+        }
+
+        void IEnumerator.Reset()
+        {
+            _current = default;
+            _index = 0;
+        }
+
+        readonly void IDisposable.Dispose() { }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs
@@ -22,16 +22,16 @@ namespace Aspid.FastTools.Enums
         private KeyValuePair<TKey, TValue> _current;
         private readonly EnumValue<TValue>[] _values;
 
+        readonly object IEnumerator.Current => _current;
+
+        public readonly KeyValuePair<TKey, TValue> Current => _current;
+
         internal EnumValuesEnumerator(EnumValue<TValue>[] values)
         {
             _index = 0;
             _values = values;
             _current = default;
         }
-
-        public readonly KeyValuePair<TKey, TValue> Current => _current;
-
-        private readonly object IEnumerator.Current => _current;
 
         public bool MoveNext()
         {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValuesEnumerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0197281e468242079ff8d6e031e8d5f9

--- a/README.md
+++ b/README.md
@@ -524,6 +524,27 @@ In the Inspector, select the enum type in the `EnumValues` header, then assign a
 
 > The complete sample — `DamageDealer` / `DamageType` / `StatusEffect` — ships in the `EnumValues` sample (Package Manager → Aspid.FastTools → Samples).
 
+### EnumValues\<TEnum, TValue\>
+
+The typed counterpart of `EnumValues<TValue>` for the common case where the enum type is already known in code. The enum is fixed by the generic argument, so the Inspector shows no type picker and lookups are compile-time safe. Lookups are also boxing-free — keys are compared as cached numeric values — and `foreach` over either variant binds to a struct enumerator, so iteration does not allocate. Implements `IEnumerable<KeyValuePair<TEnum, TValue>>`.
+
+| Member | Description |
+|--------|-------------|
+| `TValue GetValue(TEnum enumValue)` | Returns the mapped value, or `_defaultValue` if not found |
+| `bool Equals(TEnum, TEnum)` | Equality check with proper `[Flags]` support |
+
+```csharp
+public sealed class HitEffect : MonoBehaviour
+{
+    // No type picker in the Inspector — the enum is fixed to DamageType.
+    [SerializeField] private EnumValues<DamageType, Color> _damageColors;
+
+    public Color GetColor(DamageType type) => _damageColors.GetValue(type);
+}
+```
+
+Lookup semantics (including `[Flags]` handling) are identical to `EnumValues<TValue>`, and the serialized layout is compatible — switching a field between the two variants keeps the existing data as long as the enum type matches.
+
 ---
 
 ## ID System (Beta)

--- a/README_RU.md
+++ b/README_RU.md
@@ -526,6 +526,27 @@ public sealed class DamageDealer : MonoBehaviour
 
 > Полный сэмпл — `DamageDealer` / `DamageType` / `StatusEffect` — поставляется в сэмпле `EnumValues` (Package Manager → Aspid.FastTools → Samples).
 
+### EnumValues\<TEnum, TValue\>
+
+Типизированный вариант `EnumValues<TValue>` для частого случая, когда тип перечисления уже известен в коде. Тип фиксируется generic-аргументом, поэтому в Inspector нет выбора типа, а обращения проверяются на этапе компиляции. Поиск при этом не использует boxing — ключи сравниваются как закэшированные числовые значения, — а `foreach` по обоим вариантам использует struct-энумератор и не аллоцирует. Реализует `IEnumerable<KeyValuePair<TEnum, TValue>>`.
+
+| Член | Описание |
+|------|----------|
+| `TValue GetValue(TEnum enumValue)` | Возвращает сопоставленное значение или `_defaultValue`, если не найдено |
+| `bool Equals(TEnum, TEnum)` | Проверка равенства с корректной поддержкой `[Flags]` |
+
+```csharp
+public sealed class HitEffect : MonoBehaviour
+{
+    // В Inspector нет выбора типа — перечисление зафиксировано как DamageType.
+    [SerializeField] private EnumValues<DamageType, Color> _damageColors;
+
+    public Color GetColor(DamageType type) => _damageColors.GetValue(type);
+}
+```
+
+Семантика поиска (включая обработку `[Flags]`) идентична `EnumValues<TValue>`, а сериализованный формат совместим — смена типа поля между двумя вариантами сохраняет существующие данные, пока тип перечисления совпадает.
+
 ---
 
 ## ID System (Beta)

--- a/docs/QA-CHECKLIST.md
+++ b/docs/QA-CHECKLIST.md
@@ -110,6 +110,7 @@
 ## 11. Remaining package features
 
 - [ ] **EnumValues\<TValue\>**: plain and `[Flags]` enums, the key does not reset while editing, adding/removing entries.
+- [ ] **EnumValues\<TEnum, TValue\>**: no type-picker row in the Inspector, rows render typed enum fields immediately, "Populate Missing Enum Members" works, switching a field from `EnumValues<TValue>` (same enum) keeps the serialized data.
 - [ ] **Id Registries**: creation via `Assets → Create → Aspid → Id Registry`, `TryGetId`/`TryGetName`/`Contains`, an IId struct binds to exactly one registry (IdRegistryResolver), editor-side validation and mutation.
 - [ ] **SerializedProperty Extensions**: `.SetValue()`, `.Apply()`, chained calls, reflection helpers.
 - [ ] **VisualElement Extensions**: spot-check the fluent API (layout/style/borders/callbacks/USS/child) + the Math satellite (`float2/3/4` INotifyValueChanged) with Mathematics installed.

--- a/docs/QA-CHECKLIST_RU.md
+++ b/docs/QA-CHECKLIST_RU.md
@@ -110,6 +110,7 @@
 ## 11. Остальные фичи пакета
 
 - [ ] **EnumValues\<TValue\>**: обычные и `[Flags]` enum, ключ не сбрасывается при редактировании, добавление/удаление записей.
+- [ ] **EnumValues\<TEnum, TValue\>**: в инспекторе нет строки выбора типа, строки сразу рендерят типизированные enum-поля, «Populate Missing Enum Members» работает, смена типа поля с `EnumValues<TValue>` (тот же enum) сохраняет сериализованные данные.
 - [ ] **Id Registries**: создание через `Assets → Create → Aspid → Id Registry`, `TryGetId`/`TryGetName`/`Contains`, привязка IId-структа ровно к одному реестру (IdRegistryResolver), валидация и мутации в редакторе.
 - [ ] **SerializedProperty Extensions**: `.SetValue()`, `.Apply()`, chain-вызовы, reflection-хелперы.
 - [ ] **VisualElement Extensions**: выборочная проверка fluent API (layout/style/borders/callbacks/USS/child) + Math-satellite (`float2/3/4` INotifyValueChanged) при установленном Mathematics.


### PR DESCRIPTION
## Summary

- Add `EnumValues<TEnum, TValue>` for enums known at compile time — no Inspector type picker, rows render typed enum fields immediately; the serialized layout is shared with `EnumValues<TValue>`, so switching a field between the two variants keeps its data.
- Extract shared internals into `EnumInfo` (Int64 conversion / flags metadata), `EnumValueLookup` (exact-match-first flags lookup), and `EnumValuesEnumerator` (struct enumerator).
- Harden `EnumValues<TValue>`: an unresolvable enum type now degrades to the default value instead of throwing, and values of a foreign enum type never match.
- Update the `EnumValue`/`EnumValues` property drawers for the typed variant.
- Add editor tests (`EnumValuesTests`), QA-checklist items (EN/RU), and document the typed variant in all 4 READMEs.

## Notes for review

- The typed variant intentionally reuses `EnumValue<TValue>[]` as its backing storage — worth eyes on the serialization-compat assumptions in `EnumValues.cs`.
- `EnumValuesEnumerator.cs.meta` was generated manually (Unity hadn't produced it yet); GUID is fresh and unique.

## Linked issues

Closes ASP-47