### PR TITLE
fix(editor): catch Required violations in nested serializable containers

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceInspectorTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceInspectorTests.cs
@@ -56,6 +56,29 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
         }
 
         [Test]
+        public void IsViolation_RequiredInNestedContainer_TrueWhenEmpty_FalseWhenSet()
+        {
+            // Parity pin for ASP-52: the live half resolves the attribute through the container hop, so the
+            // inspector notice and the YAML scan agree on nested required fields.
+            var obj = ScriptableObject.CreateInstance<NestedRequiredTestObject>();
+            try
+            {
+                var serialized = new SerializedObject(obj);
+                Assert.IsTrue(SerializeReferenceRequiredGate.IsViolation(serialized.FindProperty("_loadout.primary")),
+                    "An empty required managed reference inside a serializable container is a violation.");
+
+                var prop = serialized.FindProperty("_loadout.primary");
+                prop.managedReferenceValue = new TestSword();
+                serialized.ApplyModifiedProperties();
+                serialized.Update();
+
+                Assert.IsFalse(SerializeReferenceRequiredGate.IsViolation(serialized.FindProperty("_loadout.primary")),
+                    "A set nested required managed reference is not a violation.");
+            }
+            finally { UnityEngine.Object.DestroyImmediate(obj); }
+        }
+
+        [Test]
         public void IsViolation_RequiredString_TrueWhenEmpty_FalseWhenSet()
         {
             var obj = ScriptableObject.CreateInstance<RequiredTestObject>();

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceRequiredYamlTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceRequiredYamlTests.cs
@@ -157,5 +157,71 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
 
             Assert.AreEqual(0, violations.Count, "A populated SerializableType is not a violation.");
         }
+
+        // ---- required fields nested inside plain [Serializable] containers (ASP-52) ------------------------------------
+
+        [Test]
+        public void GetRequiredFields_NestedContainer_ReturnsPathedDescriptors()
+        {
+            var byPath = SerializeReferenceRequiredGate.GetRequiredFields(typeof(NestedRequiredTestObject))
+                .ToDictionary(field => field.Path, field => field.Kind);
+
+            Assert.AreEqual(2, byPath.Count, "Both required fields inside the container should be returned.");
+            Assert.AreEqual(RequiredFieldKind.ManagedReference, byPath["_loadout.primary"],
+                "The nested managed reference is reported under its container path.");
+            Assert.AreEqual(RequiredFieldKind.String, byPath["_loadout.typeName"],
+                "The nested string type field is reported under its container path.");
+        }
+
+        [Test]
+        public void GetRequiredFields_SelfReferentialContainer_TerminatesAndPrunesCycle()
+        {
+            var paths = SerializeReferenceRequiredGate.GetRequiredFields(typeof(CycleRequiredTestObject))
+                .Select(field => field.Path).ToList();
+
+            Assert.AreEqual(new[] { "root.typeName" }, paths,
+                "The cyclic 'next' branch must be pruned, leaving exactly the first level's required field.");
+        }
+
+        // Maps the fixtures' script guid to NestedRequiredTestObject, whose required fields all sit inside _loadout.
+        private static IReadOnlyList<RequiredFieldDescriptor> ResolveNested(string guid) =>
+            guid == YamlFixtures.RequiredSceneScriptGuid
+                ? SerializeReferenceRequiredGate.GetRequiredFields(typeof(NestedRequiredTestObject))
+                : Array.Empty<RequiredFieldDescriptor>();
+
+        [Test]
+        public void FindUnsetRequiredFields_NestedUnset_ReportsBothWithPaths()
+        {
+            _path = YamlFixtures.WriteTemp(YamlFixtures.RequiredSceneNestedUnset);
+
+            var violations = SerializeReferenceYamlEditor.FindUnsetRequiredFields(_path, ResolveNested);
+
+            Assert.AreEqual(2, violations.Count, "Both unset fields inside the container should be reported.");
+
+            var managed = violations.Single(v => v.FieldName == "_loadout.primary");
+            Assert.AreEqual(-2L, managed.Rid, "The nested unset managed reference reads the null id (-2).");
+            Assert.IsTrue(violations.Any(v => v.FieldName == "_loadout.typeName"),
+                "The nested empty string field is a violation.");
+        }
+
+        [Test]
+        public void FindUnsetRequiredFields_NestedSet_ReportsNone()
+        {
+            _path = YamlFixtures.WriteTemp(YamlFixtures.RequiredSceneNestedSet);
+            var violations = SerializeReferenceYamlEditor.FindUnsetRequiredFields(_path, ResolveNested);
+
+            Assert.AreEqual(0, violations.Count, "Set fields inside the container are not violations.");
+        }
+
+        [Test]
+        public void FindUnsetRequiredFields_NestedContainerAbsent_ReportsNone()
+        {
+            // The whole container key is missing (object saved before the field was added) — like a top-level absent
+            // key, that needs a reserialize, not a build failure.
+            _path = YamlFixtures.WriteTemp(YamlFixtures.RequiredSceneNestedContainerAbsent);
+            var violations = SerializeReferenceYamlEditor.FindUnsetRequiredFields(_path, ResolveNested);
+
+            Assert.AreEqual(0, violations.Count, "An absent container key is not a violation — it needs a reserialize.");
+        }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceTestFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceTestFixtures.cs
@@ -31,6 +31,36 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
         [TypeSelector(Required = true)] public string requiredString;
     }
 
+    // A plain [Serializable] by-value container holding required fields — the nesting shape the required gate must
+    // recurse into (ASP-52): the fields appear in YAML as children of the container key, not at the document top level.
+    [Serializable]
+    internal sealed class RequiredLoadout
+    {
+        [SerializeReference, TypeSelector(Required = true)] public ITestWeapon primary;
+        [TypeSelector(Required = true)] public string typeName;
+    }
+
+    // A component whose only required fields live inside a nested serializable container ([SerializeField] private,
+    // so the walk is proven to include non-public serialized fields).
+    internal sealed class NestedRequiredTestObject : ScriptableObject
+    {
+        [SerializeField] private RequiredLoadout _loadout = new();
+    }
+
+    // A self-referential serializable shape: the reflection walk must terminate on the cycle instead of recursing
+    // forever (Unity itself refuses such graphs at serialize time, but GetRequiredFields sees the raw type).
+    [Serializable]
+    internal sealed class RequiredCycleNode
+    {
+        public RequiredCycleNode next;
+        [TypeSelector(Required = true)] public string typeName;
+    }
+
+    internal sealed class CycleRequiredTestObject : ScriptableObject
+    {
+        public RequiredCycleNode root;
+    }
+
     // Top-level (namespace-scoped) candidate pool for the ranking tests. The marker interface keeps the TypeCache
     // pool down to these two types, so the assertions never race additions elsewhere in the project.
     internal interface IRepairRankTarget { }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/YamlFixtures.cs
@@ -447,6 +447,81 @@ MonoBehaviour:
     _assemblyQualifiedName: Aspid.FastTools.Samples.SerializeReferences.Pistol, Aspid.FastTools.Samples.SerializeReferences
 ";
 
+        // A scene whose required fields live INSIDE a plain [Serializable] container (_loadout) — both unset: the
+        // managed reference (primary) at the null id, the string (typeName) empty. Unity writes the container as a
+        // nested mapping, so the keys sit one indent level below the document's top-level fields (ASP-52).
+        public const string RequiredSceneNestedUnset =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+  _loadout:
+    primary:
+      rid: -2
+    typeName:
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
+";
+
+        // The same nested-container scene with both fields set: primary points at a real rid, typeName holds a name.
+        // No violations expected.
+        public const string RequiredSceneNestedSet =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+  _loadout:
+    primary:
+      rid: 5001
+    typeName: 'Aspid.FastTools.Samples.SerializeReferences.Pistol, Aspid.FastTools.Samples.SerializeReferences'
+  references:
+    version: 2
+    RefIds:
+    - rid: 5001
+      type: {class: Pistol, ns: Aspid.FastTools.Samples.SerializeReferences, asm: Aspid.FastTools.Samples.SerializeReferences}
+      data:
+        _damage: 5
+";
+
+        // The nested-container scene with the WHOLE _loadout key absent (object saved before the container field was
+        // added). Like a top-level absent key, this needs a reserialize, not a build failure — no violations expected.
+        public const string RequiredSceneNestedContainerAbsent =
+@"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100
+GameObject:
+  m_Component:
+  - component: {fileID: 101}
+  m_Name: Hero
+--- !u!114 &101
+MonoBehaviour:
+  m_GameObject: {fileID: 100}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}
+  m_Name:
+";
+
         // The same scene where BOTH required keys are ABSENT from the MonoBehaviour — the shape Unity writes when the
         // object was last saved before the [TypeSelector(Required = true)] fields were added (also stripped / nested-prefab
         // docs). Reserializing fills the defaults; until then the gate must NOT flag the missing keys, so no violations

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Build/SerializeReferenceGateScanner.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Build/SerializeReferenceGateScanner.cs
@@ -13,7 +13,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// asset's objects and checks <see cref="SerializeReferenceRequiredGate.IsViolation"/> per managed-reference and
     /// string type property; scenes — which cannot be read through <see cref="AssetDatabase.LoadAllAssetsAtPath"/> — go
     /// through the pure-YAML <see cref="SerializeReferenceYamlEditor.FindUnsetRequiredFields"/> instead, so a <c>.unity</c>
-    /// is covered for top-level required fields too.
+    /// is covered too — including required fields nested inside plain serializable containers.
     /// </summary>
     internal static class SerializeReferenceGateScanner
     {
@@ -48,7 +48,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (options.ScanRequiredFields)
                 {
                     // Scenes cannot be object-loaded, so they take the pure-YAML required scan; saved assets keep the
-                    // object-load path, which also covers required fields nested inside serializable containers.
+                    // object-load path. Both cover required fields nested inside serializable containers.
                     if (SerializeReferenceHelpers.IsScene(path)) CollectSceneRequiredViolations(path, violations);
                     else CollectRequiredViolations(path, violations);
                 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRequiredGate.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceRequiredGate.cs
@@ -62,12 +62,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         /// <summary>
-        /// Reflects the top-level serialized fields of <paramref name="type"/> that opt into the required check
-        /// (<c>[TypeSelector(Required = true)]</c>), classifying each as a <c>string</c> field or a
-        /// <c>[SerializeReference]</c> managed reference. Drives the pure-YAML scene scan, which needs the field keys and
-        /// kinds without a live <see cref="SerializedObject"/>. Cached per type (stable until a domain reload). Fields
-        /// nested inside serializable containers are out of scope — only the type's own declared fields are returned,
-        /// matching the scene scan's top-level reach.
+        /// Reflects the serialized fields of <paramref name="type"/> that opt into the required check
+        /// (<c>[TypeSelector(Required = true)]</c>), classifying each as a <c>string</c> field, a
+        /// <see cref="SerializableType"/> wrapper or a <c>[SerializeReference]</c> managed reference. Drives the
+        /// pure-YAML scene scan, which needs the field keys and kinds without a live <see cref="SerializedObject"/>.
+        /// Recurses into plain <c>[Serializable]</c> by-value containers (their fields nest as child keys in YAML),
+        /// recording the container chain in <see cref="RequiredFieldDescriptor.Parents"/>. Collections of containers
+        /// and fields behind a <c>[SerializeReference]</c> hop are out of scope — their values live outside the
+        /// document's top-level mapping (indexed elements / <c>RefIds</c> data). Cached per type (stable until a
+        /// domain reload).
         /// </summary>
         public static IReadOnlyList<RequiredFieldDescriptor> GetRequiredFields(Type type)
         {
@@ -75,31 +78,80 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (RequiredFieldCache.TryGetValue(type, out var cached)) return cached;
 
             var result = new List<RequiredFieldDescriptor>();
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-
-            // Walk the hierarchy declared-only per level so a base field is read once; a `new`-shadowed name (one YAML
-            // key) is de-duplicated so it is never reported twice.
-            for (var current = type; current is not null && current != typeof(object); current = current.BaseType)
-            {
-                foreach (var field in current.GetFields(DeclaredFieldFlags))
-                {
-                    var selector = field.GetCustomAttribute<TypeSelectorAttribute>();
-                    if (selector is null || !selector.Required) continue;
-                    if (!seen.Add(field.Name)) continue;
-
-                    if (field.FieldType == typeof(string))
-                        result.Add(new RequiredFieldDescriptor(field.Name, RequiredFieldKind.String));
-                    else if (IsSerializableTypeField(field.FieldType))
-                        result.Add(new RequiredFieldDescriptor(field.Name, RequiredFieldKind.SerializableType));
-                    else if (field.IsDefined(typeof(SerializeReference), inherit: false))
-                        result.Add(new RequiredFieldDescriptor(field.Name, RequiredFieldKind.ManagedReference));
-                    // A required [TypeSelector] on any other shape is a misuse the analyzer flags; skip it here.
-                }
-            }
+            CollectRequiredFields(type, Array.Empty<string>(), new HashSet<Type>(), new HashSet<string>(StringComparer.Ordinal), result);
 
             IReadOnlyList<RequiredFieldDescriptor> readOnly = result;
             RequiredFieldCache[type] = readOnly;
             return readOnly;
+        }
+
+        // Unity refuses deeper by-value nesting at serialize time ("Serialization depth limit 10 exceeded"), so a
+        // longer container chain cannot exist in a saved file.
+        private const int MaxContainerDepth = 10;
+
+        private static void CollectRequiredFields(
+            Type type, string[] parents, HashSet<Type> visiting, HashSet<string> seen, List<RequiredFieldDescriptor> result)
+        {
+            // The visiting set prunes self-referential container shapes; Unity cannot serialize them, but the raw
+            // reflected type still declares the cycle and the walk must terminate on it.
+            if (parents.Length >= MaxContainerDepth || !visiting.Add(type)) return;
+
+            try
+            {
+                // Walk the hierarchy declared-only per level so a base field is read once; a `new`-shadowed name (one
+                // YAML key) is de-duplicated by its full path so it is never reported twice.
+                for (var current = type; current is not null && current != typeof(object); current = current.BaseType)
+                {
+                    foreach (var field in current.GetFields(DeclaredFieldFlags))
+                    {
+                        var selector = field.GetCustomAttribute<TypeSelectorAttribute>();
+                        if (selector is not null && selector.Required)
+                        {
+                            if (!seen.Add(parents.Length == 0 ? field.Name : string.Join(".", parents) + "." + field.Name))
+                                continue;
+
+                            if (field.FieldType == typeof(string))
+                                result.Add(new RequiredFieldDescriptor(parents, field.Name, RequiredFieldKind.String));
+                            else if (IsSerializableTypeField(field.FieldType))
+                                result.Add(new RequiredFieldDescriptor(parents, field.Name, RequiredFieldKind.SerializableType));
+                            else if (field.IsDefined(typeof(SerializeReference), inherit: false))
+                                result.Add(new RequiredFieldDescriptor(parents, field.Name, RequiredFieldKind.ManagedReference));
+                            // A required [TypeSelector] on any other shape is a misuse the analyzer flags; skip it here.
+
+                            continue;
+                        }
+
+                        if (!IsSerializedContainerField(field)) continue;
+
+                        var childParents = new string[parents.Length + 1];
+                        Array.Copy(parents, childParents, parents.Length);
+                        childParents[parents.Length] = field.Name;
+                        CollectRequiredFields(field.FieldType, childParents, visiting, seen, result);
+                    }
+                }
+            }
+            finally
+            {
+                visiting.Remove(type);
+            }
+        }
+
+        // A field Unity serializes by value as a nested mapping — the only shape whose children the YAML scan can
+        // address by key. [SerializeReference] hops (RefIds), collections (indexed elements), UnityEngine.Object
+        // references (external pointers) and the SerializableType wrapper (a leaf) are all excluded.
+        private static bool IsSerializedContainerField(FieldInfo field)
+        {
+            if (field.IsNotSerialized) return false;
+            if (!field.IsPublic && !field.IsDefined(typeof(SerializeField), inherit: false)) return false;
+            if (field.IsDefined(typeof(SerializeReference), inherit: false)) return false;
+
+            var type = field.FieldType;
+            if (type.IsPrimitive || type.IsEnum || type == typeof(string)) return false;
+            if (type.IsArray || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))) return false;
+            if (typeof(UnityEngine.Object).IsAssignableFrom(type)) return false;
+            if (IsSerializableTypeField(type)) return false;
+
+            return type.IsDefined(typeof(SerializableAttribute), inherit: false);
         }
 
         // Per-type memo for GetRequiredFields — the reflected field set is stable until a domain reload clears statics.

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/RequiredFieldDescriptor.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/RequiredFieldDescriptor.cs
@@ -20,7 +20,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
     /// <summary>
     /// A serialized field that opts into the <c>[TypeSelector(Required = true)]</c> check, captured for the pure-YAML
-    /// scene scan: the YAML field key and its <see cref="RequiredFieldKind"/>. Produced by reflection in
+    /// scene scan: the YAML field key, its <see cref="RequiredFieldKind"/>, and — for a field nested inside plain
+    /// <c>[Serializable]</c> containers — the chain of container keys leading to it. Produced by reflection in
     /// <see cref="SerializeReferenceRequiredGate.GetRequiredFields"/> and consumed by
     /// <see cref="SerializeReferenceYamlEditor.FindUnsetRequiredFields"/>, which stays reflection-free.
     /// </summary>
@@ -29,9 +30,21 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         public readonly RequiredFieldKind Kind;
         public readonly string FieldName;
 
+        /// <summary>Container keys from the document's top level down to <see cref="FieldName"/>'s parent;
+        /// empty for a top-level field.</summary>
+        public readonly string[] Parents;
+
+        /// <summary>The dotted property path (<c>_loadout.primary</c>) — matches the shape
+        /// <c>SerializedProperty.propertyPath</c> reports for the same field, so gate reports read alike.</summary>
+        public string Path => Parents is { Length: > 0 } ? string.Join(".", Parents) + "." + FieldName : FieldName;
+
         public RequiredFieldDescriptor(string fieldName, RequiredFieldKind kind)
+            : this(System.Array.Empty<string>(), fieldName, kind) { }
+
+        public RequiredFieldDescriptor(string[] parents, string fieldName, RequiredFieldKind kind)
         {
             Kind = kind;
+            Parents = parents;
             FieldName = fieldName;
         }
     }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Scan.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/SerializeReferenceYamlEditor.Scan.cs
@@ -101,8 +101,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// concern, not a required violation. A field whose key is <em>absent</em> from the document is NOT a violation:
         /// Unity omits a serialized field from YAML when the object was last saved before the field was added (and for
         /// stripped / nested-prefab docs), so flagging it would fail a project that is valid once reopened/reserialized.
-        /// Required fields nested inside serializable containers are not covered here (the field keys are read at the
-        /// document's top level only).
+        /// A required field nested inside plain <c>[Serializable]</c> containers is read by first narrowing the window
+        /// to the innermost container block along <see cref="RequiredFieldDescriptor.Parents"/>; an absent ancestor key
+        /// counts as absent for the same reserialize reason.
         /// </summary>
         public static List<RequiredViolationEntry> FindUnsetRequiredFields(
             string assetPath, Func<string, IReadOnlyList<RequiredFieldDescriptor>> requiredFieldsForScript)
@@ -133,19 +134,26 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
                     foreach (var descriptor in required)
                     {
+                        // A nested field is read inside its container block; an absent ancestor key means the whole
+                        // chain is absent (needs a reserialize), so the descriptor is skipped like an absent leaf.
+                        var start = i + 1;
+                        var end = fieldsEnd;
+                        var indent = fieldIndent;
+                        if (!TryEnterContainers(lines, ref start, ref end, ref indent, descriptor.Parents)) continue;
+
                         // An absent key is not a violation (see FieldState); only a present-but-empty key is reported.
                         var rid = 0L;
                         var state = descriptor.Kind switch
                         {
                             RequiredFieldKind.String =>
-                                IsStringFieldUnset(lines, i + 1, fieldsEnd, fieldIndent, descriptor.FieldName),
+                                IsStringFieldUnset(lines, start, end, indent, descriptor.FieldName),
                             RequiredFieldKind.SerializableType =>
-                                IsSerializableTypeFieldUnset(lines, i + 1, fieldsEnd, fieldIndent, descriptor.FieldName),
-                            _ => IsManagedReferenceUnset(lines, i + 1, fieldsEnd, fieldIndent, descriptor.FieldName, out rid),
+                                IsSerializableTypeFieldUnset(lines, start, end, indent, descriptor.FieldName),
+                            _ => IsManagedReferenceUnset(lines, start, end, indent, descriptor.FieldName, out rid),
                         };
 
                         if (state == FieldState.PresentUnset)
-                            result.Add(new RequiredViolationEntry(fileId, descriptor.FieldName, rid));
+                            result.Add(new RequiredViolationEntry(fileId, descriptor.Path, rid));
                     }
                 }
             }
@@ -187,6 +195,53 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             }
 
             return false;
+        }
+
+        // Narrows the [start, end) window and key indent to the innermost container block along `parents` — each hop
+        // finds the container key at the current indent and descends to its children's indent. False when any ancestor
+        // key is absent or the container block is empty; the caller treats that as an absent leaf (needs reserialize).
+        private static bool TryEnterContainers(string[] lines, ref int start, ref int end, ref int indent, string[] parents)
+        {
+            if (parents is not { Length: > 0 }) return true;
+
+            foreach (var parent in parents)
+            {
+                var pattern = new Regex($@"^(?<indent>\s*){Regex.Escape(parent)}:\s*$");
+                var entered = false;
+
+                for (var i = start; i < end; i++)
+                {
+                    var match = pattern.Match(lines[i]);
+                    if (!match.Success || match.Groups["indent"].Length != indent) continue;
+
+                    // The block spans until the first line dedented back to (or above) the container key; its direct
+                    // children sit at the first child line's indent — deeper lines belong to sub-blocks and are
+                    // filtered out by the leaf matchers' exact-indent checks.
+                    var blockEnd = i + 1;
+                    var childIndent = -1;
+
+                    for (var j = i + 1; j < end; j++)
+                    {
+                        if (lines[j].Trim().Length == 0) { blockEnd = j + 1; continue; }
+                        if (IndentOf(lines[j]) <= indent) break;
+
+                        if (childIndent < 0) childIndent = IndentOf(lines[j]);
+                        blockEnd = j + 1;
+                    }
+
+                    if (childIndent < 0) return false; // container key present but the block carries no children
+
+                    start = i + 1;
+                    end = blockEnd;
+                    indent = childIndent;
+                    entered = true;
+                    break;
+                }
+
+                if (!entered) return false;
+            }
+
+            return true;
         }
 
         // The exclusive end of a MonoBehaviour's own serialized fields: the "references:" line, or the document end when

--- a/docs/QA-CHECKLIST.md
+++ b/docs/QA-CHECKLIST.md
@@ -52,6 +52,7 @@
 - [ ] Make Unique / Link to Existing: deep copy of the reference graph preserving aliasing topology, cyclic graphs safe; Link never offers an aliasing ancestor.
 - [ ] Authoring: dragging a MonoScript onto the field; Save as Template… / Paste Template ▸ (persisted per project); the list `+` opens the picker; Create New Script… generates a stub and assigns it after compilation (survives the domain reload).
 - [ ] `Required` on a managed reference: warning when null *(2×UI)* + counted by the gate.
+- [ ] `Required` inside a plain `[Serializable]` container (nested field): inline warning in the inspector + counted by the gate for prefabs/SOs **and** the pure-YAML scene scan (reported under the dotted path, e.g. `_loadout.primary`).
 - [ ] `SerializeReferenceEditorGUI` facade (`CreateField`/`CreateList`/`DrawFieldLayout`) works from a custom editor's `CreateInspectorGUI`/`OnInspectorGUI`.
 - [ ] Notice placement agrees between both renderers (missing/required/mixed — only when the field is empty; shared — at the very bottom).
 

--- a/docs/QA-CHECKLIST_RU.md
+++ b/docs/QA-CHECKLIST_RU.md
@@ -52,6 +52,7 @@
 - [ ] Make Unique / Link to Existing: deep-copy графа с сохранением топологии, циклы безопасны; Link не предлагает алиасящего предка.
 - [ ] Authoring: drag MonoScript на поле; Save as Template… / Paste Template ▸ (персист на проект); list `+` открывает пикер; Create New Script… генерит стаб и назначает после компиляции (переживает domain reload).
 - [ ] `Required` на managed reference: warning при null *(2×UI)* + учёт в gate.
+- [ ] `Required` внутри обычного `[Serializable]`-контейнера (вложенное поле): inline-warning в инспекторе + учёт в gate для prefabs/SO **и** pure-YAML скана сцен (в отчёте — путь через точку, например `_loadout.primary`).
 - [ ] Facade `SerializeReferenceEditorGUI` (`CreateField`/`CreateList`/`DrawFieldLayout`) работает из `CreateInspectorGUI`/`OnInspectorGUI` кастомного эдитора.
 - [ ] Позиции notices совпадают в обоих рендерерах (missing/required/mixed — при пустом значении; shared — в самом низу).
 


### PR DESCRIPTION
## Summary

- 🐛 The Required gate's scene half missed `[TypeSelector(Required = true)]` fields declared inside plain `[Serializable]` containers: `GetRequiredFields` only reflected top-level fields, so the pure-YAML `.unity` scan silently skipped them (prefabs/SOs were already covered by the object-load walk).
- ✨ `GetRequiredFields` now recurses into by-value containers (cycle- and depth-guarded; collections and `[SerializeReference]` hops stay out of scope), recording the container chain in `RequiredFieldDescriptor.Parents`; the YAML scan narrows its window to the innermost container block along that chain.
- ✅ Violations report the dotted path (`_loadout.primary`), matching the object-load half's `propertyPath` shape; an absent ancestor key still counts as "needs reserialize", not a violation.
- 📝 Tests: failing-first nested reflection/YAML coverage, a live-half parity pin, and a self-referential-container termination pin; QA checklists (EN/RU) gain the nested-container item.

## Notes for review

- The pre-existing `TypeSelectorIntersectionTests.TwoBases_…` failure on this branch is unrelated — its fix ships in #132.

## Linked issues

Closes ASP-52

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- 🐛 Сценная половина Required-гейта пропускала поля `[TypeSelector(Required = true)]`, объявленные внутри обычных `[Serializable]`-контейнеров: `GetRequiredFields` рефлексировал только поля верхнего уровня, поэтому чистый YAML-скан `.unity` молча их пропускал (префабы/SO уже покрывались обходом с загрузкой объектов).
- ✨ `GetRequiredFields` теперь рекурсивно заходит в by-value контейнеры (с защитой от циклов и глубины; коллекции и переходы `[SerializeReference]` остаются вне скоупа), записывая цепочку контейнеров в `RequiredFieldDescriptor.Parents`; YAML-скан сужает окно поиска до блока самого внутреннего контейнера по этой цепочке.
- ✅ Нарушения репортятся точечным путём (`_loadout.primary`) в формате `propertyPath` объектной половины; отсутствующий ключ предка по-прежнему считается «нужен reserialize», а не нарушением.
- 📝 Тесты: failing-first покрытие вложенной рефлексии/YAML, пин паритета с живой половиной и пин терминации на самоссылающемся контейнере; в QA-чеклисты (EN/RU) добавлен пункт про вложенные контейнеры.

## Notes for review

- Падение `TypeSelectorIntersectionTests.TwoBases_…` на этой ветке — унаследованное и с изменениями не связано; фикс едет в #132.

</details>
