### PR TITLE
perf(serializereferences): single cold-index sweep per folder, wider mixed-types memo

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
@@ -126,7 +126,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             // Memoise the per-target probe per selection: it allocates a SerializedObject per selected object on every
             // IMGUI repaint, while the all-missing state it measures is stable until the backing assets change.
-            if (MixedCacheMatches(property.propertyPath, first, targets)) return _mixedResult;
+            if (TryGetMixedCache(property.propertyPath, first, targets, out var cached)) return cached;
 
             var result = false;
             foreach (var target in targets)
@@ -143,26 +143,35 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return result;
         }
 
-        // Per-selection memo backing HasMixedTypes' expensive all-missing multi-select probe.
-        private static string _mixedPath;
-        private static string _mixedFirst;
+        // Per-selection memo backing HasMixedTypes' expensive all-missing multi-select probe. Entries are held per
+        // property path so several empty fields drawn under ONE multi-selection all stay memoized across a repaint —
+        // a single shared slot would be overwritten by each field and miss on the next. The map is scoped to one
+        // selection snapshot (_mixedTargets) and resets whenever the selection changes, so it stays bounded by the
+        // fields the current inspector actually draws.
         private static Object[] _mixedTargets;
-        private static bool _mixedResult;
+        private static readonly Dictionary<string, (string first, bool result)> _mixedResults = new(StringComparer.Ordinal);
 
         // The memo is keyed by selection, not file state, so an EXTERNAL rewrite of the selected assets must drop it
         // explicitly (see SerializeReferenceEditorCacheInvalidator).
         public static void InvalidateMixedTypesCache()
         {
-            _mixedPath = null;
-            _mixedFirst = null;
             _mixedTargets = null;
-            _mixedResult = false;
+            _mixedResults.Clear();
         }
 
-        private static bool MixedCacheMatches(string path, string first, UnityEngine.Object[] targets)
+        private static bool TryGetMixedCache(string path, string first, UnityEngine.Object[] targets, out bool result)
+        {
+            result = false;
+            if (!MixedTargetsMatch(targets)) return false;
+            if (!_mixedResults.TryGetValue(path, out var entry) || entry.first != first) return false;
+
+            result = entry.result;
+            return true;
+        }
+
+        private static bool MixedTargetsMatch(UnityEngine.Object[] targets)
         {
             if (_mixedTargets is null || _mixedTargets.Length != targets.Length) return false;
-            if (_mixedPath != path || _mixedFirst != first) return false;
 
             for (var i = 0; i < targets.Length; i++)
                 if (!ReferenceEquals(_mixedTargets[i], targets[i])) return false;
@@ -172,10 +181,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private static void StoreMixedCache(string path, string first, UnityEngine.Object[] targets, bool result)
         {
-            _mixedPath = path;
-            _mixedFirst = first;
-            _mixedTargets = (Object[])targets.Clone(); // snapshot the references so a reused array can't alias
-            _mixedResult = result;
+            if (!MixedTargetsMatch(targets))
+            {
+                _mixedResults.Clear();
+                _mixedTargets = (Object[])targets.Clone(); // snapshot the references so a reused array can't alias
+            }
+
+            _mixedResults[path] = (first, result);
         }
 
         /// <summary>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceDeleteGuard.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceDeleteGuard.cs
@@ -56,16 +56,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Sweeps the folder's contained scripts and raises ONE combined dialog for every referenced type found.
         private static AssetDeleteResult GuardFolder(string folderPath)
         {
+            var types = new List<Type>();
+            foreach (var guid in AssetDatabase.FindAssets("t:MonoScript", new[] { folderPath }))
+            {
+                var type = ResolveScriptType(AssetDatabase.GUIDToAssetPath(guid));
+                if (type is not null) types.Add(type);
+            }
+
+            if (types.Count == 0) return AssetDeleteResult.DidNotDelete;
+
             var affected = new List<string>();
             var totalCount = 0;
 
-            foreach (var guid in AssetDatabase.FindAssets("t:MonoScript", new[] { folderPath }))
+            foreach (var (type, count) in CountUsagesBatch(types))
             {
-                var path = AssetDatabase.GUIDToAssetPath(guid);
-                var type = ResolveScriptType(path);
-                if (type is null) continue;
-
-                GatherUsageSample(type, out var count);
                 if (count <= 0) continue;
 
                 totalCount += count;
@@ -81,6 +85,44 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             var proceed = EditorUtility.DisplayDialog("Delete Folder", message, "Delete Anyway", "Cancel");
             return proceed ? AssetDeleteResult.DidNotDelete : AssetDeleteResult.FailedDelete;
+        }
+
+        // Counts usages for a whole batch of types at once. A warm index answers per type; a cold index falls back to
+        // ONE combined project sweep matching every type's open key — never one full sweep per contained script, which
+        // would freeze the editor when deleting a folder of scripts.
+        private static IEnumerable<(Type type, int count)> CountUsagesBatch(List<Type> types)
+        {
+            if (SerializeReferenceTypeUsageIndex.IsWarm)
+            {
+                foreach (var type in types)
+                    yield return (type, SerializeReferenceTypeUsageIndex.CountUsages(type));
+
+                yield break;
+            }
+
+            var countsByKey = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var type in types)
+                countsByKey[SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(type))] = 0;
+
+            foreach (var path in AssetDatabase.GetAllAssetPaths())
+            {
+                if (!SerializeReferenceHelpers.IsScanCandidate(path)) continue;
+
+                // Data-only scan — skipping display-name resolution keeps this a pure text pass, not an asset load.
+                foreach (var document in SerializeReferenceGraphScanner.Build(path, resolveTypeNames: false))
+                {
+                    foreach (var node in document.Nodes)
+                    {
+                        if (node.StoredType.IsEmpty) continue;
+
+                        var key = SerializeReferenceHelpers.OpenTypeKey(node.StoredType);
+                        if (countsByKey.TryGetValue(key, out var count)) countsByKey[key] = count + 1;
+                    }
+                }
+            }
+
+            foreach (var type in types)
+                yield return (type, countsByKey[SerializeReferenceHelpers.OpenTypeKey(ManagedTypeName.FromType(type))]);
         }
 
         // Uses the warm index when available; a cold index is never warmed (a modal full-project build) just to answer


### PR DESCRIPTION
## Summary

- `Index/SerializeReferenceDeleteGuard.cs:62` — `GuardFolder` called `GatherUsageSample` once per contained MonoScript, and with a cold `SerializeReferenceTypeUsageIndex` each call fell back to a full `AssetDatabase.GetAllAssetPaths()` text sweep — deleting a folder with N scripts ran N complete project scans, freezing the editor. Now all contained script types are collected first and `CountUsagesBatch` answers them together: the warm index is queried per type as before, while a cold index runs a **single** combined sweep matching every type's open-generic key against one dictionary.
- `Extensions/SerializeReferenceHelpers.cs:147` — the memo behind `HasMixedTypes`' all-missing multi-select probe was a single `(path, first, targets, result)` slot, so two or more empty managed-reference fields drawn under one multi-selection overwrote each other every repaint and the probe re-allocated a `SerializedObject` per selected object per field per `GetHeight`/`Draw` call. The slot is now a small dictionary keyed by property path, scoped to one selection snapshot: it resets whenever the selection changes (staying bounded by the fields the inspector actually draws) and is still dropped by the existing `InvalidateMixedTypesCache` on external asset rewrites.

## Notes for review

- `CountUsagesBatch` reuses the exact matching discipline of the cold branch it replaces (`IsScanCandidate` filter, `SerializeReferenceGraphScanner.Build(path, resolveTypeNames: false)`, `OpenTypeKey` identity), so warm/cold results are unchanged — only the number of sweeps drops from N to 1.
- The single-script delete path (`GatherUsageSample`) is untouched: one script was always exactly one sweep, and it still supplies the sample paths for the dialog message.
