### PR TITLE
test: close the three gaps left by the test audit

### DIFF
--- a/Aspid.FastTools.Generators/Aspid.FastTools.Generators.Tests/ProfilerMarkersGeneratorTests.cs
+++ b/Aspid.FastTools.Generators/Aspid.FastTools.Generators.Tests/ProfilerMarkersGeneratorTests.cs
@@ -386,6 +386,7 @@ public class ProfilerMarkersGeneratorTests
             """;
 
         var run = GeneratorTestHost.RunProfilerMarkers(source);
+        GeneratorTestHost.AssertNoErrors(run);
         var generated = run.RunResult.Results[0].GeneratedSources;
 
         Assert.Single(generated);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSharedAliasTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/SerializeReferenceSharedAliasTests.cs
@@ -97,12 +97,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors.Tests
             {
                 var detail = SerializeReferenceHelpers.BuildSharedReferenceDetail(serialized.FindProperty("primary"));
 
-                StringAssert.Contains("Also used by:", detail,
-                    "A shared reference's tooltip must announce the other fields using the instance.");
+                // Structural assertions only — the surrounding tooltip copy is free to change without breaking this
+                // test; what must hold is WHICH paths the detail lists and in what form.
                 StringAssert.Contains("Sidearms › Element 0", detail,
                     "The alias must be listed by its inspector-style display path, not the raw property path.");
-                StringAssert.Contains("Make unique", detail,
-                    "The tooltip must explain the notice's Make-unique affordance.");
+                StringAssert.DoesNotContain("Primary", detail,
+                    "The queried field itself is not an alias — only the other members of the pair are listed.");
             }
             finally
             {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorRestoreTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/SerializeReferences/Yaml/SerializeReferenceYamlEditorRestoreTests.cs
@@ -100,6 +100,47 @@ MonoBehaviour:
                 "Restoring over a sentinel element must succeed.");
         }
 
+        // ---- TryFindTopLevelArrayElementForRid: rid -> (field, index) attribution the delete-guard relies on ---------
+
+        [Test]
+        public void TryFindTopLevelArrayElementForRid_ListElements_ReportFieldAndIndex()
+        {
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryFindTopLevelArrayElementForRid(
+                _pristinePath, YamlFixtures.MonoBehaviourFileId, YamlFixtures.GhostPistolRid, out var field, out var index));
+            Assert.AreEqual("_sidearms", field);
+            Assert.AreEqual(0, index);
+
+            Assert.IsTrue(SerializeReferenceYamlEditor.TryFindTopLevelArrayElementForRid(
+                _pristinePath, YamlFixtures.MonoBehaviourFileId, YamlFixtures.ShotgunRid, out field, out index));
+            Assert.AreEqual("_sidearms", field);
+            Assert.AreEqual(1, index, "Element indexing must count within the field, not across the document.");
+        }
+
+        [Test]
+        public void TryFindTopLevelArrayElementForRid_SingleFieldPointer_ReturnsFalse()
+        {
+            // _primaryWeapon holds Railgun as a plain (non-array) field — a list resize cannot destroy it, so the
+            // rid must not be attributed to any array element.
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryFindTopLevelArrayElementForRid(
+                _pristinePath, YamlFixtures.MonoBehaviourFileId, YamlFixtures.RailgunRid, out _, out _));
+        }
+
+        [Test]
+        public void TryFindTopLevelArrayElementForRid_NestedPointer_ReturnsFalse()
+        {
+            // BurnEffect is pointed at from INSIDE Railgun's RefIds data (_chargeEffect), not from a top-level list —
+            // the references block must be excluded from the walk.
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryFindTopLevelArrayElementForRid(
+                _pristinePath, YamlFixtures.MonoBehaviourFileId, YamlFixtures.BurnEffectRid, out _, out _));
+        }
+
+        [Test]
+        public void TryFindTopLevelArrayElementForRid_UnknownRid_ReturnsFalse()
+        {
+            Assert.IsFalse(SerializeReferenceYamlEditor.TryFindTopLevelArrayElementForRid(
+                _pristinePath, YamlFixtures.MonoBehaviourFileId, 999_999, out _, out _));
+        }
+
         [Test]
         public void TryReadArrayElementEntryBlock_CapturesTypeAndData()
         {


### PR DESCRIPTION
## Summary

- ✅ `FieldInitializer_UsesFieldNameAsMarkerName` now runs `AssertNoErrors` like every other happy-path generator test, so malformed generated C# can't slip through this one path.
- ✅ `TryFindTopLevelArrayElementForRid` gets direct coverage: list-element attribution with per-field indexing, single-field and nested-pointer rejections, and the unknown-rid miss.
- ♻️ `BuildSharedReferenceDetail_ListsAliasesByDisplayPath` asserts structure (the alias's display path is listed, the queried field's own path is not) instead of literal tooltip copy — wording tweaks no longer break the test.

## Linked issues

Closes ASP-54

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- ✅ `FieldInitializer_UsesFieldNameAsMarkerName` теперь выполняет `AssertNoErrors`, как и все остальные happy-path тесты генератора, — некорректный сгенерированный C# больше не проскочит через этот путь.
- ✅ `TryFindTopLevelArrayElementForRid` получает прямое покрытие: атрибуция элементов списка с пофилдовой индексацией, отказы для single-field и вложенных указателей, промах по неизвестному rid.
- ♻️ `BuildSharedReferenceDetail_ListsAliasesByDisplayPath` проверяет структуру (display path алиаса присутствует в списке, собственный путь запрошенного поля — нет) вместо дословного текста тултипа — правки формулировок больше не ломают тест.

</details>
