### PR TITLE
test(editor): add EditMode coverage for Id registries

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84f6ae6dbd3a447dfa100b57540ec615
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryResolverTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryResolverTests.cs
@@ -1,0 +1,126 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using Aspid.FastTools.Ids.Editors;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Aspid.FastTools.Ids.Tests
+{
+    // Two distinct generator-backed IId struct types so the binding tests can prove per-type isolation and retargeting.
+    internal partial struct ResolverTestIdA : IId { }
+    internal partial struct ResolverTestIdB : IId { }
+
+    /// <summary>
+    /// Locks the <see cref="IdRegistryResolver"/> binding invariants (see <c>Ids/CLAUDE.md</c>): <c>Find</c> is the
+    /// only sanctioned registry lookup, it indexes assets by the struct's assembly-qualified name stored in
+    /// <c>_targetStructType</c>, and the one-registry-per-type rule is enforced at lookup time — a second asset bound
+    /// to the same struct logs an error instead of silently shadowing the first. The tests drive real <c>.asset</c>
+    /// files through AssetDatabase because the resolver's cache is patched by an AssetPostprocessor on import.
+    /// </summary>
+    [TestFixture]
+    internal sealed class IdRegistryResolverTests
+    {
+        private readonly List<string> _assetPaths = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var path in _assetPaths)
+                AssetDatabase.DeleteAsset(path);
+            _assetPaths.Clear();
+
+            // The resolver cache is process-wide static state; reset it so no binding leaks into other fixtures.
+            IdRegistryResolver.ClearCache();
+        }
+
+        private IdRegistry Track(IdRegistry registry)
+        {
+            _assetPaths.Add(AssetDatabase.GetAssetPath(registry));
+            return registry;
+        }
+
+        // A second asset bound to the same AQN, created the way a user duplicating an asset would end up with one —
+        // bypassing Create() so the resolver only discovers it on the next cache rebuild.
+        private string CreateDuplicateBoundTo(Type structType)
+        {
+            var path = AssetDatabase.GenerateUniqueAssetPath($"Assets/IdRegistry_{structType.Name}_dup.asset");
+            var registry = ScriptableObject.CreateInstance<IdRegistry>();
+            AssetDatabase.CreateAsset(registry, path);
+
+            var serialized = new SerializedObject(registry);
+            serialized.FindProperty("_targetStructType").stringValue = structType.AssemblyQualifiedName;
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+            AssetDatabase.SaveAssets();
+
+            _assetPaths.Add(path);
+            return path;
+        }
+
+        [Test]
+        public void Create_BindsTheStructAqn_FindReturnsThatAsset()
+        {
+            var registry = Track(IdRegistryResolver.Create(typeof(ResolverTestIdA)));
+
+            Assert.AreSame(registry, IdRegistryResolver.Find(typeof(ResolverTestIdA)),
+                "Find must resolve the struct type to the asset Create just bound.");
+        }
+
+        [Test]
+        public void Find_TypeWithoutRegistry_ReturnsNull_AndNullTypeIsSafe()
+        {
+            Assert.IsNull(IdRegistryResolver.Find(typeof(ResolverTestIdB)),
+                "A struct type no asset is bound to has no registry.");
+            Assert.IsNull(IdRegistryResolver.Find(null));
+        }
+
+        [Test]
+        public void GetOrCreate_ReusesTheExistingBinding()
+        {
+            var created = Track(IdRegistryResolver.GetOrCreate(typeof(ResolverTestIdA)));
+            var again = IdRegistryResolver.GetOrCreate(typeof(ResolverTestIdA));
+
+            Assert.AreSame(created, again, "GetOrCreate must never create a second asset for an already-bound type.");
+        }
+
+        [Test]
+        public void Find_TwoRegistriesBoundToOneType_LogsTheDuplicateError_StillReturnsARegistry()
+        {
+            var duplicateError = new Regex("Multiple registries found for type AQN=");
+            Track(IdRegistryResolver.Create(typeof(ResolverTestIdA)));
+
+            // The rule is enforced at two points, each logging once: the import of the second asset hits the warm
+            // cache (the AssetPostprocessor routes it through OnAssetImported)...
+            LogAssert.Expect(LogType.Error, duplicateError);
+            CreateDuplicateBoundTo(typeof(ResolverTestIdA));
+
+            // ...and the full rescan a fresh domain / editor session performs with both assets already on disk.
+            LogAssert.Expect(LogType.Error, duplicateError);
+            IdRegistryResolver.ClearCache();
+
+            Assert.IsNotNull(IdRegistryResolver.Find(typeof(ResolverTestIdA)),
+                "The one-per-type violation is reported, but lookup still degrades to a single winner.");
+        }
+
+        [Test]
+        public void OnAssetImported_RetargetedAsset_MovesTheBindingToTheNewType()
+        {
+            // Rebinding an existing asset to another struct (via its Type field) must atomically move the cache
+            // entry: the new type resolves, the old one no longer does.
+            var registry = Track(IdRegistryResolver.Create(typeof(ResolverTestIdA)));
+            var path = AssetDatabase.GetAssetPath(registry);
+
+            var serialized = new SerializedObject(registry);
+            serialized.FindProperty("_targetStructType").stringValue = typeof(ResolverTestIdB).AssemblyQualifiedName;
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+            IdRegistryResolver.OnAssetImported(path);
+
+            Assert.AreSame(registry, IdRegistryResolver.Find(typeof(ResolverTestIdB)),
+                "The retargeted asset must resolve for its new struct type.");
+            Assert.IsNull(IdRegistryResolver.Find(typeof(ResolverTestIdA)),
+                "The old binding must be removed in the same import pass.");
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryResolverTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d8bfe700edd384dc680fa4188f626861

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using NUnit.Framework;
+using Aspid.FastTools.Ids.Editors;
+using System.Collections.Generic;
+
+namespace Aspid.FastTools.Ids.Tests
+{
+    // A generator-backed IId struct (IdStructGenerator emits _id / Id into the other partial part); the extra
+    // constructor lets tests build a value for a specific id.
+    internal partial struct TestWeaponId : IId
+    {
+        public TestWeaponId(int id) : this() => _id = id;
+    }
+
+    // IdRegistry<T> is generic, so Unity cannot instantiate it directly — the concrete subclass is the shape users declare.
+    internal sealed class TestWeaponIdRegistry : IdRegistry<TestWeaponId> { }
+
+    /// <summary>
+    /// Locks the <see cref="IdRegistry"/> lookup contract the drawers and user code rely on: name↔id resolution over
+    /// the serialized parallel arrays, the explicit cache-invalidation protocol (<see cref="IdRegistry.InvalidateCache"/>
+    /// → <see cref="IdRegistry.EnsureCache"/> — the reason RegistryEditorCore's Commit exists), the documented
+    /// last-entry-wins semantics for duplicate names, and order-independence of the mapping (reordering rows must never
+    /// change what a stored id resolves to — that is the "stable IDs" promise).
+    /// </summary>
+    [TestFixture]
+    internal sealed class IdRegistryTests
+    {
+        private readonly List<UnityEngine.Object> _created = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var obj in _created)
+                if (obj != null) UnityEngine.Object.DestroyImmediate(obj);
+            _created.Clear();
+        }
+
+        // Populates the private parallel arrays the way the registry inspector does — through SerializedProperty —
+        // and invalidates the cache explicitly, mirroring RegistryEditorCore.Commit.
+        private T NewRegistry<T>(params (int id, string name)[] entries) where T : IdRegistry
+        {
+            var registry = ScriptableObject.CreateInstance<T>();
+            _created.Add(registry);
+
+            var serialized = new SerializedObject(registry);
+            var ids = serialized.FindProperty("_ids");
+            var names = serialized.FindProperty("_names");
+
+            ids.arraySize = entries.Length;
+            names.arraySize = entries.Length;
+
+            for (var i = 0; i < entries.Length; i++)
+            {
+                ids.GetArrayElementAtIndex(i).intValue = entries[i].id;
+                names.GetArrayElementAtIndex(i).stringValue = entries[i].name;
+            }
+
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+            registry.InvalidateCache();
+            return registry;
+        }
+
+        [Test]
+        public void TryGetId_TryGetName_RoundTripBothDirections()
+        {
+            var registry = NewRegistry<IdRegistry>((1, "Sword"), (2, "Bow"), (7, "Shield"));
+
+            Assert.IsTrue(registry.TryGetId("Bow", out var id));
+            Assert.AreEqual(2, id);
+
+            Assert.IsTrue(registry.TryGetName(7, out var name));
+            Assert.AreEqual("Shield", name);
+        }
+
+        [Test]
+        public void TryGetName_UnknownId_ReturnsFalse_WithEmptyName()
+        {
+            var registry = NewRegistry<IdRegistry>((1, "Sword"));
+
+            Assert.IsFalse(registry.TryGetName(42, out var name));
+            Assert.AreEqual(string.Empty, name, "A failed name lookup must yield string.Empty, not null.");
+        }
+
+        [Test]
+        public void Contains_ChecksBothIdAndName()
+        {
+            var registry = NewRegistry<IdRegistry>((1, "Sword"), (2, "Bow"));
+
+            Assert.IsTrue(registry.Contains(1));
+            Assert.IsTrue(registry.Contains("Bow"));
+            Assert.IsFalse(registry.Contains(3));
+            Assert.IsFalse(registry.Contains("Axe"));
+        }
+
+        [Test]
+        public void Reorder_DoesNotChangeWhatAStoredIdResolvesTo()
+        {
+            // The "stable IDs" promise: a stored int survives any row reordering in the registry asset.
+            var original = NewRegistry<IdRegistry>((1, "Sword"), (2, "Bow"), (7, "Shield"));
+            var reordered = NewRegistry<IdRegistry>((7, "Shield"), (1, "Sword"), (2, "Bow"));
+
+            foreach (var pair in original)
+            {
+                Assert.IsTrue(reordered.TryGetName(pair.Key, out var name));
+                Assert.AreEqual(pair.Value, name, $"Id {pair.Key} must resolve identically after reordering.");
+            }
+        }
+
+        [Test]
+        public void DuplicateNames_LastEntryWinsForNameLookup_EveryIdStillNamed()
+        {
+            // Duplicate rows are invalid data the Clean-up flow reports; until cleaned, the cache resolves the name to
+            // the LAST row (dictionary overwrite) while both ids keep resolving to the shared name.
+            var registry = NewRegistry<IdRegistry>((1, "Sword"), (2, "Sword"));
+
+            Assert.IsTrue(registry.TryGetId("Sword", out var id));
+            Assert.AreEqual(2, id, "The last duplicate row wins the name→id lookup.");
+
+            Assert.IsTrue(registry.TryGetName(1, out var first));
+            Assert.IsTrue(registry.TryGetName(2, out var second));
+            Assert.AreEqual("Sword", first);
+            Assert.AreEqual("Sword", second);
+        }
+
+        [Test]
+        public void WhitespaceName_ExcludedFromNameLookup_IdStillNamed()
+        {
+            var registry = NewRegistry<IdRegistry>((1, "  "), (2, "Bow"));
+
+            Assert.IsFalse(registry.Contains("  "), "A whitespace name never enters the name→id lookup.");
+            Assert.IsTrue(registry.TryGetName(1, out _), "The id itself still resolves (to its raw stored name).");
+        }
+
+        [Test]
+        public void Enumerator_YieldsPairsForTheShorterArray()
+        {
+            // Mismatched array lengths are a corrupt-asset shape (the inspector always writes both); enumeration
+            // degrades to the shorter length instead of throwing.
+            var registry = NewRegistry<IdRegistry>((1, "Sword"), (2, "Bow"));
+            var serialized = new SerializedObject(registry);
+            serialized.FindProperty("_names").arraySize = 1;
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+            registry.InvalidateCache();
+
+            var pairs = registry.ToList();
+
+            Assert.AreEqual(1, pairs.Count);
+            Assert.AreEqual(new KeyValuePair<int, string>(1, "Sword"), pairs[0]);
+        }
+
+        [Test]
+        public void CacheProtocol_InvalidateMarksDirty_EnsureCacheClears()
+        {
+            // RegistryEditorCore.Commit relies on exactly this flag protocol; a lookup transparently rebuilds.
+            var registry = NewRegistry<IdRegistry>((1, "Sword"));
+
+            registry.EnsureCache();
+            Assert.IsFalse(registry.IsCacheDirty, "EnsureCache must clear the dirty flag.");
+
+            registry.InvalidateCache();
+            Assert.IsTrue(registry.IsCacheDirty, "InvalidateCache must mark the cache dirty.");
+
+            Assert.IsTrue(registry.Contains(1), "A lookup on a dirty cache rebuilds it transparently.");
+            Assert.IsFalse(registry.IsCacheDirty);
+        }
+
+        [Test]
+        public void TypedRegistry_ResolvesThroughTheStructsIdValue()
+        {
+            var registry = NewRegistry<TestWeaponIdRegistry>((1, "Sword"), (2, "Bow"));
+
+            Assert.IsTrue(registry.Contains(new TestWeaponId(2)));
+            Assert.IsFalse(registry.Contains(new TestWeaponId(3)));
+
+            Assert.IsTrue(registry.TryGetName(new TestWeaponId(1), out var name));
+            Assert.AreEqual("Sword", name);
+        }
+    }
+
+    /// <summary>
+    /// Locks <see cref="IdRegistryValidator"/> — the single name check every entry point (Add row, rename, Clean-up)
+    /// funnels through, so one rule change propagates everywhere. The rules are ordered: whitespace → identifier
+    /// grammar → length cap → taken.
+    /// </summary>
+    [TestFixture]
+    internal sealed class IdRegistryValidatorTests
+    {
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void IsValidName_RejectsEmptyOrWhitespace(string input)
+        {
+            Assert.IsFalse(IdRegistryValidator.IsValidName(input, isTaken: null, out var error));
+            Assert.IsNotEmpty(error);
+        }
+
+        [TestCase("1Sword", Description = "must not start with a digit")]
+        [TestCase("-Sword", Description = "must not start with a hyphen")]
+        [TestCase("Sword Axe", Description = "no spaces")]
+        [TestCase("Меч", Description = "ASCII identifier grammar only")]
+        [TestCase("Sword.Fire", Description = "no dots")]
+        public void IsValidName_RejectsNonIdentifierGrammar(string input)
+        {
+            Assert.IsFalse(IdRegistryValidator.IsValidName(input, isTaken: null, out _));
+        }
+
+        [TestCase("Sword")]
+        [TestCase("_hidden")]
+        [TestCase("Sword-2")]
+        [TestCase("fire_bolt3")]
+        public void IsValidName_AcceptsIdentifierGrammar(string input)
+        {
+            Assert.IsTrue(IdRegistryValidator.IsValidName(input, isTaken: null, out var error));
+            Assert.IsNull(error);
+        }
+
+        [Test]
+        public void IsValidName_CapsLengthAt255()
+        {
+            Assert.IsTrue(IdRegistryValidator.IsValidName(new string('a', 255), isTaken: null, out _));
+            Assert.IsFalse(IdRegistryValidator.IsValidName(new string('a', 256), isTaken: null, out _));
+        }
+
+        [Test]
+        public void IsValidName_RejectsTakenNames_NullDelegateSkipsTheCheck()
+        {
+            Assert.IsFalse(IdRegistryValidator.IsValidName("Sword", isTaken: _ => true, out var error));
+            StringAssert.Contains("Sword", error, "The duplicate error names the offending input.");
+
+            Assert.IsTrue(IdRegistryValidator.IsValidName("Sword", isTaken: null, out _));
+        }
+
+        [Test]
+        public void Summarize_CountsEmptyAndDuplicateRowsSeparately()
+        {
+            // Rows: valid, empty, duplicate-of-first, empty — 2 empty + 1 duplicate, matching EnumerateInvalidIndices.
+            var names = new[] { "Sword", "", "Sword", null };
+            var summary = IdRegistryValidator.Summarize(names.Length, i => names[i]);
+
+            Assert.AreEqual(2, summary.EmptyCount);
+            Assert.AreEqual(1, summary.DuplicateCount);
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Ids/IdRegistryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ac2b2432c22e04aa3b4bd8abf7c104e0


### PR DESCRIPTION
## Summary

- ✅ `IdRegistryTests` pin the lookup contract: name↔id round-trip, order-independence of stored ids (the "stable IDs" promise), last-duplicate-wins semantics, whitespace-name exclusion, shorter-array enumeration, and the explicit `InvalidateCache`/`EnsureCache` protocol `RegistryEditorCore.Commit` relies on; the typed `IdRegistry<T>` resolves through the struct's `Id`.
- ✅ `IdRegistryValidatorTests` pin the single name check every entry point funnels through (identifier grammar, 255-char cap, taken-name rejection) and the Clean-up summary counting.
- ✅ `IdRegistryResolverTests` drive real `.asset` files through `Find`/`Create`/`GetOrCreate`: AQN binding, the one-registry-per-type error at **both** enforcement points (import with a warm cache and the full rescan), and `OnAssetImported` retargeting moving the binding atomically.
- ♻️ Fixture `IId` structs are generator-backed (`partial`) — hand-written ones trip the package's own `AFID001`, which doubles as a live end-to-end check of `IdStructGenerator`.

## Notes for review

- The Ids feature had no tests at all before this (flagged by the 2026-07-07 test audit as the largest untested area guarding user data).
- The pre-existing `TypeSelectorIntersectionTests.TwoBases_…` failure on this branch is unrelated — its fix ships in #132.

## Linked issues

Closes ASP-53

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- ✅ `IdRegistryTests` фиксируют контракт лукапа: round-trip name↔id, независимость от порядка хранения id (обещание «стабильных ID»), семантику «побеждает последний дубликат», исключение имён из пробелов, перечисление по более короткому массиву и явный протокол `InvalidateCache`/`EnsureCache`, на который опирается `RegistryEditorCore.Commit`; типизированный `IdRegistry<T>` резолвится через `Id` структуры.
- ✅ `IdRegistryValidatorTests` фиксируют единственную проверку имени, через которую проходят все входные точки (грамматика идентификатора, лимит 255 символов, отказ занятому имени), и подсчёт в сводке Clean-up.
- ✅ `IdRegistryResolverTests` гоняют реальные `.asset`-файлы через `Find`/`Create`/`GetOrCreate`: биндинг по AQN, ошибка «один реестр на тип» в **обеих** точках контроля (импорт с тёплым кешем и полный рескан) и атомарное перенацеливание биндинга в `OnAssetImported`.
- ♻️ Структуры `IId` в фикстурах — сгенерированные (`partial`): рукописные ловят собственный `AFID001` пакета, что заодно служит живой end-to-end проверкой `IdStructGenerator`.

## Notes for review

- До этого PR у фичи Ids не было тестов вовсе (аудит тестов от 2026-07-07 отметил её как крупнейшую непокрытую область, защищающую пользовательские данные).
- Падение `TypeSelectorIntersectionTests.TwoBases_…` на этой ветке существовало и раньше и с изменениями не связано — фикс едет в #132.

</details>
