### PR TITLE
ci: run Unity EditMode tests via game-ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,34 @@ jobs:
 
       - name: Run ${{ matrix.name }} tests
         run: dotnet test "${{ matrix.path }}" --nologo
+
+  unity-tests:
+    name: Unity EditMode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Library/ is regenerated from Packages + ProjectSettings; a stale restore still saves most of the reimport,
+      # hence the bare restore-keys fallback.
+      - uses: actions/cache@v4
+        with:
+          path: Aspid.FastTools/Library
+          key: unity-library-${{ hashFiles('Aspid.FastTools/Packages/packages-lock.json', 'Aspid.FastTools/ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: unity-library-
+
+      # Requires the UNITY_LICENSE secret (personal-license .ulf contents) — see docs in the PR that added this job.
+      - uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: Aspid.FastTools
+          testMode: editmode
+          artifactsPath: unity-test-results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Unity EditMode results
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unity-test-results
+          path: unity-test-results


### PR DESCRIPTION
## Summary

- ✅ New `unity-tests` job in `tests.yml`: `game-ci/unity-test-runner@v4` over the `Aspid.FastTools` project, EditMode only, Unity version auto-detected from `ProjectVersion.txt` (currently `6000.4.0f1`).
- ⚡ `Library/` is cached on `packages-lock.json` + `ProjectVersion.txt` with a bare fallback key, so runs after the first don't reimport the project from scratch.
- 📝 Test results are uploaded as an artifact and reported as a **Unity EditMode results** check via `githubToken`.

## Notes for review

⚠️ **The job fails until the `UNITY_LICENSE` secret is added** (owner-only step). Activation for a personal license:

1. Run the [`game-ci/request-activation-file`](https://game.ci/docs/github/activation) step once (or locally: `Unity -batchmode -createManualActivationFile -quit`) to get `Unity_v6000.4.0f1.alf`.
2. Upload the `.alf` at <https://license.unity3d.com/manual>, choose *Personal* → download the `.ulf`.
3. Repo → Settings → Secrets and variables → Actions → new secret `UNITY_LICENSE` with the **entire file contents** of the `.ulf`.
4. Re-run this PR's checks — the job should go green (first run is slow: docker image pull + full import; later runs hit the Library cache).

## Linked issues

Closes ASP-55


<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- ✅ Новый job `unity-tests` в `tests.yml`: `game-ci/unity-test-runner@v4` над проектом `Aspid.FastTools`, только EditMode, версия Unity автоопределяется из `ProjectVersion.txt` (сейчас `6000.4.0f1`).
- ⚡ `Library/` кэшируется по `packages-lock.json` + `ProjectVersion.txt` с bare-fallback-ключом, так что прогоны после первого не импортируют проект с нуля.
- 📝 Результаты тестов выгружаются артефактом и репортятся отдельным check'ом **Unity EditMode results** через `githubToken`.

## Notes for review

⚠️ **Job падает, пока не добавлен секрет `UNITY_LICENSE`** (шаг только для владельца). Активация personal-лицензии:

1. Один раз выполнить шаг [`game-ci/request-activation-file`](https://game.ci/docs/github/activation) (или локально: `Unity -batchmode -createManualActivationFile -quit`) — получится `Unity_v6000.4.0f1.alf`.
2. Загрузить `.alf` на <https://license.unity3d.com/manual>, выбрать *Personal* → скачать `.ulf`.
3. Repo → Settings → Secrets and variables → Actions → новый секрет `UNITY_LICENSE` с **полным содержимым** файла `.ulf`.
4. Перезапустить чеки этого PR — job должен позеленеть (первый прогон медленный: докер-образ + полный импорт; дальше работает кэш Library).

</details>
