### PR TITLE
test: prune redundant tests and fix intersection assertion

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferencePendingAssignmentTests.cs
@@ -146,16 +146,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
             Assert.AreEqual("Game.B", queue[1].FullTypeName);
         }
 
-        [Test]
-        public void GiveUpBoundary_LastIncrementBeforeCapSurvives_NextOneIsAbandoned()
-        {
-            var oneShort = new Entry(GlobalId, Path, TypeName, Store.MaxResolveAttempts - 2).WithIncrementedAttempt();
-            Assert.Less(oneShort.Attempts, Store.MaxResolveAttempts,
-                "An entry one short of the cap must remain pending after the next reload.");
-
-            Assert.GreaterOrEqual(oneShort.WithIncrementedAttempt().Attempts, Store.MaxResolveAttempts,
-                "Reaching the attempt cap is the give-up boundary the resolver drops (with a warning) on.");
-        }
     }
 
     // A persistable target for the resolve-pass tests: saved as an asset so its GlobalObjectId round-trips back to the

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorHardeningTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorHardeningTests.cs
@@ -188,25 +188,6 @@ MonoBehaviour:
             }
         }
 
-        // ---- positive control: the guards do NOT regress a well-formed, space-indented Unity asset --------------------
-
-        [Test]
-        public void WellFormedUnityAsset_PassesGuards_RemoveEntrySucceeds()
-        {
-            var path = YamlFixtures.WriteTemp(YamlFixtures.MissingTypePrefab);
-            try
-            {
-                Assert.IsTrue(SerializeReferenceYamlEditor.TryRemoveEntry(
-                    path, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid),
-                    "A canonical Unity asset (%TAG present, space-indented) must still be editable after hardening.");
-                StringAssert.DoesNotContain("Shotgun", File.ReadAllText(path));
-            }
-            finally
-            {
-                YamlFixtures.Delete(path);
-            }
-        }
-
         [Test]
         public void TryRemoveEntry_BlankLineWithStrayTabInsideEntry_StillRemoves_LeavesNoEntry()
         {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeUtilityTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeUtilityTests.cs
@@ -14,13 +14,6 @@ namespace Aspid.FastTools.Types.Editors.Tests
     internal sealed class SerializableTypeUtilityTests
     {
         [Test]
-        public void BothWrappers_ImplementISerializableType()
-        {
-            Assert.IsInstanceOf<ISerializableType>(new SerializableType());
-            Assert.IsInstanceOf<ISerializableType>(new SerializableType<Exception>());
-        }
-
-        [Test]
         public void BaseType_IsObject_OnTheUnconstrainedWrapper()
         {
             ISerializableType wrapper = new SerializableType();

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorAttributeTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorAttributeTests.cs
@@ -6,31 +6,16 @@ namespace Aspid.FastTools.Types.Editors.Tests
     /// Guards the default of <see cref="TypeSelectorAttribute.Allow"/>. Every "name a type" context
     /// (a raw <c>string</c> picker or a <see cref="SerializableType"/>) offers abstract classes and
     /// interfaces unless the field opts out with <see cref="TypeAllow.None"/>, so the attribute must
-    /// default to <see cref="TypeAllow.All"/> whichever constructor built it — and an explicit value
-    /// must still win over that default.
+    /// default to <see cref="TypeAllow.All"/>.
     /// </summary>
     [TestFixture]
     internal sealed class TypeSelectorAttributeTests
     {
         [Test]
-        public void Allow_DefaultsToAll_OnTheParameterlessConstructor()
+        public void Allow_DefaultsToAll()
         {
             var attribute = new TypeSelectorAttribute();
             Assert.AreEqual(TypeAllow.All, attribute.Allow);
-        }
-
-        [Test]
-        public void Allow_DefaultsToAll_OnTheSingleTypeConstructor()
-        {
-            var attribute = new TypeSelectorAttribute(typeof(object));
-            Assert.AreEqual(TypeAllow.All, attribute.Allow);
-        }
-
-        [Test]
-        public void Allow_HonoursAnExplicitNone()
-        {
-            var attribute = new TypeSelectorAttribute(typeof(object)) { Allow = TypeAllow.None };
-            Assert.AreEqual(TypeAllow.None, attribute.Allow);
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorIntersectionTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorIntersectionTests.cs
@@ -28,7 +28,9 @@ namespace Aspid.FastTools.Types.Editors.Tests
 
         private static void Collect(TreeNode node, List<string> names)
         {
-            if (node.IsType) names.Add(node.DisplayName);
+            // FlattenSingleChildChain merges a lone leaf into its namespace chain ("Ns.Sub.Sword"),
+            // so keep only the trailing segment of the display name.
+            if (node.IsType) names.Add(node.DisplayName[(node.DisplayName.LastIndexOf('.') + 1)..]);
             foreach (var child in node.Children) Collect(child, names);
         }
 


### PR DESCRIPTION
## Summary

- ♻️ Remove five tests found redundant in a full test audit: a ctor-default duplicate and an auto-property tautology (`TypeSelectorAttributeTests`), a compile-time-enforced interface check (`SerializableTypeUtilityTests`), a give-up-boundary arithmetic tautology that never invoked `ResolvePass` (`SerializeReferencePendingAssignmentTests`), and a positive control fully subsumed by the rewrite suite (`SerializeReferenceYamlEditorHardeningTests`).
- 🐛 Fix `TypeSelectorIntersectionTests` to compare the trailing display-name segment: `FlattenSingleChildChain` merges a lone leaf into its namespace chain, so a single-type intersection reports `Ns.Sub.Sword` instead of `Sword`.

## Notes for review

- Full EditMode suite after pruning: 220/220 green.
- Companion PR in the analyzers submodule removes one duplicate test there; the gitlink bump will follow once that PR merges.

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- ♻️ Удалены пять тестов, признанных избыточными в полном аудите: дубликат дефолтов конструктора и тавтология auto-property (`TypeSelectorAttributeTests`), проверка интерфейса, которую и так гарантирует компилятор (`SerializableTypeUtilityTests`), арифметическая тавтология границы give-up, ни разу не вызывавшая `ResolvePass` (`SerializeReferencePendingAssignmentTests`), и позитивный контроль, полностью поглощённый rewrite-сьютом (`SerializeReferenceYamlEditorHardeningTests`).
- 🐛 Исправлен `TypeSelectorIntersectionTests`: сравнивается хвостовой сегмент display name — `FlattenSingleChildChain` сливает одинокий лист в цепочку namespace, поэтому пересечение из одного типа репортит `Ns.Sub.Sword`, а не `Sword`.

## Notes for review

- Полный EditMode-сьют после чистки: 220/220 зелёные.
- Парный PR в сабмодуле analyzers удаляет один дубликат там; бамп gitlink последует после мержа того PR.

</details>
