### PR TITLE
Add beta warning to Claude Code Plugin README section

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
@@ -72,6 +72,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 
 If you use [Claude Code](https://docs.claude.com/en/docs/claude-code), the companion [Aspid.Claude.Plugins](https://github.com/VPDPersonal/Aspid.Claude.Plugins) marketplace ships the `aspid-fasttools` plugin — a set of skills that teach Claude Code this package's conventions and APIs.
 
+> [!WARNING]
+> The plugin is still in beta — its skills and commands may change between releases.
+
 Add the marketplace and install the plugin:
 
 ```sh

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
@@ -72,6 +72,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 
 Если вы используете [Claude Code](https://docs.claude.com/en/docs/claude-code), сопутствующий маркетплейс [Aspid.Claude.Plugins](https://github.com/VPDPersonal/Aspid.Claude.Plugins) поставляет плагин `aspid-fasttools` — набор скиллов, которые обучают Claude Code конвенциям и API этого пакета.
 
+> [!WARNING]
+> Плагин всё ещё находится в бета-версии — его скиллы и команды могут меняться между релизами.
+
 Добавьте маркетплейс и установите плагин:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 
 If you use [Claude Code](https://docs.claude.com/en/docs/claude-code), the companion [Aspid.Claude.Plugins](https://github.com/VPDPersonal/Aspid.Claude.Plugins) marketplace ships the `aspid-fasttools` plugin — a set of skills that teach Claude Code this package's conventions and APIs.
 
+> [!WARNING]
+> The plugin is still in beta — its skills and commands may change between releases.
+
 Add the marketplace and install the plugin:
 
 ```sh

--- a/README_RU.md
+++ b/README_RU.md
@@ -75,6 +75,9 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.2
 
 Если вы используете [Claude Code](https://docs.claude.com/en/docs/claude-code), сопутствующий маркетплейс [Aspid.Claude.Plugins](https://github.com/VPDPersonal/Aspid.Claude.Plugins) поставляет плагин `aspid-fasttools` — набор скиллов, которые обучают Claude Code конвенциям и API этого пакета.
 
+> [!WARNING]
+> Плагин всё ещё находится в бета-версии — его скиллы и команды могут меняться между релизами.
+
 Добавьте маркетплейс и установите плагин:
 
 ```sh


### PR DESCRIPTION
Adds a `> [!WARNING]` beta notice to the **Claude Code Plugin** section — the plugin's skills and commands may still change between releases. Applied to all 4 synced READMEs (root `README.md`/`README_RU.md` and `Documentation/EN|RU/README.md`).

<details>
<summary>🇷🇺 Описание на русском</summary>

Добавляет предупреждение `> [!WARNING]` о бета-статусе в секцию **Claude Code Plugin** — скиллы и команды плагина ещё могут меняться между релизами. Изменение внесено во все 4 синхронизируемых README (корневые `README.md`/`README_RU.md` и `Documentation/EN|RU/README.md`).

</details>
