### PR TITLE
fix(editor): anchor selector dropdowns to the element's owner window

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/VisualElementExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/VisualElementExtensions.md
@@ -581,6 +581,7 @@ image.AddOpenScriptCommand(target);
 | Method | Target | Description |
 |--------|--------|-------------|
 | `AddOpenScriptCommand(Object)` | `VisualElement` | Registers a double-click handler that opens the source script for the given `MonoBehaviour` / `ScriptableObject` in the IDE. |
+| `GetOwnerWindow()` | `VisualElement` | Returns the `EditorWindow` whose panel hosts the element (falls back to the focused / mouse-over window for detached elements). Use it instead of `EditorWindow.focusedWindow` when anchoring popups to an element — pointer events arrive before focus moves to the clicked window. |
 | `BindTo(SerializedObject)` | `VisualElement` | Calls `BindingExtensions.Bind` on the element. |
 | `BindTo(SerializedObject, string propertyPath)` | `IBindable` | Sets `bindingPath` and binds to the given `SerializedObject`. |
 | `BindPropertyTo(SerializedProperty)` | `IBindable` | Calls `BindingExtensions.BindProperty` with the supplied property. |

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/VisualElementExtensions.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/VisualElementExtensions.md
@@ -581,6 +581,7 @@ image.AddOpenScriptCommand(target);
 | Метод | Цель | Описание |
 |-------|------|----------|
 | `AddOpenScriptCommand(Object)` | `VisualElement` | Регистрирует обработчик двойного клика, открывающий исходный скрипт `MonoBehaviour` / `ScriptableObject` в IDE. |
+| `GetOwnerWindow()` | `VisualElement` | Возвращает `EditorWindow`, чья панель содержит элемент (для отсоединённых элементов — откат на окно в фокусе / под курсором). Используйте вместо `EditorWindow.focusedWindow` при привязке попапов к элементу — pointer-события приходят до переключения фокуса на кликнутое окно. |
 | `BindTo(SerializedObject)` | `VisualElement` | Вызывает `BindingExtensions.Bind` на элементе. |
 | `BindTo(SerializedObject, string propertyPath)` | `IBindable` | Устанавливает `bindingPath` и привязывается к указанному `SerializedObject`. |
 | `BindPropertyTo(SerializedProperty)` | `IBindable` | Вызывает `BindingExtensions.BindProperty` для переданного property. |

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/VisualElements/IdField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Ids/VisualElements/IdField.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
 using Aspid.FastTools.UIElements;
+using Aspid.FastTools.UIElements.Editors;
 using Aspid.FastTools.UIElements.Editors.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -180,10 +181,7 @@ namespace Aspid.FastTools.Ids.Editors
             if (evt.button is not 0) return;
             if (IdType is null) return;
 
-            var window = EditorWindow.focusedWindow != null
-                ? EditorWindow.focusedWindow
-                : EditorWindow.mouseOverWindow;
-
+            var window = _visualInput.GetOwnerWindow();
             if (!window) return;
 
             IdSelectorWindow.Show(

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
 using Aspid.FastTools.Types.Editors;
+using Aspid.FastTools.UIElements.Editors;
 using Object = UnityEngine.Object;
 
 // ReSharper disable once CheckNamespace
@@ -55,7 +56,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Shared with SerializeReferenceListField, whose "+" needs the same picker anchored the same way.
         public static void OpenAppendPicker(Object target, string arrayPath, Type elementType, Type[] baseTypes, VisualElement anchor)
         {
-            var window = EditorWindow.mouseOverWindow != null ? EditorWindow.mouseOverWindow : EditorWindow.focusedWindow;
+            var window = anchor.GetOwnerWindow();
             if (window == null) return;
 
             // Anchor the picker to the ListView (spanning its width) rather than the small "+" button, so it opens as

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -7,6 +7,7 @@ using Aspid.FastTools.Editors;
 using System.Collections.Generic;
 using Aspid.FastTools.UIElements;
 using Aspid.FastTools.Types.Editors;
+using Aspid.FastTools.UIElements.Editors;
 using Aspid.FastTools.UIElements.Editors.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -721,9 +722,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private void OpenFixSelector()
         {
-            var window = EditorWindow.focusedWindow != null
-                ? EditorWindow.focusedWindow
-                : EditorWindow.mouseOverWindow;
+            var window = _missingNotice.GetOwnerWindow();
             if (!window) return;
 
             // Anchor from the notice's yMin + its own size so ShowAsDropDown opens flush below it — anchoring from
@@ -748,10 +747,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         {
             if (evt.button is not 0) return;
 
-            var window = EditorWindow.focusedWindow != null
-                ? EditorWindow.focusedWindow
-                : EditorWindow.mouseOverWindow;
-
+            var window = _dropdown.GetOwnerWindow();
             if (!window) return;
 
             // Under mixed types there is no single "current" type to pre-highlight in the picker — open it unselected.

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/VisualElements/TypeField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/VisualElements/TypeField.cs
@@ -5,6 +5,7 @@ using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
 using Aspid.FastTools.UIElements;
+using Aspid.FastTools.UIElements.Editors;
 using Aspid.FastTools.UIElements.Editors.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -151,10 +152,7 @@ namespace Aspid.FastTools.Types.Editors
         {
             if (_isReadOnly || evt.button is not 0) return;
 
-            var window = EditorWindow.focusedWindow != null
-                ? EditorWindow.focusedWindow
-                : EditorWindow.mouseOverWindow;
-            
+            var window = _visualInput.GetOwnerWindow();
             if (!window) return;
 
             var filter = new TypeSelectorFilter

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Extensions/VisualElementExtensions.OwnerWindow.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Extensions/VisualElementExtensions.OwnerWindow.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.UIElements.Editors
+{
+    public static partial class VisualElementExtensions
+    {
+        /// <summary>
+        /// Returns the <see cref="EditorWindow"/> whose panel hosts <paramref name="element"/>, falling back to
+        /// <see cref="EditorWindow.focusedWindow"/> / <see cref="EditorWindow.mouseOverWindow"/> when no window's
+        /// panel matches (e.g. the element is detached).
+        /// </summary>
+        /// <remarks>
+        /// Use this instead of <see cref="EditorWindow.focusedWindow"/> when anchoring a dropdown to an element:
+        /// a click into an unfocused floating window dispatches its pointer event before focus moves, so
+        /// <c>focusedWindow</c> still points at the previously focused window and a rect built from its
+        /// <see cref="EditorWindow.position"/> lands in the wrong window's coordinate space.
+        /// </remarks>
+        public static EditorWindow GetOwnerWindow(this VisualElement element)
+        {
+            var panel = element?.panel;
+
+            if (panel is not null)
+            {
+                foreach (var window in Resources.FindObjectsOfTypeAll<EditorWindow>())
+                {
+                    if (window && window.rootVisualElement?.panel == panel)
+                        return window;
+                }
+            }
+
+            return EditorWindow.focusedWindow != null
+                ? EditorWindow.focusedWindow
+                : EditorWindow.mouseOverWindow;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Extensions/VisualElementExtensions.OwnerWindow.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Extensions/VisualElementExtensions.OwnerWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49f33e3886ca4735aac96a60a2fc8096
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 2d380e9402a9f4c5b8eb637f9f40c400, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Type/Id/SerializeReference selector dropdowns opened in the wrong screen position when the inspector was an unfocused floating window: anchors were built from `EditorWindow.focusedWindow`, but UIToolkit dispatches the pointer event **before** focus moves, so the rect landed in the previously focused window's coordinate space (e.g. over the Project panel).

- 🐛 Add `VisualElementExtensions.GetOwnerWindow()` — resolves the `EditorWindow` whose panel actually hosts the element, falling back to focused/mouse-over window for detached elements
- ♻️ Use it for every dropdown anchor: `SerializeReferenceField` (dropdown + fix selector), `TypeField`, `IdField`, and the list `+` append picker
- 📝 Document the new extension in `VisualElementExtensions.md` (EN/RU, *Editor commands* section)

**Notes for review**
- ⚠️ `SerializeReferenceSharedNavigation.ScrollTo` intentionally keeps `mouseOverWindow` — it scrolls the window under the cursor, which is the correct semantics there
- ✅ Unity 6000.4.0f1 batch compile clean (0 errors in package code)

<details>
<summary>🇷🇺 Описание на русском</summary>

Дропдауны селекторов Type/Id/SerializeReference открывались не в том месте экрана, когда инспектор был нефокусным плавающим окном: якорь строился от `EditorWindow.focusedWindow`, но UIToolkit доставляет pointer-событие **до** переключения фокуса, поэтому прямоугольник оказывался в системе координат прежнего окна (например, поверх панели Project).

- 🐛 Добавлен `VisualElementExtensions.GetOwnerWindow()` — находит `EditorWindow`, чья панель реально содержит элемент, с откатом на focused/mouse-over окно для отсоединённых элементов
- ♻️ Используется для всех якорей дропдаунов: `SerializeReferenceField` (дропдаун + Fix-селектор), `TypeField`, `IdField` и пикер кнопки `+` у списков
- 📝 Новое расширение задокументировано в `VisualElementExtensions.md` (EN/RU, раздел *Editor commands*)

**Заметки для ревью**
- ⚠️ `SerializeReferenceSharedNavigation.ScrollTo` намеренно оставлен на `mouseOverWindow` — там скроллится окно под курсором, это корректная семантика
- ✅ Батч-компиляция Unity 6000.4.0f1 чистая (0 ошибок в коде пакета)

</details>
