### PR TITLE
fix(ids): id-assignment guards, inherited-field index, IMGUI warning layout

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Drawers/IdStructDrawerHelper.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Drawers/IdStructDrawerHelper.cs
@@ -36,7 +36,6 @@ namespace Aspid.FastTools.Ids.Editors
             if (registryName == ctx.StringProperty.stringValue) return;
 
             ctx.StringProperty.SetStringAndApply(registryName);
-            ctx.Property.ApplyModifiedProperties();
         }
         
         public static void ApplySelection(
@@ -63,7 +62,6 @@ namespace Aspid.FastTools.Ids.Editors
         {
             ctx.IntProperty.SetIntAndApply(id);
             ctx.StringProperty.SetStringAndApply(nameId);
-            ctx.Property.ApplyModifiedPropertiesWithoutUndo();
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Drawers/IdStructIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Drawers/IdStructIMGUIPropertyDrawer.cs
@@ -62,7 +62,8 @@ namespace Aspid.FastTools.Ids.Editors
             if (!isUnique) return;
             if (IsUniqueFor(ctx)) return;
 
-            var warningY = position.y + position.height + EditorGUIUtility.standardVerticalSpacing;
+            // position spans the full reserved height (field line + warning line) — anchor below the field line.
+            var warningY = position.y + EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
             var warningRect = new Rect(position.x, warningY, position.width, EditorGUIUtility.singleLineHeight);
            
             EditorGUI.HelpBox(warningRect, "ID is not unique among assets of this type", MessageType.Warning);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Registries/CleanUpSummary.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Registries/CleanUpSummary.cs
@@ -20,10 +20,10 @@ namespace Aspid.FastTools.Ids.Editors
         public string ToShortLabel()
         {
             var parts = new List<string>();
-            if (DuplicateCount > 0) parts.Add($"{DuplicateCount} duplicates");
+            if (DuplicateCount > 0) parts.Add($"{DuplicateCount} duplicate" + (DuplicateCount is 1 ? string.Empty : "s"));
             if (EmptyCount > 0) parts.Add($"{EmptyCount} empty name" + (EmptyCount is 1 ? string.Empty : "s"));
-            
-            return $"⚠ {Total} invalid enter{(Total == 1 ? "y" : "ies")} ({string.Join(", ", parts)})";
+
+            return $"⚠ {Total} invalid entr{(Total == 1 ? "y" : "ies")} ({string.Join(", ", parts)})";
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Registries/RegistryEditorCore.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Registries/RegistryEditorCore.cs
@@ -65,7 +65,7 @@ namespace Aspid.FastTools.Ids.Editors
             var root = new VisualElement()
                 .AddAspidThemeStyleSheets()
                 .AddStyleSheetsFromResource(Constants.Registry.StyleSheetPath)
-                .AddClass("aspid-fasttools-inspector-container");
+                .AddClass(AspidStyles.InspectorStyleClass);
 
             root.Add(new AspidInspectorHeader(_registry.name + " (Beta)", _registry)
             {
@@ -356,9 +356,9 @@ namespace Aspid.FastTools.Ids.Editors
                     $"Reusing ID {value} may silently remap references: assets that previously pointed to this ID will appear bound to the next name you create. Proceed only if you know these IDs are unused.");
             }
 
-            return value < 1
-                ? NextIdWarning.Hidden("Next ID must be ≥ 1.")
-                : NextIdWarning.Hidden();
+            // A hidden icon is display:none, so it can't carry a tooltip —
+            // the "must be ≥ 1" message is surfaced by ValidateAddRow instead.
+            return NextIdWarning.Hidden();
         }
 
         private bool NextIdCollides(int nextId)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Selectors/IdSelectorWindow.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/Selectors/IdSelectorWindow.cs
@@ -146,14 +146,26 @@ namespace Aspid.FastTools.Ids.Editors
             var registry = IdRegistryResolver.GetOrCreate(_idType);
             if (!IdRegistryValidator.IsValidName(nameId, registry.Contains, out _)) return;
 
-            Undo.RegisterCompleteObjectUndo(registry, "Add string id");
-
             var serializedObject = new SerializedObject(registry);
             var idsProp = serializedObject.FindProperty("_ids");
             var namesProp = serializedObject.FindProperty("_names");
             var nextIdProp = serializedObject.FindProperty("_nextId");
 
+            // Same guards as RegistryEditorCore.ValidateAddRow — stable ids must never be reused.
             var id = nextIdProp.intValue;
+            if (id < 1)
+            {
+                ShowError("Next ID must be ≥ 1 — change it in the registry inspector before adding.");
+                return;
+            }
+
+            if (NextIdCollides(idsProp, id))
+            {
+                ShowError($"Next ID {id} is already used — change it in the registry inspector before adding.");
+                return;
+            }
+
+            Undo.RegisterCompleteObjectUndo(registry, "Add string id");
             nextIdProp.intValue = id + 1;
 
             var newIndex = idsProp.arraySize;
@@ -169,6 +181,21 @@ namespace Aspid.FastTools.Ids.Editors
 
             _onSelected?.Invoke(nameId);
             Close();
+        }
+
+        private void ShowError(string message)
+        {
+            _errorLabel.text = message;
+            _errorLabel.SetDisplay(DisplayStyle.Flex);
+        }
+
+        private static bool NextIdCollides(SerializedProperty idsProp, int nextId)
+        {
+            var count = idsProp.arraySize;
+            for (var i = 0; i < count; i++)
+                if (idsProp.GetArrayElementAtIndex(i).intValue == nextId) return true;
+
+            return false;
         }
 
         private void BindItem(VisualElement element, int index)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/UniqueIdIndex.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/UniqueIdIndex.cs
@@ -32,18 +32,13 @@ namespace Aspid.FastTools.Ids.Editors
             if (_index is null) return;
             if (target == null) return;
 
-            var assetType = target.GetType();
-            if (!TryGetFieldsFor(assetType, out var fields)) return;
-
             var path = AssetDatabase.GetAssetPath(target);
             if (string.IsNullOrEmpty(path)) return;
 
             var guid = AssetDatabase.AssetPathToGUID(path);
             if (string.IsNullOrEmpty(guid)) return;
 
-            var so = new SerializedObject(target);
-            RebuildAssetBucket(so, fields, assetType, guid);
-            IndexChanged?.Invoke();
+            RefreshAssetBuckets(target, guid);
         }
 
         public static void OnAssetChanged(string path)
@@ -53,15 +48,10 @@ namespace Aspid.FastTools.Ids.Editors
             var asset = AssetDatabase.LoadAssetAtPath<ScriptableObject>(path);
             if (asset == null) return;
 
-            var assetType = asset.GetType();
-            if (!TryGetFieldsFor(assetType, out var fields)) return;
-
             var guid = AssetDatabase.AssetPathToGUID(path);
             if (string.IsNullOrEmpty(guid)) return;
 
-            var so = new SerializedObject(asset);
-            RebuildAssetBucket(so, fields, assetType, guid);
-            IndexChanged?.Invoke();
+            RefreshAssetBuckets(asset, guid);
         }
 
         public static void Reset()
@@ -121,10 +111,25 @@ namespace Aspid.FastTools.Ids.Editors
             return result;
         }
 
-        private static bool TryGetFieldsFor(Type assetType, out FieldInfo[] fields)
+        // The index is keyed by the field's declaring type while assets carry their concrete type,
+        // so every declaring-type bucket the asset is assignable to must be rebuilt.
+        private static void RefreshAssetBuckets(UnityEngine.Object asset, string guid)
         {
             _fieldsByType ??= BuildFieldsByType();
-            return _fieldsByType.TryGetValue(assetType, out fields);
+
+            SerializedObject so = null;
+            var assetType = asset.GetType();
+
+            foreach (var (declaringType, fields) in _fieldsByType)
+            {
+                if (!declaringType.IsAssignableFrom(assetType)) continue;
+
+                so ??= new SerializedObject(asset);
+                RebuildAssetBucket(so, fields, declaringType, guid);
+            }
+
+            if (so is not null)
+                IndexChanged?.Invoke();
         }
 
         private static void AddToIndex(Dictionary<string, HashSet<string>> byId, string stringId, string guid)
@@ -138,12 +143,12 @@ namespace Aspid.FastTools.Ids.Editors
             set.Add(guid);
         }
 
-        private static void RebuildAssetBucket(SerializedObject so, FieldInfo[] fields, Type assetType, string guid)
+        private static void RebuildAssetBucket(SerializedObject so, FieldInfo[] fields, Type declaringType, string guid)
         {
-            if (!_index.TryGetValue(assetType, out var byId))
+            if (!_index.TryGetValue(declaringType, out var byId))
             {
                 byId = new Dictionary<string, HashSet<string>>();
-                _index[assetType] = byId;
+                _index[declaringType] = byId;
             }
             else
             {


### PR DESCRIPTION
## Summary

Fixes for the audit findings in the Ids editor tooling (`Unity/Editor/Scripts/Ids/`):

| File | What was wrong | Fix |
|---|---|---|
| `Selectors/IdSelectorWindow.cs:156` | `TryAdd` assigned `_nextId` with no `>= 1` / collision guard, so the "Create \"x\"" flow could silently reuse an already-assigned id (or assign the `0` sentinel) after a manual `_nextId` override | Applied the same guards as `RegistryEditorCore.ValidateAddRow` before mutating; on failure the selector shows the error in its existing error label and aborts. `Undo` registration moved after the guards so a rejected add no longer records a spurious undo step |
| `UniqueIdIndex.cs:35` | `RefreshAsset` / `OnAssetChanged` looked up fields by the asset's **concrete** type while the index is keyed by the field's **declaring** type — inherited `[UniqueId]` fields on derived assets kept a stale index until a full reset | Both paths now funnel into `RefreshAssetBuckets`, which rebuilds every declaring-type bucket the asset is assignable to, keyed by the declaring type (matching `EnsureBuilt` and `IsUnique`) |
| `Drawers/IdStructIMGUIPropertyDrawer.cs:65` | Not-unique warning `HelpBox` was anchored at `position.y + position.height` — one line **below** the rect reserved by `GetIMGUIHeight`, overlapping the next inspector row | Anchored at `position.y + singleLineHeight + standardVerticalSpacing`, inside the reserved second line |
| `Registries/CleanUpSummary.cs:26` | User-visible label rendered "invalid entery/enteries" and always-plural "1 duplicates" | "entry/entries" spelling; duplicate count singularized the same way as the empty-name part |
| `Registries/RegistryEditorCore.cs:68` | Hard-coded `"aspid-fasttools-inspector-container"` literal duplicating `AspidStyles.InspectorStyleClass` | Replaced with the constant (its only code consumer) |
| `Registries/RegistryEditorCore.cs:360` | `NextIdWarning.Hidden("Next ID must be ≥ 1.")` tooltip was unreachable — the hidden icon is `display: none`, so the tooltip could never show | Removed the dead tooltip; the `< 1` message is already surfaced by `ValidateAddRow`'s add-row error (matching the surrounding UX) |
| `Drawers/IdStructDrawerHelper.cs:66` | Trailing `ApplyModifiedPropertiesWithoutUndo()` in `SetFields` (and `ApplyModifiedProperties()` in `SyncStringFromInt`) were no-ops on the same `SerializedObject` already applied by `SetIntAndApply`/`SetStringAndApply`, and misleadingly suggested a without-Undo apply | Removed both redundant calls |

No findings were skipped.

## Notes for review

- `IdSelectorWindow.TryAdd` still mutates the registry through its own `SerializedObject` (it has no `RegistryEditorCore` instance); this PR only adds the missing guards — funneling the window's add through core would be a larger refactor.
- `UniqueIdIndex.RefreshAssetBuckets` uses `IsAssignableFrom`, so an asset touching several `[UniqueId]`-declaring base types rebuilds each bucket in one pass and fires `IndexChanged` once.
