### PR TITLE
fix(types): invalidate SerializableType's resolved-type cache on re-deserialization

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Enums/EnumValues.cs
@@ -38,6 +38,10 @@ namespace Aspid.FastTools.Enums
     /// Iteration via <see cref="GetEnumerator"/> yields only the explicitly configured entries and
     /// does <b>not</b> include the default value.
     /// </para>
+    /// <para>
+    /// Internal hot paths are wrapped in profiler markers; define the
+    /// <c>ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED</c> scripting symbol to compile them out.
+    /// </para>
     /// </remarks>
     /// <example>
     /// Map a damage type to a color:
@@ -229,6 +233,10 @@ namespace Aspid.FastTools.Enums
     /// field between the two variants therefore migrates existing data, as long as the configured
     /// enum type matches <typeparamref name="TEnum"/>. Player builds strip the field — at runtime
     /// the enum type comes from the generic argument alone.
+    /// </para>
+    /// <para>
+    /// Internal hot paths are wrapped in profiler markers; define the
+    /// <c>ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED</c> scripting symbol to compile them out.
     /// </para>
     /// </remarks>
     /// <example>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
@@ -9,6 +9,10 @@ namespace Aspid.FastTools.Types
     /// A wrapper around <see cref="System.Type"/> that supports Unity Inspector serialization.
     /// The type is stored by its <c>AssemblyQualifiedName</c> and resolved lazily on first access.
     /// </summary>
+    /// <remarks>
+    /// Type resolution is wrapped in a profiler marker; define the
+    /// <c>ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED</c> scripting symbol to compile it out.
+    /// </remarks>
     /// <example>
     /// Declare a serializable type field and use the resolved type at runtime:
     /// <code>
@@ -82,6 +86,10 @@ namespace Aspid.FastTools.Types
     /// constrained to types assignable to <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">The base constraint type. Only subtypes will be offered in the editor picker.</typeparam>
+    /// <remarks>
+    /// Type resolution is wrapped in a profiler marker; define the
+    /// <c>ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED</c> scripting symbol to compile it out.
+    /// </remarks>
     /// <example>
     /// Constrain the picker to <c>MonoBehaviour</c> subtypes only:
     /// <code>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
@@ -70,11 +70,6 @@ namespace Aspid.FastTools.Types
         /// </summary>
         public static implicit operator Type?(SerializableType type) => type.Type;
 
-        /// <summary>
-        /// Invalidates the resolved-type cache so the next access re-resolves it — otherwise
-        /// an Inspector edit that changes the stored name (apply during play mode, undo, preset)
-        /// would keep returning the previously resolved type.
-        /// </summary>
         void ISerializationCallbackReceiver.OnAfterDeserialize() =>
             _type = null;
 
@@ -146,11 +141,6 @@ namespace Aspid.FastTools.Types
         /// </summary>
         public static implicit operator Type?(SerializableType<T> type) => type.Type;
 
-        /// <summary>
-        /// Invalidates the resolved-type cache so the next access re-resolves it — otherwise
-        /// an Inspector edit that changes the stored name (apply during play mode, undo, preset)
-        /// would keep returning the previously resolved type.
-        /// </summary>
         void ISerializationCallbackReceiver.OnAfterDeserialize() =>
             _type = null;
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
@@ -26,7 +26,7 @@ namespace Aspid.FastTools.Types
     /// </code>
     /// </example>
     [Serializable]
-    public sealed class SerializableType
+    public sealed class SerializableType : ISerializationCallbackReceiver
     {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         [SerializeField] private string _assemblyQualifiedName;
@@ -65,6 +65,16 @@ namespace Aspid.FastTools.Types
         /// Implicitly converts to <see cref="System.Type"/>. Equivalent to accessing <see cref="Type"/>.
         /// </summary>
         public static implicit operator Type?(SerializableType type) => type.Type;
+
+        /// <summary>
+        /// Invalidates the resolved-type cache so the next access re-resolves it — otherwise
+        /// an Inspector edit that changes the stored name (apply during play mode, undo, preset)
+        /// would keep returning the previously resolved type.
+        /// </summary>
+        void ISerializationCallbackReceiver.OnAfterDeserialize() =>
+            _type = null;
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
     }
 
     /// <summary>
@@ -89,7 +99,7 @@ namespace Aspid.FastTools.Types
     /// </code>
     /// </example>
     [Serializable]
-    public sealed class SerializableType<T>
+    public sealed class SerializableType<T> : ISerializationCallbackReceiver
     {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         [SerializeField] private string _assemblyQualifiedName;
@@ -127,5 +137,15 @@ namespace Aspid.FastTools.Types
         /// Implicitly converts to <see cref="System.Type"/>. Equivalent to accessing <see cref="Type"/>.
         /// </summary>
         public static implicit operator Type?(SerializableType<T> type) => type.Type;
+
+        /// <summary>
+        /// Invalidates the resolved-type cache so the next access re-resolves it — otherwise
+        /// an Inspector edit that changes the stored name (apply during play mode, undo, preset)
+        /// would keep returning the previously resolved type.
+        /// </summary>
+        void ISerializationCallbackReceiver.OnAfterDeserialize() =>
+            _type = null;
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
     }
 }


### PR DESCRIPTION
## Summary

- `SerializableType` and `SerializableType<T>` now implement `ISerializationCallbackReceiver` and reset the cached resolved `Type` in `OnAfterDeserialize` (`Unity/Runtime/Types/SerializableType.cs:57` / `:119`) — previously an Inspector edit that changed `_assemblyQualifiedName` on a live instance (apply during play mode, undo, preset apply) kept serving the stale cached `Type` until domain reload, mirroring the invalidation `EnumValues` already does.
- Documented the user-facing opt-out define `ASPID_FAST_TOOLS_UNITY_PROFILER_DISABLED` (`SerializableType.cs:50`) in the XML docs of every public type that consumes it (`SerializableType`, `SerializableType<T>`, `EnumValues<TValue>`, `EnumValues<TEnum,TValue>`) — it gates profiler-marker code at 8 runtime sites but appeared in no user-visible documentation.

## Notes for review

- The define is deliberately **not** renamed to the `ASPID_FASTTOOLS_*` spelling used by `ASPID_FASTTOOLS_UNITY_MATHEMATICS_INTEGRATION` — renaming would silently break projects that already define it.
- `OnBeforeSerialize` is intentionally empty, same shape as `EnumValues`.
