### PR TITLE
chore: enforce Source assembly boundary, drop dead versionDefines, fix CLAUDE.md claims

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Source/Aspid.FastTools.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Source/Aspid.FastTools.asmdef
@@ -1,3 +1,4 @@
 {
-	"name": "Aspid.FastTools"
+	"name": "Aspid.FastTools",
+	"noEngineReferences": true
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Aspid.FastTools.Unity.asmdef
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Aspid.FastTools.Unity.asmdef
@@ -8,12 +8,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.unity.mathematics",
-            "expression": "",
-            "define": "ASPID_FASTTOOLS_UNITY_MATHEMATICS_INTEGRATION"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The Unity package itself has no CLI build — Unity compiles it when the project
 
 **Assembly boundary rule:** `Unity/Runtime/` code must NOT reference `UnityEditor` — it ships with player builds.
 
-**Optional Mathematics integration:** new Mathematics-dependent code goes in the satellite `Aspid.FastTools.Unity.VisualElements.Math` assembly, compiled only when `com.unity.mathematics` is installed (via `versionDefines`). The same `ASPID_FASTTOOLS_UNITY_MATHEMATICS_INTEGRATION` symbol is also declared on the main runtime asmdef for the rare single-file gate in `Aspid.FastTools.Unity`.
+**Optional Mathematics integration:** new Mathematics-dependent code goes in the satellite `Aspid.FastTools.Unity.VisualElements.Math` assembly, compiled only when `com.unity.mathematics` is installed (via `versionDefines` declaring `ASPID_FASTTOOLS_UNITY_MATHEMATICS_INTEGRATION`). Only the satellite asmdef declares that symbol — the main runtime asmdef does not.
 
 ### Assembly Definitions
 
@@ -76,7 +76,7 @@ All components load `AspidStyles.DefaultStyleSheet` as the base stylesheet and f
 
 **IMGUI Scopes** (`Unity/Editor/Scripts/IMGUI/`): Disposable `VerticalScope`, `HorizontalScope`, `ScrollViewScope` wrappers with `Rect` properties.
 
-**Editor Extensions** (`Unity/Editor/Scripts/Extensions/`): `GetScriptName()` and `GetScriptNameWithIndex()` on `MonoScript` — respects `[AddComponentMenu]` attribute and appends index suffix for duplicate components.
+**Editor Extensions** (`Unity/Editor/Scripts/Extensions/`): `GetScriptName()` on `UnityEngine.Object` and `GetScriptNameWithIndex()` on `Component` — respects `[AddComponentMenu]` attribute and appends index suffix for duplicate components.
 
 **Welcome View** (`Unity/Editor/Scripts/Welcome/`): `WelcomeView` — the **Welcome** tab of `SerializeReferenceWindow` (menu `Tools/Aspid 🐍/FastTools/Welcome`) + `WelcomeWindowStartup` (auto-show on first import) + `WelcomeSettings*`. UXML/USS at `Resources/UI/Windows/Welcome/`. Lists installable samples from `package.json`.
 


### PR DESCRIPTION
## Summary

Fixes three verified audit findings around asmdef configuration and stale CLAUDE.md claims:

| Finding | What was wrong | Fix |
|---|---|---|
| `Source/Aspid.FastTools.asmdef:2` | The pure-C# assembly did not set `noEngineReferences`, so the documented zero-Unity boundary was unenforced (a Unity dependency could creep in silently). | Added `"noEngineReferences": true` — verified beforehand that `Source/` contains only `System.*` usings and no `UnityEngine`/`UnityEditor` references. |
| `Unity/Runtime/Aspid.FastTools.Unity.asmdef:11` | The `versionDefines` entry declaring `ASPID_FASTTOOLS_UNITY_MATHEMATICS_INTEGRATION` gated nothing: a repo-wide grep finds the symbol only in the two Math-satellite files, which belong to `Aspid.FastTools.Unity.VisualElements.Math` with its own identical entry. | Removed the dead `versionDefines` entry from the main runtime asmdef (the Math satellite keeps its own). |
| `CLAUDE.md:38` / `CLAUDE.md:79` (via `Unity/Editor/Scripts/Extensions/EditorExtensions.cs:27`) | CLAUDE.md claimed the symbol is "also declared on the main runtime asmdef for the rare single-file gate" (no such gate exists) and described `GetScriptName()`/`GetScriptNameWithIndex()` as extensions "on `MonoScript`" — the actual receivers are `UnityEngine.Object` and `Component`. | Updated both sentences to match the code; `EditorExtensions.cs` itself is unchanged. |

No findings were skipped.

## Notes for review

- Behavior-neutral for consumers: `noEngineReferences` only forbids what the assembly already didn't use, and the removed define was consumed by no file in the main runtime assembly.
- Unity was not run here; correctness established by grep verification (no `UnityEngine`/`UnityEditor` tokens in `Source/`, symbol usage limited to the Math satellite files).
