### PR TITLE
fix(serializereferences): YAML top-level path matching and key collection

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorReadEdgeTests.cs
@@ -7,8 +7,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
     /// <summary>
     /// Edge-case read coverage the happy-path tests miss: the <c>-2</c> null-sentinel contract of
     /// <see cref="SerializeReferenceYamlEditor.TryReadReferenceId"/>, the single-document anchor fallback and
-    /// multi-document write confinement of the internal <c>FindDocumentRange</c>, and the single-quoted generic
-    /// class round-trip (the risk-register generic case) through the reader.
+    /// multi-document write confinement of the internal <c>FindDocumentRange</c>, the single-quoted generic
+    /// class round-trip (the risk-register generic case) through the reader, and the top-level-indent segment
+    /// matching that keeps a same-named nested key from shadowing the real top-level field.
     /// </summary>
     [TestFixture]
     internal sealed class SerializeReferenceYamlEditorReadEdgeTests
@@ -87,6 +88,30 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
                 Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
                     path, YamlFixtures.ListOfStructFileId, "_slots.Array.data[1]._weapon", out var second));
                 Assert.AreEqual(3002, second, "Second List<struct> element's nested managed reference must resolve.");
+            }
+            finally
+            {
+                YamlFixtures.Delete(path);
+            }
+        }
+
+        [Test]
+        public void TryReadReferenceId_TopLevelFieldShadowedByEarlierNestedKey_ResolvesTopLevelRid()
+        {
+            var path = YamlFixtures.WriteTemp(YamlFixtures.ShadowedFieldPrefab);
+            try
+            {
+                // The nested _config._weapon pointer appears before the top-level _weapon in the document — the first
+                // path segment must be matched at the top-level field indent, not at any indent.
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.ShadowedFileId, "_weapon", out var topLevel));
+                Assert.AreEqual(YamlFixtures.ShadowedTopLevelRid, topLevel,
+                    "A same-named key nested in an earlier container must not shadow the real top-level field.");
+
+                Assert.IsTrue(SerializeReferenceYamlEditor.TryReadReferenceId(
+                    path, YamlFixtures.ShadowedFileId, "_config._weapon", out var nested));
+                Assert.AreEqual(YamlFixtures.ShadowedNestedRid, nested,
+                    "The nested occurrence must still resolve through its own path.");
             }
             finally
             {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorTests.cs
@@ -124,6 +124,22 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
         }
 
         [Test]
+        public void GetReferenceFieldNames_SequenceItemsInData_ReportsParentKeyOnly()
+        {
+            // WeaponRack's data holds a list whose "- rid:" items Unity writes at the parent key's own indent — they
+            // must not be reported as bogus "- rid" pseudo-keys next to the real _weapons field.
+            var path = YamlFixtures.WriteTemp(YamlFixtures.NestedListPointerPrefab);
+            try
+            {
+                var fields = SerializeReferenceYamlEditor.GetReferenceFieldNames(
+                    path, YamlFixtures.NestedListPointerFileId, YamlFixtures.NestedListPointerRackRid);
+                CollectionAssert.AreEqual(new[] { "_weapons" }, fields,
+                    "Only the block's own field keys are field-shape signal; sequence items are not keys.");
+            }
+            finally { YamlFixtures.Delete(path); }
+        }
+
+        [Test]
         public void ParseTopLevelFieldNames_SkipsIndentedAndSequenceLines()
         {
             var names = SerializeReferenceYamlEditor.ParseTopLevelFieldNames(

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorTests.cs
@@ -60,6 +60,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
                 Assert.AreEqual(1, missing.Count,
                     "A nested '- rid:' list element must not be read as a second, phantom RefIds entry.");
                 Assert.AreEqual(YamlFixtures.GhostPistolRid, missing[0].Rid);
+                Assert.AreEqual(YamlFixtures.NestedListPointerFileId, missing[0].FileId);
                 Assert.AreEqual("GhostPistol", missing[0].StoredType.Class);
             }
             finally { YamlFixtures.Delete(path); }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
@@ -144,8 +144,9 @@ MonoBehaviour:
         _slowPercent: 40
 ";
 
-        // The single-object document file id of the nested-list-pointer fixture below.
+        // The single-object document file id of the nested-list-pointer fixture below, and its resolvable WeaponRack entry.
         public const long NestedListPointerFileId = 8800000000000000003L;
+        public const long NestedListPointerRackRid = 1001;
 
         // A MonoBehaviour whose one managed reference (WeaponRack, rid 1001) holds a List<IWeapon> _weapons with a single
         // element pointing at a MISSING entry (GhostPistol, rid 1002). The nested "- rid: 1002" list element sits DEEPER
@@ -308,6 +309,44 @@ MonoBehaviour:
       data:
         _pellets: 6
         _spreadAngle: 20
+";
+
+        // The single-object document file id and the two rids of the shadowed-field fixture below.
+        public const long ShadowedFileId = 9900000000000000003L;
+        public const long ShadowedNestedRid = 4001;   // _config._weapon (nested inside a plain serializable container)
+        public const long ShadowedTopLevelRid = 4002; // _weapon         (the real top-level field)
+
+        // A MonoBehaviour where an EARLIER field's plain serializable container (_config) holds a key named exactly like
+        // a later TOP-LEVEL field (_weapon). The nested _weapon (rid 4001) appears first in the document, so a reader
+        // that matched the first path segment at any indent would resolve "_weapon" to the nested pointer; matching at
+        // the document's top-level field indent (the m_Script line's indent) must resolve it to rid 4002.
+        public const string ShadowedFieldPrefab =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &9900000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}
+  m_Name: ShadowedLoadout
+  _config:
+    _weapon:
+      rid: 4001
+    _label: primary
+  _weapon:
+    rid: 4002
+  references:
+    version: 2
+    RefIds:
+    - rid: 4001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 10
+        _magazineSize: 7
+    - rid: 4002
+      type: {class: Shotgun, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _pellets: 8
+        _spreadAngle: 25
 ";
 
         // Script guids for the scene required-field fixtures below. The first maps (via the test's injected resolver) to

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
@@ -11,9 +11,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
     /// (single managed ref, list of managed refs, nested managed ref). The strings are written at column 0 inside the
     /// verbatim literal — their leading whitespace IS the YAML indentation and must not be reflowed.
     /// </summary>
-    // Public (not internal) because the SerializeReference editor test assembly references this test assembly to reuse
-    // these fixtures in its SR+YAML integration tests, which live outside Aspid.FastTools.Unity.Editor.SerializeReferences.Tests.
-    public static class YamlFixtures
+    internal static class YamlFixtures
     {
         // The MonoBehaviour document's local file id (its "--- !u!114 &<fileID>" anchor).
         public const long MonoBehaviourFileId = 6500000000000000003L;
@@ -179,9 +177,8 @@ MonoBehaviour:
         _magazineSize: 12
 ";
 
-        // RefIds present in the empty-fields fixture below.
-        public const long EmptyRailgunRid = 1001;  // _primaryWeapon  (resolvable, holds a cleared nested _chargeEffect)
-        public const long EmptyPistolRid = 1002;   // _sidearms[0]    (resolvable)
+        // The Railgun entry of the empty-fields fixture below: _primaryWeapon, resolvable, holds a cleared nested _chargeEffect.
+        public const long EmptyRailgunRid = 1001;
 
         // A MonoBehaviour exercising unassigned (null-sentinel) [SerializeReference] slots written by Unity as
         // "rid: -2" (ManagedReferenceUtility.RefIdNull): a cleared top-level field (_onHitEffect), a null list element
@@ -349,14 +346,12 @@ MonoBehaviour:
         _spreadAngle: 25
 ";
 
-        // Script guids for the scene required-field fixtures below. The first maps (via the test's injected resolver) to
-        // RequiredTestObject's required fields; the second is an "unknown" script the resolver returns no fields for.
+        // The script guid of the scene required-field fixtures below — maps (via the test's injected resolver) to
+        // RequiredTestObject's required fields. Any other guid (the mixed fixture's bbbb… script) is unknown to the resolver.
         public const string RequiredSceneScriptGuid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        public const string UnknownScriptGuid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-        // MonoBehaviour document file ids in the scene fixtures (the "--- !u!114 &<fileID>" anchors).
+        // The known-script MonoBehaviour document's file id in the scene fixtures (its "--- !u!114 &<fileID>" anchor).
         public const long RequiredSceneMonoFileId = 101L;
-        public const long RequiredSceneOtherFileId = 201L;
 
         // A scene with one MonoBehaviour whose required managed reference (requiredRef) and required string field
         // (requiredString) are both left unset — the managed reference at Unity's null id (-2), the string empty. Exact

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Read.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Read.cs
@@ -45,7 +45,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 // or sequence item, by indent) or jumps into a managed reference's RefIds data block (by rid).
                 var cursorStart = start;
                 var cursorEnd = fieldsEnd;
-                var cursorIndent = -1; // the object's top-level fields: match at any indent
+
+                // The object's top-level fields all align with the m_Script line's indent (see TryReadScriptGuid), so
+                // the first segment is matched at exactly that indent — otherwise a same-named key nested inside an
+                // earlier field's serializable container would shadow the real top-level field. A document without a
+                // readable script guid falls back to matching at any indent.
+                var cursorIndent = TryReadScriptGuid(lines, start + 1, fieldsEnd, out _, out var fieldIndent)
+                    ? fieldIndent
+                    : -1;
 
                 for (var s = 0; s < segments.Count; s++)
                 {
@@ -387,10 +394,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         // Collects the keys of "name: …" entries at exactly childIndent within [blockStart, blockEnd), skipping the
-        // deeper lines of nested mappings/sequences so only the block's own top-level fields are reported.
+        // deeper lines of nested mappings/sequences so only the block's own top-level fields are reported. Sequence
+        // items ("- rid: 7", "- _damage: 5") sit at the parent key's own indent, so the key pattern excludes the dash
+        // — they are items of an already-reported field, not keys ("- rid" / "- _damage" would be pseudo-keys).
         private static void CollectTopLevelKeys(string[] lines, int blockStart, int blockEnd, int childIndent, List<string> result)
         {
-            var keyPattern = new Regex(@"^(?<indent>\s*)(?<key>[^\s:][^:]*):(\s.*|\s*)$");
+            var keyPattern = new Regex(@"^(?<indent>\s*)(?<key>[^\s:#-][^:]*):(\s.*|\s*)$");
 
             for (var i = blockStart; i < blockEnd; i++)
             {
@@ -401,9 +410,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (!match.Success) continue;
                 if (match.Groups["indent"].Length != childIndent) continue;
 
-                var key = match.Groups["key"].Value.Trim();
-                if (key.Length > 0 && key != "-")
-                    result.Add(key);
+                result.Add(match.Groups["key"].Value.Trim());
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes two adversarially-verified audit findings in the SerializeReference YAML reader, plus test-fixture hygiene:

- **`Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Read.cs:48`** — `TryReadReferenceId` resolved the first path segment at *any* indent, so a same-named key nested inside an earlier field's serializable container (e.g. `_config: → _weapon: → rid:` before the real top-level `_weapon:`) shadowed the real top-level field — returning the wrong rid, or a false `NotFound` when the shadow was a scalar. The first segment is now matched at the document's top-level field indent, recovered from the `m_Script` line (same recovery `FindUnsetRequiredFields` uses); a document without a readable script guid keeps the previous any-indent fallback.
- **`Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Read.cs:393`** — `CollectTopLevelKeys` accepted sequence-item lines (`- rid: 7`, `- _damage: 5`), which Unity writes at the parent key's own indent, so `GetReferenceFieldNames` — the Smart-Fix field-shape signal — was polluted with bogus `- rid` / `- _damage` pseudo-keys. The key pattern's first-char class now excludes the dash (matching `TryFindTopLevelArrayElementForRid` in `.Restore.cs`), and the now-dead `key != "-"` guard is gone.
- **`Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs:148`** — of the four never-referenced constants, `NestedListPointerFileId` is now actually asserted by `FindMissingReferences_NestedListPointer_ReportsEntryOnce` (it was evidently added for that); `EmptyPistolRid`, `UnknownScriptGuid` and `RequiredSceneOtherFileId` are removed.
- **`Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs:14`** — the header comment justified `public` with a cross-assembly consumer that does not exist (no asmdef references the test assembly; every consumer is same-assembly). Comment dropped, class made `internal` like the rest of the test code.

Regression coverage:

| Bug | Test |
|---|---|
| Nested key shadowing a top-level field | `TryReadReferenceId_TopLevelFieldShadowedByEarlierNestedKey_ResolvesTopLevelRid` + new `ShadowedFieldPrefab` fixture |
| Sequence-item pseudo-keys in field names | `GetReferenceFieldNames_SequenceItemsInData_ReportsParentKeyOnly` (drives `NestedListPointerPrefab`) |

## Notes for review

- The indent-exact first-segment match falls back to the old any-indent behaviour only when a document carries no readable `m_Script` guid (e.g. `m_Script: {fileID: 0}`), so no existing lookup shape regresses.
- All pre-existing Yaml tests were re-checked by reading against the new matching rules; every fixture's top-level fields align with its `m_Script` indent, so they stay green.
