### PR TITLE
fix(editor): internal component fixes — InspectorHeader.Obj, GradientButton texture lifecycle, convention cleanups

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidAnimatedLogo/AspidAnimatedLogo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidAnimatedLogo/AspidAnimatedLogo.cs
@@ -15,6 +15,8 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
     [UxmlElement(libraryPath = "Aspid/FastTools")]
     internal sealed partial class AspidAnimatedLogo : VisualElement
     {
+        private const string StyleSheetPath = "UI/Components/Aspid-FastTools-AspidAnimatedLogo";
+
         private const int LayerCount = 3;
         private const long AnimationIntervalMs = 33;
         private const float PulseAmplitudeSmoothing = 0.07f;
@@ -104,7 +106,7 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         /// <param name="preset">The configuration preset to apply.</param>
         public AspidAnimatedLogo(AspidAnimatedLogoPreset preset)
         {
-            this.AddStyleSheetsFromResource("UI/Components/Aspid-FastTools-AspidAnimatedLogo");
+            this.AddStyleSheetsFromResource(StyleSheetPath);
 
             ColorCycleIntervalMs = preset.ColorCycleIntervalMs;
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidAnimatedTitle/AspidAnimatedTitle.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidAnimatedTitle/AspidAnimatedTitle.cs
@@ -15,6 +15,8 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
     [UxmlElement(nameof(AspidAnimatedTitle), libraryPath = "Aspid/FastTools")]
     internal sealed partial class AspidAnimatedTitle : VisualElement
     {
+        private const string StyleSheetPath = "UI/Components/Aspid-FastTools-AspidAnimatedTitle";
+
         private const int PaletteCount = 3;
         private const string WordClass = "aspid-fasttools-animated-title__word";
 
@@ -143,7 +145,7 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         /// <param name="preset">The configuration preset to apply.</param>
         public AspidAnimatedTitle(string text, AspidAnimatedTitlePreset preset)
         {
-            this.AddStyleSheetsFromResource("UI/Components/Aspid-FastTools-AspidAnimatedTitle");
+            this.AddStyleSheetsFromResource(StyleSheetPath);
 
             _colors = new AspidAnimatedTitleColorsStyle(
                 this, preset.Color1, preset.Color2, preset.Color3, onChanged: null);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/AspidGradientButton.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/AspidGradientButton.cs
@@ -211,6 +211,10 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
 
         private void RebuildGradient(Color color)
         {
+            // Textures live only while the element is attached: OnAttachToPanel builds the first
+            // one and OnDetachFromPanel disposes it, so a detached button never holds a texture.
+            if (panel == null) return;
+
             DisposeTexture();
             _gradientTexture = CreateHorizontalFadeTexture(color);
             style.backgroundImage = new StyleBackground(_gradientTexture);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidHoverGradientOverlays/AspidHoverGradientOverlay.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidHoverGradientOverlays/AspidHoverGradientOverlay.cs
@@ -20,8 +20,10 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         private const float DefaultLerpRate = 0.12f;
         private const float DefaultAlphaScale = 0.35f;
 
-        // Each step emits 6 indices, so steps must stay at or below 65535 / 6 = 10922 to keep the
-        // (ushort)(i * 2 + 3) index math from wrapping past the 65535 ushort mesh-index limit.
+        // Conservative cap on the step count: each step emits 6 indices, so 65535 / 6 = 10922 steps
+        // keeps even the total index count within ushort range. The hard limits — the largest emitted
+        // vertex index, (ushort)(i * 2 + 3) = 2 * steps + 1, and the 65535-vertex allocation ceiling —
+        // are only reached above ~32k steps, well past this cap.
         private const int MaxSteps = ushort.MaxValue / 6;
 
         private const string StyleSheetPath = "UI/Components/Aspid-FastTools-AspidHoverGradientOverlay";

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidInspectorHeaders/AspidInspectorHeader.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidInspectorHeaders/AspidInspectorHeader.cs
@@ -1,3 +1,4 @@
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
@@ -26,6 +27,9 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         private readonly AspidLabel _subtextElement;
         private readonly AspidHoverGradientOverlay _overlay;
         private readonly StatusStyle _status;
+
+        private Object _obj;
+        private MonoScript _script;
 
         /// <summary>
         /// Gets or sets the primary header text.
@@ -61,7 +65,20 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         /// Gets or sets the Unity Object whose script is opened on icon double-click.
         /// Setting <see langword="null"/> or an object without a resolvable script disables the open-script command.
         /// </summary>
-        public Object Obj { get; set; }
+        public Object Obj
+        {
+            get => _obj;
+            set
+            {
+                _obj = value;
+                _script = value switch
+                {
+                    MonoBehaviour mono => MonoScript.FromMonoBehaviour(mono),
+                    ScriptableObject scriptable => MonoScript.FromScriptableObject(scriptable),
+                    _ => null
+                };
+            }
+        }
 
         /// <summary>
         /// Creates an <see cref="AspidInspectorHeader"/> using <see cref="AspidInspectorHeaderPreset.Default"/>
@@ -115,8 +132,14 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
             Obj = obj;
 
             var iconElement = new Image()
-                .AddClass(IconClass)
-                .AddOpenScriptCommand(obj);
+                .AddClass(IconClass);
+
+            var doubleClick = new DoubleClickTracker();
+            iconElement.RegisterCallback<MouseUpEvent>(evt =>
+            {
+                if (evt.button != (int)MouseButton.LeftMouse) return;
+                if (doubleClick.Detect() && _script) AssetDatabase.OpenAsset(_script);
+            });
 
             iconElement.RegisterCallback<MouseEnterEvent>(OnIconMouseEnter);
             iconElement.RegisterCallback<MouseLeaveEvent>(OnIconMouseLeave);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidLabels/AspidLabelExtensions.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidLabels/AspidLabelExtensions.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.UIElements.Editors.Internal
 {
@@ -64,17 +62,6 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         }
 
         /// <summary>
-        /// Sets <see cref="AspidLabel.LabelFontStyle"/> and returns the element for chaining.
-        /// </summary>
-        /// <param name="element">The element to configure.</param>
-        /// <param name="value">The new font style.</param>
-        public static AspidLabel SetLabelFontStyle(this AspidLabel element, FontStyle value)
-        {
-            element.LabelFontStyle = value;
-            return element;
-        }
-
-        /// <summary>
         /// Sets <see cref="AspidLabel.LineTheme"/> and returns the element for chaining.
         /// </summary>
         /// <param name="element">The element to configure.</param>
@@ -104,17 +91,6 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         public static AspidLabel SetLineSize(this AspidLabel element, AspidDividingLineSizeStyle.Type value)
         {
             element.LineSize = value;
-            return element;
-        }
-
-        /// <summary>
-        /// Sets <see cref="AspidLabel.LineDirection"/> and returns the element for chaining.
-        /// </summary>
-        /// <param name="element">The element to configure.</param>
-        /// <param name="value">The new line direction.</param>
-        public static AspidLabel SetLineDirection(this AspidLabel element, AspidDividingLineDirectionStyle.Type value)
-        {
-            element.LineDirection = value;
             return element;
         }
     }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Styles/InlineStyle.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Styles/InlineStyle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.UIElements.Editors.Internal
@@ -57,12 +58,15 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
 
         /// <summary>
         /// Applies a default value (typically from a stylesheet or other external source).
-        /// Has no effect once <see cref="IsInline"/> is <c>true</c>, so inline code always wins.
+        /// Has no effect once <see cref="IsInline"/> is <c>true</c>, so inline code always wins,
+        /// and when <paramref name="value"/> equals the current value, so repeated USS resolutions
+        /// with an unchanged value do not re-trigger the change callback.
         /// </summary>
         /// <param name="value">The new default value.</param>
         public void SetDefaultValue(T value)
         {
             if (IsInline)  return;
+            if (EqualityComparer<T>.Default.Equals(Value, value)) return;
 
             _onSet?.Invoke(Value, value);
             Value = value;


### PR DESCRIPTION
## Summary

Fixes a batch of audit findings in the internal editor VisualElement components:

| File | Finding | Fix |
|---|---|---|
| `AspidInspectorHeaders/AspidInspectorHeader.cs:64` | `Obj` was write-only: the open-script command captured the ctor argument once, so setting `Obj` (or calling `SetObj`) had no effect despite the XML doc's promise | Setter now resolves the `MonoScript` on assignment and the icon double-click handler reads it dynamically — setting `null` / a script-less object disables the command, as documented |
| `AspidInspectorHeaders/AspidInspectorHeaderExtensions.cs:28` | `SetObj` fluent extension was dead (its target property did nothing) | Kept — it is now functional through the fixed `Obj` setter and matches the per-component fluent-setter template |
| `Styles/InlineStyle.cs:63` | `SetDefaultValue` had no value-equality check, so every `CustomStyleResolvedEvent` re-invoked `_onSet` (gradient-button texture churn on each restyle) | Added `EqualityComparer<T>.Default` guard; the constructor's initial invoke is untouched |
| `AspidGradientButton/AspidGradientButton.cs:133` | Gradient texture was allocated in the constructor before any attach and leaked if the button was never attached | `RebuildGradient` now no-ops while `panel == null`; `OnAttachToPanel` builds the texture, `OnDetachFromPanel` disposes it |
| `AspidLabels/AspidLabelExtensions.cs:71,115` | `SetLabelFontStyle` and `SetLineDirection` had zero call sites (repo + InternalsVisibleTo consumer) | Removed both methods and the now-unused `using UnityEngine;` |
| `AspidAnimatedLogo/AspidAnimatedLogo.cs:107` | USS resource path inlined as a string literal | Extracted into `private const string StyleSheetPath` per convention |
| `AspidAnimatedTitle/AspidAnimatedTitle.cs:146` | Same convention violation | Same extraction |
| `AspidHoverGradientOverlays/AspidHoverGradientOverlay.cs:25` | `MaxSteps` comment justified the `65535 / 6` cap with wrong arithmetic (index values vs index count) | Rewrote the comment: the cap conservatively bounds the total index count; the real ushort-index/vertex limits are only hit above ~32k steps |

## Notes for review

- The equality guard in `InlineStyle<T>.SetDefaultValue` affects all USS-driven style bindings, not just the gradient button. It only suppresses redundant `_onSet` invocations for unchanged values (class swaps of the same class, repeat repaints); inline sets and the constructor's initial callback are unchanged.
- `AspidStyles.InspectorStyleClass` was intentionally left alone — another in-flight PR starts using it.
- `AddOpenScriptCommand` now has no in-package call sites but remains as public editor API for external consumers.
