### PR TITLE
refactor(serializereferences): remove dead code, fix misleading comments, dispose leak

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs
@@ -14,7 +14,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
     /// field. The notice host is a sibling placed after the foldout content, so it never inherits the child indent.
     /// </summary>
     /// <remarks>
-    /// Reuses <c>LinkerTestObject</c> / <c>TestSword</c> from <see cref="SerializeReferenceInspectorTests"/>: linking two
+    /// Reuses the shared <c>LinkerTestObject</c> / <c>TestSword</c> fixtures from <c>SerializeReferenceTestFixtures.cs</c>: linking two
     /// managed-reference fields onto one rid surfaces the shared-reference notice on a field that also has a value (so it
     /// renders child fields), which is the only notice that co-exists with children — the case the bug was about.
     /// </remarks>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageNotificationController.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Diagnostics/SerializeReferenceBreakageNotificationController.cs
@@ -9,7 +9,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 {
     /// <summary>
     /// Surfaces a breakage report non-intrusively: a fade-out <see cref="EditorWindow.ShowNotification"/> toast that
-    /// steals no focus, plus a single clickable warning in the console pointing at the Repair window. The same breakage
+    /// steals no focus, plus a single console warning pointing at the Repair window's menu path. The same breakage
     /// set is shown at most once per session (a content hash in <see cref="SessionState"/>), so a recompile that
     /// re-detects the identical set does not nag.
     /// </summary>
@@ -62,12 +62,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (migratable == count) Debug.Log(console);
             else Debug.LogWarning(console);
         }
-
-        /// <summary>
-        /// Public deep-link the user can wire to a button/menu — opens Repair straight into project-scan mode.
-        /// </summary>
-        public static void OpenRepair() =>
-            SerializeReferenceWindow.OpenProjectScan();
 
         private static void ShowToast(string message)
         {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
@@ -113,7 +113,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             // A fresh SerializedObject avoids any stale-binding hazard from a captured one; the bound inspector ListView
             // refreshes from the changed target on its next update.
-            var serializedObject = new SerializedObject(target);
+            using var serializedObject = new SerializedObject(target);
             var array = serializedObject.FindProperty(arrayPath);
             if (array is null || !array.isArray) return;
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceDuplicateGuard.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceDuplicateGuard.cs
@@ -35,7 +35,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// </remarks>
     internal static class SerializeReferenceDuplicateGuard
     {
-        // A managed reference with no value reports RefIdNull (-1); a missing-type one reports RefIdUnknown (-2). Only
+        // A managed reference with no value reports RefIdNull (-2); a missing-type one reports RefIdUnknown (-1). Only
         // ids >= 0 are real instances that can alias — the rest are excluded from the index → rid map.
         private const long FirstValidReferenceId = 0;
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceTemplates.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceTemplates.cs
@@ -124,17 +124,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         /// <summary>
-        /// Removes the named template. Returns whether one was removed.
-        /// </summary>
-        public static bool Remove(string name)
-        {
-            var store = Load();
-            if (store.entries.RemoveAll(e => e.name == name) == 0) return false;
-            Persist(store);
-            return true;
-        }
-
-        /// <summary>
         /// A unique default name for a new template of <paramref name="type"/> (deduplicated with a suffix).
         /// </summary>
         public static string SuggestName(Type type)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
@@ -21,11 +21,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     internal static class SerializeReferenceTypeUsageIndex
     {
         /// <summary>
-        /// Raised whenever the index changes (rebuilt, reset or an asset patched), so consumers can refresh.
-        /// </summary>
-        public static event Action IndexChanged;
-
-        /// <summary>
         /// A single managed-reference use site. Identity is (asset, document, rid); the rest is payload.
         /// </summary>
         public readonly struct Usage : IEquatable<Usage>
@@ -105,11 +100,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         /// <summary>
-        /// Number of use sites of <paramref name="type"/>.
-        /// </summary>
-        public static int CountUsages(Type type) => FindUsages(type).Count;
-
-        /// <summary>
         /// Every use site whose stored type no longer resolves — the fast-scan source for the Repair window.
         /// </summary>
         public static IEnumerable<Usage> EnumerateUnresolved()
@@ -135,11 +125,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// <summary>
         /// Drops the whole index; the next lookup rebuilds it. Alias <see cref="ClearCache"/> for the rewrite sites.
         /// </summary>
-        public static void Reset()
-        {
-            _index = null;
-            IndexChanged?.Invoke();
-        }
+        public static void Reset() => _index = null;
 
         /// <inheritdoc cref="Reset"/>
         public static void ClearCache() => Reset();
@@ -156,17 +142,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             RemoveGuid(guid);
             AddAsset(path, guid);
-            IndexChanged?.Invoke();
-        }
-
-        /// <summary>
-        /// Removes an asset's usages by guid. No-op while the index is cold.
-        /// </summary>
-        public static void RemoveAsset(string guid)
-        {
-            if (_index is null || string.IsNullOrEmpty(guid)) return;
-            RemoveGuid(guid);
-            IndexChanged?.Invoke();
         }
 
         private static void EnsureBuilt()

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSharedSettings.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSharedSettings.cs
@@ -11,7 +11,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// Persisted as a YAML asset under <c>ProjectSettings/</c> (via <see cref="ScriptableSingleton{T}"/> +
     /// <see cref="FilePathAttribute"/>) so the chosen values are committed to VCS and travel to a clean CI runner —
     /// unlike the per-machine <see cref="EditorPrefs"/> that back the purely cosmetic rest of
-    /// <see cref="SerializeReferenceSettings"/> (rid colours, breakage detection). Commit
+    /// <see cref="SerializeReferenceSettings"/> (breakage detection). Commit
     /// <c>ProjectSettings/SerializeReferenceSharedSettings.asset</c> for these values to reach CI and the rest of the team.
     /// </summary>
     [FilePath("ProjectSettings/SerializeReferenceSharedSettings.asset", FilePathAttribute.Location.ProjectFolder)]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
@@ -62,7 +62,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string DocumentBodyClass = RootClass + "__document-body";
 
         private const string NodeClass = RootClass + "__node";
-        private const string NodeOrphanClass = NodeClass + "--orphan";
         private const string NodeBackEdgeClass = NodeClass + "--back-edge";
         private const string NodeEmptyClass = NodeClass + "--empty";
         private const string NodePickingClass = NodeClass + "--picking";
@@ -84,7 +83,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private const string ChipClass = RootClass + "__chip";
         private const string ClearOrphanClass = RootClass + "__clear-orphan";
-        private const string OpenSourceClass = RootClass + "__open-source";
         private const string OrphanGroupClass = RootClass + "__orphan-group";
         private const string OrphanGroupHeaderClass = RootClass + "__orphan-group-header";
         private const string PickerClass = RootClass + "__picker";
@@ -247,8 +245,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     _list.AddChild(info);
 
                     _list.AddChild(new AspidGradientButton("Open Source Prefab",
-                            _ => SetTarget(AssetDatabase.LoadAssetAtPath<Object>(sourcePath)))
-                        .AddClass(OpenSourceClass));
+                        _ => SetTarget(AssetDatabase.LoadAssetAtPath<Object>(sourcePath))));
                     return;
                 }
 
@@ -601,7 +598,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(NodeClass);
-            if (isOrphan) card.AddClass(NodeOrphanClass);
 
             var typePreset = AspidLabelPreset.Default
                 .SetLabelSize(AspidLabelSizeStyle.Type.H5)


### PR DESCRIPTION
## Summary

- Remove dead SerializeReference editor members flagged by the audit: `SerializeReferenceBreakageNotificationController.OpenRepair`, `SerializeReferenceTypeUsageIndex.CountUsages` / `RemoveAsset` / the subscriber-less `IndexChanged` event, `SerializeReferenceTemplates.Remove`, and the unstyled `node--orphan` / `__open-source` USS classes in `SerializeReferenceGraphView`.
- Fix misleading comments: un-swap Unity's `RefIdNull`/`RefIdUnknown` sentinel values in `SerializeReferenceDuplicateGuard`, drop the nonexistent "rid colours" EditorPrefs mention in `SerializeReferenceSharedSettings`, and point the notice-layout test remarks at the shared fixtures file.
- Fix a per-add `SerializedObject` leak in `SerializeReferenceListAddBehavior.Append` (`using`, matching every sibling throwaway `SerializedObject`).

### Findings fixed

| Finding | What was wrong | What was done |
|---|---|---|
| `Diagnostics/SerializeReferenceBreakageNotificationController.cs:69` | `OpenRepair()` had zero callers; class doc promised a "clickable" console warning that has no click target | Deleted the method; reworded the class doc to "a single console warning pointing at the Repair window's menu path" |
| `Index/SerializeReferenceTypeUsageIndex.cs:26` | `IndexChanged` event raised in three places but never subscribed anywhere | Deleted the event and its three invoke sites |
| `Index/SerializeReferenceTypeUsageIndex.cs:110` | `CountUsages(Type)` never referenced (repo-wide, incl. InternalsVisibleTo consumers) | Deleted |
| `Index/SerializeReferenceTypeUsageIndex.cs:165` | `RemoveAsset(string)` never referenced; the invalidator works via `OnPostprocessAllAssets`/`Reset` | Deleted |
| `Extensions/SerializeReferenceTemplates.cs:129` | `Remove(string)` never called — no delete-template UI exists | Deleted; a future "Delete Template" UI can revive it from git history |
| `Windows/SerializeReferenceGraphView.cs:65` | `NodeOrphanClass` / `OpenSourceClass` applied in code but styled by no stylesheet — the `AddClass` calls were no-ops | Removed the constants and both `AddClass` sites (per audit notes: no .uss edits in this PR) |
| `Extensions/SerializeReferenceDuplicateGuard.cs:38` | Comment swapped Unity's sentinels (`RefIdNull (-1)` / `RefIdUnknown (-2)`) | Corrected to `RefIdNull (-2)` / `RefIdUnknown (-1)`, matching the three sibling files |
| `Settings/SerializeReferenceSharedSettings.cs:14` | Doc claimed EditorPrefs back "rid colours, breakage detection"; rid colours are explicitly non-configurable | Dropped the "rid colours" mention |
| `Tests/Editor/SerializeReferences/SerializeReferenceFieldNoticeLayoutTests.cs:17` | Remarks attributed `LinkerTestObject` / `TestSword` to `SerializeReferenceInspectorTests` | Repointed at `SerializeReferenceTestFixtures.cs`, where they are declared |
| `Drawers/SerializeReferenceListAddBehavior.cs:116` | `Append` leaked a `SerializedObject` on every picker-backed list add | `using var serializedObject = new SerializedObject(target);` |

No findings were skipped.

## Notes for review

- Deleting `OpenRepair` leaves `SerializeReferenceWindow.OpenProjectScan()` (its only callee) without callers. It is kept: it is the window's own documented deep-link API and the natural target if the console warning ever gains a real hyperlink handler (`EditorGUI.hyperLinkClicked`) — the alternative to deletion the audit allowed.
- Orphan cards keep their visual distinction via the Warning label preset and the orphan group header; if card-level orphan tinting is wanted later, re-adding the modifier class plus a USS selector is a two-line change (this PR intentionally touches no .uss files — another PR owns them).
- Without `Templates.Remove`, templates are still only pruned via `LoadResolved` when their type stops resolving; a delete-templates UI would reintroduce the method from history.
