### PR TITLE
fix(enums): degrade gracefully when the serialized enum type resolves to a non-enum

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Enums/EnumValuesTests.cs
@@ -56,7 +56,7 @@ namespace Aspid.FastTools.Enums.Tests
     /// Coverage for <see cref="EnumValues{TValue}"/> and <see cref="EnumValues{TEnum,TValue}"/>:
     /// lookup semantics (regular + <c>[Flags]</c>), the typed variant's auto-stamped
     /// <c>_enumType</c>, the serialized-layout compatibility between the two variants, and the
-    /// degrade paths (unconfigured/unresolvable enum type, unparseable entry keys).
+    /// degrade paths (unconfigured/unresolvable/non-enum enum type, unparseable entry keys).
     /// All data is written through <see cref="SerializedObject"/> so the real
     /// serialize/deserialize path (including <see cref="ISerializationCallbackReceiver"/>) runs.
     /// </summary>
@@ -403,6 +403,37 @@ namespace Aspid.FastTools.Enums.Tests
 
             LogAssert.Expect(LogType.Error, new Regex("Couldn't resolve enum type"));
             Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Untyped_NonEnumType_LogsErrorAndReturnsDefault()
+        {
+            // A type that resolves but is not an enum (e.g. an enum refactored into a
+            // class/struct with the same name) must degrade like an unresolvable one
+            // instead of throwing from Enum.TryParse on every lookup.
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 42, typeof(string).AssemblyQualifiedName);
+
+            LogAssert.Expect(LogType.Error, new Regex("is not an enum"));
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+        }
+
+        [Test]
+        public void Untyped_EnumTypeClearedAfterResolution_DegradesAndYieldsNothing()
+        {
+            SetDefaultValue("_untyped", -1);
+            AddEntry("_untyped", nameof(Season.Winter), 1, typeof(Season).AssemblyQualifiedName);
+
+            // Resolve the keys once, then clear the type — degrading must reset the
+            // previously resolved keys instead of letting them keep matching lookups
+            // and being yielded by the enumerator.
+            Assert.AreEqual(1, _host.Untyped.GetValue(Season.Winter));
+            SetEnumType("_untyped", string.Empty);
+
+            LogAssert.Expect(LogType.Warning, new Regex("No enum type configured"));
+
+            Assert.AreEqual(-1, _host.Untyped.GetValue(Season.Winter));
+            Assert.AreEqual(0, _host.Untyped.ToArray().Length);
         }
 
         [Test]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs
@@ -72,7 +72,10 @@ namespace Aspid.FastTools.Enums.Editors
                 keyEnumField.SetDisplay(DisplayStyle.None);
                 keyEnumFlagField.SetDisplay(DisplayStyle.None);
 
-                if (enumType is null)
+                // A resolvable non-enum type (e.g. an enum refactored into a class/struct with
+                // the same name) would make Enum.TryParse/Enum.GetValues below throw — fall back
+                // to the raw string field, same as EnumValuesPropertyDrawerHelper's guard.
+                if (enumType is null || !enumType.IsEnum)
                 {
                     keyField.SetDisplay(DisplayStyle.Flex);
                     return;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValue.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValue.cs
@@ -69,13 +69,22 @@ namespace Aspid.FastTools.Enums
                 {
                     // A stale Key from a previous type would silently keep matching lookups,
                     // so reset the entry instead of leaving it as-is.
-                    Key = null;
-                    NumericKey = 0L;
+                    Reset();
 
                     Debug.LogError($"[{nameof(EnumValue<TValue>)}] [{nameof(Initialize)}] " +
                         $"Couldn't parse key '{_key}' to Enum '{type.FullName}'");
                 }
             }
+        }
+
+        /// <summary>
+        /// Clears the resolved key so the entry no longer matches lookups and is skipped by
+        /// enumeration — used when the owning collection degrades to an unconfigured state.
+        /// </summary>
+        public void Reset()
+        {
+            Key = null;
+            NumericKey = 0L;
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
@@ -99,6 +99,18 @@ namespace Aspid.FastTools.Enums
                     return;
                 }
 
+                // Resolvable but not an enum (e.g. the type was refactored into a class/struct
+                // keeping the same name) — degrade the same way instead of throwing from
+                // Enum.TryParse on every lookup.
+                if (!type.IsEnum)
+                {
+                    Debug.LogError($"[{nameof(EnumValues<TValue>)}] [{nameof(Initialize)}] " +
+                        $"Type '{_enumType}' is not an enum — GetValue will always return the default value.");
+
+                    Degrade();
+                    return;
+                }
+
                 foreach (var value in _values)
                     value.Initialize(type);
 
@@ -110,6 +122,12 @@ namespace Aspid.FastTools.Enums
 
             void Degrade()
             {
+                // Reset the entries too — keys resolved by a previous initialization would
+                // otherwise keep matching lookups and being yielded by GetEnumerator even
+                // though the type is no longer configured.
+                foreach (var value in _values)
+                    value.Reset();
+
                 _type = null;
                 _isFlag = false;
                 _isInitialized = true;


### PR DESCRIPTION
## Summary

- `EnumValues<TValue>.Initialize` now degrades (error log + default-value lookups) when the serialized `_enumType` resolves to a **non-enum** type, instead of letting `Enum.TryParse(Type, …)` throw `ArgumentException` on every `GetValue`/`Equals`/`GetEnumerator` call — mirroring the existing guard in `EnumValuesPropertyDrawerHelper`.
- `Degrade()` now resets each entry's resolved key (new `EnumValue<TValue>.Reset()`), so after the enum type is cleared `GetEnumerator` no longer yields stale entries resolved against the previous type.
- `EnumValuePropertyDrawer.UpdateValue` gets the same `IsEnum` guard and falls back to the raw string key field for a non-enum type instead of breaking the inspector row.
- Regression tests added to `EnumValuesTests` for both runtime degrade paths.

### Audit findings fixed

| Finding | What was wrong | What was done |
|---|---|---|
| `Unity/Runtime/Enums/EnumValues.cs:102` | `Initialize` never checked `type.IsEnum`; a resolvable non-enum type (e.g. an enum refactored into a class/struct with the same name) fell through to `EnumValue.Initialize` → `Enum.TryParse(Type, …)` throws `ArgumentException` on every lookup, defeating the documented degrade design | Added an `IsEnum` guard that logs an error and calls `Degrade()`, matching the unresolvable-type path |
| `Unity/Runtime/Enums/EnumValues.cs:111` | `Degrade()` reset `_type`/`_isFlag` but left each entry's previously resolved `Key`/`NumericKey` intact, so `GetEnumerator` (no `_type is null` guard) kept yielding stale-resolved entries after the enum type was cleared | `Degrade()` now resets every entry via the new `EnumValue<TValue>.Reset()` (also reused in `EnumValue.Initialize`'s parse-failure branch) |
| `Unity/Editor/Scripts/Enums/EnumValuePropertyDrawer.cs:81` | `UpdateValue` only checked `enumType is null` before `Enum.TryParse`/`Enum.GetValues`, which throw `ArgumentException` for a non-enum type — inconsistent with `EnumValuesPropertyDrawerHelper`'s `!type.IsEnum` guard | Guard extended to `enumType is null || !enumType.IsEnum`, falling back to the raw string field |

No findings were skipped.

## Notes for review

- Tests: `Untyped_NonEnumType_LogsErrorAndReturnsDefault` and `Untyped_EnumTypeClearedAfterResolution_DegradesAndYieldsNothing` in `Tests/Editor/Enums/EnumValuesTests.cs` cover the two runtime findings; run via Unity Test Runner.
- `EnumValue<TValue>.Reset()` is `public` on an `internal` class, consistent with the class's other members managed by `EnumValues`.
