### PR TITLE
ci: run generator and analyzer test suites on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dotnet-tests:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Generators
+            path: Aspid.FastTools.Generators
+          - name: Analyzers
+            path: Aspid.FastTools.Analyzers
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # The test projects target net6.0; the 8.0 SDK builds them, the 6.0 runtime runs them.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+
+      - name: Run ${{ matrix.name }} tests
+        run: dotnet test "${{ matrix.path }}" --nologo


### PR DESCRIPTION
## Summary

- ✅ New `tests.yml` workflow runs both dotnet suites — Generators (36 tests) and the Analyzers submodule (28) — on every PR and on pushes to `main`; previously no workflow ran any tests.
- ⚡ Matrix job on `ubuntu-latest` with `submodules: true` checkout; 8.0 SDK builds the `net6.0` test projects, 6.0 runtime executes them. Superseded runs are cancelled via `concurrency`.

## Linked issues

Closes ASP-51

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- ✅ Новый workflow `tests.yml` запускает оба dotnet-сьюта — Generators (36 тестов) и сабмодуль Analyzers (28) — на каждом PR и на пушах в `main`; раньше тесты не запускал ни один workflow.
- ⚡ Matrix-джоба на `ubuntu-latest` с checkout `submodules: true`; SDK 8.0 собирает тестовые проекты `net6.0`, рантайм 6.0 их выполняет. Устаревшие запуски отменяются через `concurrency`.

</details>
