### PR TITLE
Restore main compilation after audit-cleanup regressions

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
@@ -309,7 +309,7 @@ MonoBehaviour:
 ";
 
         // The single-object document file id and the two rids of the shadowed-field fixture below.
-        public const long ShadowedFileId = 9900000000000000003L;
+        public const long ShadowedFileId = 9000000000000000003L;
         public const long ShadowedNestedRid = 4001;   // _config._weapon (nested inside a plain serializable container)
         public const long ShadowedTopLevelRid = 4002; // _weapon         (the real top-level field)
 
@@ -320,7 +320,7 @@ MonoBehaviour:
         public const string ShadowedFieldPrefab =
 @"%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &9900000000000000003
+--- !u!114 &9000000000000000003
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_Script: {fileID: 11500000, guid: 884d53b5154744d3af6948b1eef02505, type: 3}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Index/SerializeReferenceTypeUsageIndex.cs
@@ -100,6 +100,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         /// <summary>
+        /// Number of use sites of <paramref name="type"/>.
+        /// </summary>
+        public static int CountUsages(Type type) => FindUsages(type).Count;
+
+        /// <summary>
         /// Every use site whose stored type no longer resolves — the fast-scan source for the Repair window.
         /// </summary>
         public static IEnumerable<Usage> EnumerateUnresolved()


### PR DESCRIPTION
## Summary

- 🐛 Restore `SerializeReferenceTypeUsageIndex.CountUsages(Type)` — the dead-member cleanup deleted it as "unreferenced", but `SerializeReferenceDeleteGuard` still calls it on the warm-index batch path (CS0117).
- 🐛 Fix `YamlFixtures.ShadowedFileId`: the literal `9900000000000000003L` exceeds `long.MaxValue`, so it is inferred as `ulong` and fails the `const long` assignment (CS0266). Lower it (and the matching YAML anchor) to `9000000000000000003`, a valid `long` fixture id.

## Notes for review

- ⚠️ Both are compile-breaking regressions from the recent audit/cleanup wave — `main` currently does not compile (editor + test assemblies). Verified via unicli: the full Unity project compiles with 0 errors after these two changes.
