### PR TITLE
fix(types): interface-only filtering, TypeField refresh on external changes

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/ComponentTypeSelectorPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/ComponentTypeSelectorPropertyDrawer.cs
@@ -46,9 +46,6 @@ namespace Aspid.FastTools.Types.Editors
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
             var currentType = property.serializedObject.targetObject.GetType();
-
-            // The callback fires once the element may have outlived its source editor — closing over the
-            // drawer-time property would read a disposed SerializedObject (the Persistent() contract).
             var persistent = property.Persistent();
 
             var field = new InspectorTypeField(label: null, defaultValue: currentType)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/ComponentTypeSelectorPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/ComponentTypeSelectorPropertyDrawer.cs
@@ -21,6 +21,7 @@ namespace Aspid.FastTools.Types.Editors
             if (EditorGUI.DropdownButton(dropdownRect,
                     new GUIContent(TypeSelectorHelpers.GetTypeSelectorTitle(currentType)), FocusType.Passive))
             {
+                var persistent = property.Persistent();
                 var filter = new TypeSelectorFilter
                 {
                     Types = new[] { fieldInfo.DeclaringType },
@@ -31,7 +32,7 @@ namespace Aspid.FastTools.Types.Editors
                     filter,
                     currentType.AssemblyQualifiedName,
                     onSelected: aqn => ReplaceComponentScript(
-                        property,
+                        persistent,
                         currentType,
                         string.IsNullOrEmpty(aqn) ? null : Type.GetType(aqn, throwOnError: false)));
             }
@@ -46,17 +47,23 @@ namespace Aspid.FastTools.Types.Editors
         {
             var currentType = property.serializedObject.targetObject.GetType();
 
+            // The callback fires once the element may have outlived its source editor — closing over the
+            // drawer-time property would read a disposed SerializedObject (the Persistent() contract).
+            var persistent = property.Persistent();
+
             var field = new InspectorTypeField(label: null, defaultValue: currentType)
             {
                 Types = new[] { fieldInfo.DeclaringType },
             };
 
             field.RegisterValueChangedCallback(evt =>
-                ReplaceComponentScript(property, currentType, evt.newValue));
+                ReplaceComponentScript(persistent, currentType, evt.newValue));
 
             return field;
         }
 
+        /// <param name="property">Must own its <see cref="SerializedObject"/> (see <c>Persistent()</c>) —
+        /// it is read one <see cref="EditorApplication.delayCall"/> tick later.</param>
         private static void ReplaceComponentScript(SerializedProperty property, Type oldType, Type newType)
         {
             if (newType is null || newType == oldType) return;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeInfo.cs
@@ -103,8 +103,6 @@ namespace Aspid.FastTools.Types.Editors
                     !t.IsDefined(typeof(CompilerGeneratedAttribute), false) &&
                     !t.Name.Contains("<") &&
                     !t.Name.Contains(">") &&
-                    // Interfaces are IsAbstract in reflection, so the Abstract clause must let them through
-                    // for the Interface clause to decide their fate — otherwise TypeAllow.Interface alone lists nothing.
                     (allow.HasFlag(TypeAllow.Abstract) || t.IsInterface || !t.IsAbstract) &&
                     (allow.HasFlag(TypeAllow.Interface) || !t.IsInterface) &&
                     (filter is null || filter(t)))

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeInfo.cs
@@ -103,7 +103,9 @@ namespace Aspid.FastTools.Types.Editors
                     !t.IsDefined(typeof(CompilerGeneratedAttribute), false) &&
                     !t.Name.Contains("<") &&
                     !t.Name.Contains(">") &&
-                    (allow.HasFlag(TypeAllow.Abstract) || !t.IsAbstract) &&
+                    // Interfaces are IsAbstract in reflection, so the Abstract clause must let them through
+                    // for the Interface clause to decide their fate — otherwise TypeAllow.Interface alone lists nothing.
+                    (allow.HasFlag(TypeAllow.Abstract) || t.IsInterface || !t.IsAbstract) &&
                     (allow.HasFlag(TypeAllow.Interface) || !t.IsInterface) &&
                     (filter is null || filter(t)))
                 .Select(type => new TypeInfo(type)));

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/VisualElements/TypeField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/VisualElements/TypeField.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEditor;
 using UnityEngine;
+using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
 using Aspid.FastTools.UIElements;
@@ -70,6 +71,11 @@ namespace Aspid.FastTools.Types.Editors
         {
             _property = property.Persistent();
             SetValueFromAssemblyQualifiedNameWithoutNotify(_property.stringValue);
+
+            // Undo/redo, revert-to-prefab and scripted edits rewrite the backing string outside this field;
+            // the tracked callback hands over a fresh property each tick (the Persistent() contract).
+            this.TrackPropertyValue(_property, current =>
+                SetValueFromAssemblyQualifiedNameWithoutNotify(current.stringValue));
         }
 
         public TypeField(string label, Type defaultValue = null)
@@ -165,7 +171,8 @@ namespace Aspid.FastTools.Types.Editors
                         ? null
                         : Type.GetType(assemblyQualifiedName, throwOnError: false));
 
-                    _property?.SetStringAndApply(assemblyQualifiedName);
+                    // <None> arrives as null (the TypeSelectorWindow contract); store string.Empty like the IMGUI path.
+                    _property?.SetStringAndApply(assemblyQualifiedName ?? string.Empty);
                 });
 
             evt.StopPropagation();


### PR DESCRIPTION
## Summary

Fixes four verified audit findings in the TypeSelector editor stack:

| File | Was wrong | Fix |
|---|---|---|
| `Unity/Editor/Scripts/Types/Selectors/TypeInfo.cs:106` | `TypeAllow.Interface` alone never listed interfaces — every CLR interface has `IsAbstract == true`, so the Abstract clause rejected them before the Interface clause could admit them (contradicting the `TypeAllow.Interface` XML doc) | Abstract clause now lets interfaces through (`allow.HasFlag(TypeAllow.Abstract) \|\| t.IsInterface \|\| !t.IsAbstract`) so the Interface clause decides their fate |
| `Unity/Editor/Scripts/Types/VisualElements/TypeField.cs:72` | Property-bound `TypeField` read `stringValue` once in the constructor and never refreshed — undo/redo, revert-to-prefab and scripted edits left the field displaying a stale type | Added `TrackPropertyValue(_property, …)` that pushes the fresh `stringValue` back via `SetValueFromAssemblyQualifiedNameWithoutNotify` |
| `Unity/Editor/Scripts/Types/VisualElements/TypeField.cs:168` | Picking `<None>` wrote `null` into `stringValue` while the sibling IMGUI path normalizes to `string.Empty` | `SetStringAndApply(assemblyQualifiedName ?? string.Empty)` — stored value shape now identical across the two drawers |
| `Unity/Editor/Scripts/Types/Drawers/ComponentTypeSelectorPropertyDrawer.cs:72` | `ReplaceComponentScript` deferred via `EditorApplication.delayCall` closing over the drawer-time `SerializedProperty` on both the IMGUI and UIToolkit paths — reading a disposed `SerializedObject` once the source editor is gone (the repo's `Persistent()` contract) | Both paths now capture `property.Persistent()` before handing the property to a deferred callback; `ReplaceComponentScript` documents the contract |

## Notes for review

- The `ComponentTypeSelectorPropertyDrawer` finding was flagged PLAUSIBLE by the audit; re-verified before fixing — the UIToolkit path (`RegisterValueChangedCallback` on a field that can outlive its source editor) plus the extra `delayCall` tick match exactly the capture shapes `Persistent()` exists for, and every sibling drawer (`TypeIMGUIPropertyDrawer.cs:76`, `TypeField.cs:71`, `TypeUIToolkitPropertyDrawer.cs:36-39`) already guards them.
- `TrackPropertyValue` also fires after the field's own dropdown write; the resulting re-sync through `SetValueFromAssemblyQualifiedNameWithoutNotify` is idempotent and raises no change event.
