### PR TITLE
fix(editor): GetClassInstance resolves array/list element properties

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializedProperties/SerializePropertyExtensions.Reflection.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializedProperties/SerializePropertyExtensions.Reflection.cs
@@ -18,26 +18,35 @@ namespace Aspid.FastTools.Editors
 
         /// <summary>
         /// Returns the <see cref="Type"/> of the field or property that backs this <see cref="SerializedProperty"/>.
+        /// For an array/list element property the element type is returned.
         /// </summary>
         /// <param name="serializedProperty">The property to inspect.</param>
         /// <returns>
-        /// The <see cref="FieldInfo.FieldType"/> or <see cref="PropertyInfo.PropertyType"/> of the backing member,
+        /// The <see cref="FieldInfo.FieldType"/> or <see cref="PropertyInfo.PropertyType"/> of the backing member
+        /// (the element type when the property is an array/list element),
         /// or <see langword="null"/> if the member cannot be resolved.
         /// </returns>
-        public static Type GetPropertyType(this SerializedProperty serializedProperty) => GetMemberInfo(serializedProperty) switch
+        public static Type GetPropertyType(this SerializedProperty serializedProperty)
         {
-            FieldInfo field => field.FieldType,
-            PropertyInfo property => property.PropertyType,
-            _ => null
-        };
+            var type = GetMemberInfo(serializedProperty) switch
+            {
+                FieldInfo field => field.FieldType,
+                PropertyInfo property => property.PropertyType,
+                _ => null
+            };
+
+            return IsArrayElement(serializedProperty) ? GetElementType(type) : type;
+        }
 
         /// <summary>
         /// Uses reflection to find the <see cref="MemberInfo"/> (field or property) on the owning class
         /// that corresponds to this <see cref="SerializedProperty"/>.
+        /// For an array/list element property the collection field itself is returned.
         /// </summary>
         /// <param name="serializedProperty">The property whose backing member should be located.</param>
         /// <returns>
-        /// The <see cref="MemberInfo"/> whose name matches <see cref="SerializedProperty.name"/>,
+        /// The <see cref="MemberInfo"/> whose name matches <see cref="SerializedProperty.name"/>
+        /// (the collection field when the property is an array/list element),
         /// or <see langword="null"/> if it cannot be found.
         /// </returns>
         public static MemberInfo GetMemberInfo(this SerializedProperty serializedProperty)
@@ -45,29 +54,29 @@ namespace Aspid.FastTools.Editors
             var instance = serializedProperty.GetClassInstance();
             if (instance is null) return null;
 
+            var memberName = GetMemberName(serializedProperty);
             return instance.GetType()
                 .GetMembersInfosIncludingBaseClasses(BindingFlags)
-                .FirstOrDefault(member => member.Name == serializedProperty.name);
+                .FirstOrDefault(member => member.Name == memberName);
         }
 
         /// <summary>
         /// Traverses the <see cref="SerializedProperty.propertyPath"/> to return the runtime object instance
         /// that directly owns this property (i.e., the containing class instance, not the root target).
-        /// Supports nested objects, arrays, and generic <see cref="List{T}"/> fields.
+        /// Supports nested objects, arrays, and generic <see cref="List{T}"/> fields;
+        /// for an array/list element property the instance owning the collection field is returned.
         /// </summary>
         /// <param name="property">The property whose owning instance should be resolved.</param>
         /// <returns>The runtime object that contains the field represented by <paramref name="property"/>.</returns>
         public static object GetClassInstance(this SerializedProperty property)
         {
-            var path = property.propertyPath;
             var target = property.serializedObject.targetObject;
-            var startRemoveIndex = path.Length - property.name.Length - 1;
+            var path = property.propertyPath.Replace(".Array.data[", "[");
 
-            if (startRemoveIndex < 0) return target;
-            
-            path = path
-                .Remove(startRemoveIndex)
-                .Replace(".Array.data[", "[");
+            var lastDotIndex = path.LastIndexOf('.');
+            if (lastDotIndex < 0) return target;
+
+            path = path.Remove(lastDotIndex);
 
             object current = target;
 
@@ -108,6 +117,43 @@ namespace Aspid.FastTools.Editors
                     .OfType<FieldInfo>()
                     .FirstOrDefault(field => field.Name == name);
             }
+        }
+
+        /// <summary>
+        /// The name of the member that backs <paramref name="property"/>: <see cref="SerializedProperty.name"/>
+        /// for a regular property, the collection field's name for an array/list element
+        /// (whose path ends with <c>Array.data[i]</c> while its name is just <c>data</c>).
+        /// </summary>
+        private static string GetMemberName(SerializedProperty property)
+        {
+            if (!IsArrayElement(property)) return property.name;
+
+            var path = property.propertyPath.Replace(".Array.data[", "[");
+            var lastDotIndex = path.LastIndexOf('.');
+            var lastSegment = lastDotIndex < 0 ? path : path[(lastDotIndex + 1)..];
+
+            return lastSegment[..lastSegment.IndexOf('[')];
+        }
+
+        /// <summary>
+        /// True when <paramref name="property"/> is itself an element of an array or <see cref="List{T}"/>
+        /// (its <see cref="SerializedProperty.propertyPath"/> ends with an <c>Array.data[i]</c> segment).
+        /// </summary>
+        private static bool IsArrayElement(SerializedProperty property) =>
+            property.propertyPath.EndsWith("]", StringComparison.Ordinal);
+
+        /// <summary>
+        /// Unwraps the element type of an array or single-argument generic collection type;
+        /// returns <paramref name="collectionType"/> unchanged when it is not one.
+        /// </summary>
+        private static Type GetElementType(Type collectionType)
+        {
+            if (collectionType is null) return null;
+            if (collectionType.IsArray) return collectionType.GetElementType();
+
+            return collectionType.IsGenericType && collectionType.GetGenericArguments() is { Length: 1 } arguments
+                ? arguments[0]
+                : collectionType;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixed `SerializePropertyExtensions.Reflection.cs:64` — `GetClassInstance` stripped the `propertyPath` suffix arithmetically from `property.name`, which cuts mid-segment when the property is itself an array/list element (path ends with `Array.data[i]` while `name` is `data`): for `list.Array.data[2]` it produced `list.Array.da`, so the walk failed and the method returned `null`. It now strips the last segment of the normalized path, returning the instance that owns the collection field.
- `GetMemberInfo` on an element property now resolves the collection field itself (the raw name `data` never matches a real member), so it no longer silently returns `null`.
- `GetPropertyType` on an element property now unwraps and returns the element type instead of `null`.

## Notes for review

- Regular properties, mid-path elements (`list.Array.data[i].inner`), and the collection property itself resolve exactly as before — the only in-package caller (`SerializeReferenceEditorGUI.GetElementType`) is unaffected.
- `SerializePropertyExtensions.SetValue.cs` was intentionally left untouched (including the `UNITY_6000_0_OR_NEWER` guard).
- Audit finding fixed: `Unity/Editor/Scripts/SerializedProperties/SerializePropertyExtensions.Reflection.cs:64` — element-property paths broke `GetClassInstance`, making `GetMemberInfo`/`GetPropertyType` return `null` despite the documented array/`List<T>` support. No findings skipped.
