### PR TITLE
chore(samples): menu-path and asmdef consistency

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Scripts/WeaponPreset.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Scripts/WeaponPreset.cs
@@ -15,7 +15,7 @@ namespace Aspid.FastTools.Samples.SerializeReferences
     // See the bundled BrokenWeaponPreset.asset: its _weapon points at a type that does not exist (GhostWeapon),
     // so the Inspector shows a "Missing type" warning with a "Fix" button — set the class back to "Pistol"
     // to recover the reference and its data.
-    [CreateAssetMenu(menuName = "Aspid/FastTools Samples/Weapon Preset", fileName = "WeaponPreset")]
+    [CreateAssetMenu(menuName = "Aspid/FastTools/Samples/Weapon Preset", fileName = "WeaponPreset")]
     public sealed class WeaponPreset : ScriptableObject
     {
         [SerializeReference] [TypeSelector]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Scripts/Editor/Aspid.FastTools.Samples.Types.Editor.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Scripts/Editor/Aspid.FastTools.Samples.Types.Editor.asmdef
@@ -1,9 +1,10 @@
 {
     "name": "Aspid.FastTools.Samples.Types.Editor",
+    "rootNamespace": "",
     "references": [
-        "GUID:56ba1765a6eb4975ada12506d8c4afda",
-        "GUID:7c010b89992542508a6b6189977e64d4",
-        "GUID:94dcbbdbbd3ca48b891ee4fc8455c434"
+        "Aspid.FastTools.Samples.Types",
+        "Aspid.FastTools.Unity",
+        "Aspid.FastTools.Unity.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/VisualElements/Scripts/Editor/Aspid.FastTools.Samples.VisualElements.Editor.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/VisualElements/Scripts/Editor/Aspid.FastTools.Samples.VisualElements.Editor.asmdef
@@ -1,10 +1,10 @@
 {
     "name": "Aspid.FastTools.Samples.VisualElements.Editor",
+    "rootNamespace": "",
     "references": [
-        "GUID:d8b63aba1907145bea998dd612889d6b",
-        "GUID:7c010b89992542508a6b6189977e64d4",
-        "GUID:94dcbbdbbd3ca48b891ee4fc8455c434",
-        "GUID:6a3c7b14e2f94d71b15d0e8f2f4a1c9d"
+        "Aspid.FastTools.Samples.VisualElements",
+        "Aspid.FastTools.Unity",
+        "Aspid.FastTools.Unity.Editor"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary

- `Samples~/SerializeReferences/Scripts/WeaponPreset.cs:18` — `CreateAssetMenu` used `Aspid/FastTools Samples/Weapon Preset` (separate flat submenu) while every other sample asset uses the nested `Aspid/FastTools/Samples/…` path; aligned it to `Aspid/FastTools/Samples/Weapon Preset`.
- `Samples~/Types/Scripts/Editor/Aspid.FastTools.Samples.Types.Editor.asmdef` — referenced assemblies by raw GUID and was missing the `rootNamespace` key its siblings carry; converted the same three references to name-based (`Aspid.FastTools.Samples.Types`, `Aspid.FastTools.Unity`, `Aspid.FastTools.Unity.Editor`) and added `"rootNamespace": ""`.
- `Samples~/VisualElements/Scripts/Editor/Aspid.FastTools.Samples.VisualElements.Editor.asmdef` — carried an unused `Unity.Mathematics` GUID reference (`d8b63aba…`; no Mathematics usage anywhere in the sample) plus GUID-based references; dropped the Mathematics entry and converted the remaining references to the same name-based form.

## Notes for review

- GUID → name mapping was verified against the committed `.asmdef.meta` files: `56ba1765…` = `Aspid.FastTools.Samples.Types`, `7c010b89…` = `Aspid.FastTools.Unity`, `94dcbbdb…` = `Aspid.FastTools.Unity.Editor`, `6a3c7b14…` = `Aspid.FastTools.Samples.VisualElements`.
- No findings were skipped.
