### PR TITLE
docs: sync documented API names with the code

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/SerializedPropertyExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/SerializedPropertyExtensions.md
@@ -58,7 +58,7 @@ For each supported type four variants exist:
 | `SetVector4` | `Vector4` | |
 | `SetQuaternion` | `Quaternion` | |
 | `SetAnimationCurve` | `AnimationCurve` | |
-| `SetEntityId` | `Unity.Entities.EntityId` | Unity 6.2+. The apply-variant is named `SetEntityIdApply` *(method name preserves the source typo: missing `And`)* |
+| `SetEntityId` | `EntityId` (`UnityEngine`) | Unity 6.2+ |
 
 ### Enum setters
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/VisualElementExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/VisualElementExtensions.md
@@ -153,7 +153,7 @@ Convenience methods for toggling bold / italic without overwriting the other fla
 
 | Method | Style property | Notes |
 |--------|---------------|-------|
-| `SetWorldSpacing(StyleLength)` | `wordSpacing` | |
+| `SetWordSpacing(StyleLength)` | `wordSpacing` | |
 | `SetLetterSpacing(StyleLength)` | `letterSpacing` | |
 | `SetUnityTextAlign(TextAnchor)` | `unityTextAlign` | |
 | `SetTextShadow(StyleTextShadow)` | `textShadow` | |
@@ -223,7 +223,7 @@ Available on Unity 6000.3+.
 
 | Method | Style property |
 |--------|---------------|
-| `SetAspectRation(StyleRatio)` | `aspectRatio` *(method name preserves the source typo)* |
+| `SetAspectRatio(StyleRatio)` | `aspectRatio` |
 | `SetFilter(StyleList<FilterFunction>)` | `filter` |
 | `SetUnityMaterial(StyleMaterialDefinition)` | `unityMaterial` |
 
@@ -387,7 +387,7 @@ button
 slider
     .SetLowValue(0f)
     .SetHighValue(100f)
-    .SetShowInputField<SliderFloat, float>(true);
+    .SetShowInputField(true);
 ```
 
 | Method | Description |
@@ -521,7 +521,7 @@ listView
 | `AddItemsSourceChanged(Action)` / `RemoveItemsSourceChanged` | `itemsSource` reference changed |
 | `AddCanStartDrag(Func<CanStartDragArgs, bool>)` / `RemoveCanStartDrag` | Custom drag-start gating |
 | `AddSetupDragAndDrop(Func<SetupDragAndDropArgs, StartDragArgs>)` / `RemoveSetupDragAndDrop` | Drag-and-drop preparation |
-| `AddSetupDragAndDrop(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveSetupDragAndDrop` | Drag-and-drop visual mode |
+| `AddDragAndDropUpdate(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveDragAndDropUpdate` | Drag-and-drop visual mode |
 | `AddHandleDrop(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveHandleDrop` | Drop handling |
 
 #### `BaseListView`-specific

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/SerializedPropertyExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/SerializedPropertyExtensions.md
@@ -58,7 +58,7 @@ property
 | `SetVector4` | `Vector4` | |
 | `SetQuaternion` | `Quaternion` | |
 | `SetAnimationCurve` | `AnimationCurve` | |
-| `SetEntityId` | `Unity.Entities.EntityId` | Unity 6.2+. Apply-вариант называется `SetEntityIdApply` *(имя метода сохраняет опечатку из исходника: пропущено `And`)* |
+| `SetEntityId` | `EntityId` (`UnityEngine`) | Unity 6.2+ |
 
 ### Enum setters
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/VisualElementExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/VisualElementExtensions.md
@@ -153,7 +153,7 @@ element
 
 | Метод | Свойство стиля | Примечания |
 |-------|---------------|------------|
-| `SetWorldSpacing(StyleLength)` | `wordSpacing` | |
+| `SetWordSpacing(StyleLength)` | `wordSpacing` | |
 | `SetLetterSpacing(StyleLength)` | `letterSpacing` | |
 | `SetUnityTextAlign(TextAnchor)` | `unityTextAlign` | |
 | `SetTextShadow(StyleTextShadow)` | `textShadow` | |
@@ -223,7 +223,7 @@ element
 
 | Метод | Свойство стиля |
 |-------|----------------|
-| `SetAspectRation(StyleRatio)` | `aspectRatio` *(имя метода сохраняет опечатку из исходника)* |
+| `SetAspectRatio(StyleRatio)` | `aspectRatio` |
 | `SetFilter(StyleList<FilterFunction>)` | `filter` |
 | `SetUnityMaterial(StyleMaterialDefinition)` | `unityMaterial` |
 
@@ -387,7 +387,7 @@ button
 slider
     .SetLowValue(0f)
     .SetHighValue(100f)
-    .SetShowInputField<SliderFloat, float>(true);
+    .SetShowInputField(true);
 ```
 
 | Метод | Описание |
@@ -521,7 +521,7 @@ listView
 | `AddItemsSourceChanged(Action)` / `RemoveItemsSourceChanged` | Смена ссылки `itemsSource` |
 | `AddCanStartDrag(Func<CanStartDragArgs, bool>)` / `RemoveCanStartDrag` | Кастомный gating старта drag |
 | `AddSetupDragAndDrop(Func<SetupDragAndDropArgs, StartDragArgs>)` / `RemoveSetupDragAndDrop` | Подготовка drag-and-drop |
-| `AddSetupDragAndDrop(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveSetupDragAndDrop` | Визуальный режим drag-and-drop |
+| `AddDragAndDropUpdate(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveDragAndDropUpdate` | Визуальный режим drag-and-drop |
 | `AddHandleDrop(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveHandleDrop` | Обработка drop |
 
 #### `BaseListView`-specific

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL.md
@@ -93,8 +93,8 @@ element (and alias its data); here "+" always appends a fresh, typed instance.
 **Fields:** three `IWeapon` fields with different attribute arguments.
 
 ```csharp
-[SerializeReference] [TypeSelector(typeof(IRanged))]            private IWeapon _step4Ranged;
-[SerializeReference] [TypeSelector(typeof(IMelee))]             private IWeapon _step4Melee;
+[SerializeReference] [TypeSelector(typeof(IRanged))] private IWeapon _step4Ranged;
+[SerializeReference] [TypeSelector(typeof(IMelee))] private IWeapon _step4Melee;
 [SerializeReference] [TypeSelector(typeof(IMelee), typeof(IRanged))] private IWeapon _step4MeleeOrRanged;
 ```
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL_RU.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL_RU.md
@@ -84,8 +84,8 @@ private IWeapon _weapon;
 **Поля:** три поля `IWeapon` с разными аргументами аттрибута.
 
 ```csharp
-[SerializeReference] [TypeSelector(typeof(IRanged))]            private IWeapon _step4Ranged;
-[SerializeReference] [TypeSelector(typeof(IMelee))]             private IWeapon _step4Melee;
+[SerializeReference] [TypeSelector(typeof(IRanged))] private IWeapon _step4Ranged;
+[SerializeReference] [TypeSelector(typeof(IMelee))] private IWeapon _step4Melee;
 [SerializeReference] [TypeSelector(typeof(IMelee), typeof(IRanged))] private IWeapon _step4MeleeOrRanged;
 ```
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL_RU.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/SerializeReferences/Documentation/TUTORIAL_RU.md
@@ -5,8 +5,8 @@
 **Единственное правило:** ставьте `[SerializeReference]` **и** `[TypeSelector]` на одно и то же поле. Первое говорит Unity хранить полиморфный экземпляр, второе рисует выпадающий селектор типов с поиском.
 
 ```csharp
-[TypeSelector]
-[SerializeReference] private IWeapon _weapon;
+[SerializeReference] [TypeSelector]
+private IWeapon _weapon;
 ```
 
 ## Как открыть туториал
@@ -26,7 +26,7 @@
 
 ## Урок 1 — Ваш первый селектор
 
-**Поле:** `[TypeSelector] [SerializeReference] IWeapon _step1Single`
+**Поле:** `IWeapon _step1Single` · `[SerializeReference] [TypeSelector]`
 
 Кликните по выпадающему списку в заголовке поля. Откроется иерархическое окно с поиском, в котором перечислены все конкретные реализации `IWeapon`: `Sword`, `Pistol`, `Shotgun`, `Railgun`, `Crossbow`.
 
@@ -48,7 +48,7 @@
 
 ## Урок 2 — Списки и массивы
 
-**Поле:** `[TypeSelector] [SerializeReference] List<IWeapon> _step2List`
+**Поле:** `List<IWeapon> _step2List` · `[SerializeReference] [TypeSelector]`
 
 `List<T>` (или массив) поля `[SerializeReference]` превращает каждый элемент в собственный независимый селектор.
 
@@ -64,7 +64,7 @@
 
 ## Урок 3 — Абстрактные базы и интерфейсы
 
-**Поле:** `[TypeSelector] [SerializeReference] StatusEffect _step3Abstract`
+**Поле:** `StatusEffect _step3Abstract` · `[SerializeReference] [TypeSelector]`
 
 `StatusEffect` — **абстрактный** класс, создать его через `new` нельзя.
 
@@ -84,14 +84,9 @@
 **Поля:** три поля `IWeapon` с разными аргументами аттрибута.
 
 ```csharp
-[TypeSelector(typeof(IRanged))]
-[SerializeReference] private IWeapon _step4Ranged;
-
-[TypeSelector(typeof(IMelee))]
-[SerializeReference] private IWeapon _step4Melee;
-
-[TypeSelector(typeof(IMelee), typeof(IRanged))] 
-[SerializeReference] private IWeapon _step4MeleeOrRanged;
+[SerializeReference] [TypeSelector(typeof(IRanged))]            private IWeapon _step4Ranged;
+[SerializeReference] [TypeSelector(typeof(IMelee))]             private IWeapon _step4Melee;
+[SerializeReference] [TypeSelector(typeof(IMelee), typeof(IRanged))] private IWeapon _step4MeleeOrRanged;
 ```
 
 Все три поля объявлены как `IWeapon`, но селектор показывает разные наборы. Базовые типы, переданные в `[TypeSelector(...)]`, работают как **дополнительный фильтр, применяемый ниже объявленного типа поля**:
@@ -114,11 +109,11 @@
 
 ## Урок 5 — Вложенные ссылки (рекурсия)
 
-**Поле:** `[TypeSelector] [SerializeReference] IWeapon _step5Nested`
+**Поле:** `IWeapon _step5Nested` · `[SerializeReference] [TypeSelector]`
 
 **Попробуйте:**
 1. Выберите **`Railgun`** и разверните его foldout.
-2. Найдите его поле `Charge Effect` — это снова `[TypeSelector] [SerializeReference] StatusEffect`.
+2. Найдите его поле `Charge Effect` — это снова `[SerializeReference] [TypeSelector] StatusEffect`.
 3. Откройте *этот* селектор и присвойте `BurnEffect` или `FreezeEffect`.
 
 **Обратите внимание:**
@@ -152,7 +147,7 @@
 
 **Поля:** `WeaponSlot _step7Slot` и `List<WeaponSlot> _step7Slots`.
 
-`WeaponSlot` (`Scripts/WeaponSlot.cs`) — обычный `[Serializable]`-класс (сам не managed-ссылка), содержащий `label`, `priority` и `[TypeSelector] [SerializeReference] IWeapon`.
+`WeaponSlot` (`Scripts/WeaponSlot.cs`) — обычный `[Serializable]`-класс (сам не managed-ссылка), содержащий `label`, `priority` и `[SerializeReference] [TypeSelector] IWeapon`.
 
 **Попробуйте:**
 1. Разверните `_step7Slot` и выберите оружие для его внутреннего поля.

--- a/README_RU.md
+++ b/README_RU.md
@@ -202,7 +202,6 @@ public sealed class AbilitySelector : MonoBehaviour
     }
 }
 ```
-<!-- TODO(media): re-record aspid_fasttools_serializable_type.gif — picker now has Favorites/Recent and the new window styling -->
 ![aspid_fasttools_serializable_type.gif](Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/Images/aspid_fasttools_serializable_type.gif)
 
 ### TypeSelectorAttribute
@@ -295,7 +294,6 @@ public sealed class DamageModifier { }
 - Поддержку generic-типов — выбор открытого generic ведёт через выбор его аргументов и возвращает сконструированный тип
 - Настройку Favorites/Recent (вкл/выкл, ёмкость Recent) во вкладке Settings окна SerializeReference
 
-<!-- TODO(media): re-shoot aspid_fasttools_type_selector_window.png — window UI changed (Favorites/Recent, counters, dividers) -->
 ![aspid_fasttools_type_selector_window.png](Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/Images/aspid_fasttools_type_selector_window.png)
 
 Это же окно доступно как публичный API — открывайте его из любого editor-кода (кастомных инспекторов, `EditorWindow`, пунктов меню), когда нужно вывести выбор типа за пределами стандартного потока `SerializableType` / `[TypeSelector]`.


### PR DESCRIPTION
## Summary

Sync documented API names and mirrored EN/RU doc copies with the actual code (audit findings, adversarially verified).

### Documentation/EN|RU/VisualElementExtensions.md

| Line | Was | Now |
|---|---|---|
| 156 | `SetWorldSpacing(StyleLength)` — no such method | `SetWordSpacing(StyleLength)` (matches `VisualElementExtensions.Style.cs` / `IStyleExtensions.cs`) |
| 226 | `SetAspectRation(StyleRatio)` with a note claiming the typo is preserved in code | `SetAspectRatio(StyleRatio)` — the code typo was fixed, note removed |
| 390 | Slider example `.SetShowInputField<SliderFloat, float>(true)` — `SliderFloat` does not exist, wrong arity | `.SetShowInputField(true)` — matches `SetShowInputField<TValue>(this BaseSlider<TValue>, bool)` |
| 524 | Duplicated `AddSetupDragAndDrop(Func<HandleDragAndDropArgs, DragVisualMode>)` / `RemoveSetupDragAndDrop` row | `AddDragAndDropUpdate` / `RemoveDragAndDropUpdate` — the real API for that signature (`BaseVerticalCollectionViewExtensions.cs`) |

### Documentation/EN|RU/SerializedPropertyExtensions.md

- Line 61: the `SetEntityId` row claimed the apply-variant is named `SetEntityIdApply` (a "preserved source typo") — the code method is `SetEntityIdAndApply`, so the row now follows the standard `SetXxxAndApply` pattern documented above the table; the parameter type corrected from `Unity.Entities.EntityId` to `EntityId` (`UnityEngine`).

### README_RU.md (repo root)

- Lines 205/298: removed two `TODO(media)` comments already resolved and absent from the other three synced README copies — README_RU.md is back to 809 lines, matching README.md.

### Samples~/SerializeReferences/Documentation/TUTORIAL_RU.md

- All code fences and inline field signatures reversed the attribute order (`[TypeSelector]` before `[SerializeReference]`, split across lines) versus TUTORIAL.md and the shipped sample source (`TypeSelectorTutorial.cs`) — realigned to `[SerializeReference] [TypeSelector]` and the EN inline format.

All fixes applied to both EN and RU copies; every corrected name verified against the code with grep. No skipped findings.

## Notes for review

- Docs-only change; no code touched.
