### PR TITLE
chore: migrate dev tooling from UniCli to the official Unity CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-  "extraKnownMarketplaces": {
-    "unicli": {
-      "source": {
-        "source": "github",
-        "repo": "yucchiy/UniCli"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "unicli@unicli": true
-  },
   "hooks": {
     "PostToolUse": [
       {

--- a/Aspid.FastTools/Assets/DevTests/CliCommands.meta
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce9aa844052a54282b9acd83bdc3ae75
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/DevTests/CliCommands/Editor.meta
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 101ca99d4e0f54189ab70cf8029bc101
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/Aspid.FastTools.DevTests.CliCommands.Editor.asmdef
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/Aspid.FastTools.DevTests.CliCommands.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Aspid.FastTools.DevTests.CliCommands.Editor",
+    "references": [
+        "Aspid.FastTools.Unity.Editor",
+        "Aspid.FastTools.Unity.Editor.SerializeReferences.Yaml",
+        "Unity.Pipeline"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/Aspid.FastTools.DevTests.CliCommands.Editor.asmdef.meta
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/Aspid.FastTools.DevTests.CliCommands.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c012c3cc320d547c19d595e9f832cb5f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/SerializeReferenceGateCommands.cs
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/SerializeReferenceGateCommands.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Unity.Pipeline.Commands;
+using Aspid.FastTools.SerializeReferences.Editors;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.DevTests.Editors
+{
+    /// <summary>
+    /// Dev-only Unity CLI wrapper over the SerializeReference gate scanner: <c>unity command sr_gate</c> returns the
+    /// violations as structured JSON without a batchmode Editor relaunch, unlike <see cref="SerializeReferenceCiGate"/>.
+    /// </summary>
+    internal static class SerializeReferenceGateCommands
+    {
+        [CliCommand("sr_gate", "Scan the project for SerializeReference gate violations (missing types / unset Required fields)")]
+        internal static object Run(
+            [CliArg("scope", "What to scan: missing | required | full")] string scope = "missing",
+            [CliArg("warn_only", "Force Warn severity: report but exit code 0")] bool warnOnly = false,
+            [CliArg("fail", "Force Fail severity: exit code 1 on violations")] bool fail = false)
+        {
+            var options = scope?.ToLowerInvariant() switch
+            {
+                "missing" => GateOptions.MissingOnly,
+                "required" => GateOptions.RequiredOnly,
+                "full" => GateOptions.Full,
+                _ => default,
+            };
+
+            if (options.Equals(default(GateOptions)))
+                return new { success = false, error = $"Unknown scope '{scope}'. Use: missing | required | full." };
+
+            var severity = SerializeReferenceCiGate.ResolveSeverity(SerializeReferenceSettings.BuildSeverity, warnOnly, fail);
+            var violations = SerializeReferenceGateScanner.Scan(options);
+
+            return new
+            {
+                success = true,
+                scope,
+                severity = severity.ToString(),
+                violationCount = violations.Count,
+                exitCode = SerializeReferenceCiGate.ComputeExitCode(violations.Count, severity),
+                violations = violations.Select(violation => new
+                {
+                    kind = violation.Kind.ToString(),
+                    assetPath = violation.AssetPath,
+                    fieldPath = violation.FieldPath,
+                    storedType = violation.StoredType.Class,
+                    fileId = violation.FileId,
+                    rid = violation.Rid,
+                }).ToArray(),
+            };
+        }
+    }
+}

--- a/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/SerializeReferenceGateCommands.cs.meta
+++ b/Aspid.FastTools/Assets/DevTests/CliCommands/Editor/SerializeReferenceGateCommands.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 22168adc7920444d0a81ca384ff585d9

--- a/Aspid.FastTools/Packages/manifest.json
+++ b/Aspid.FastTools/Packages/manifest.json
@@ -13,7 +13,6 @@
     "com.unity.timeline": "1.8.11",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.10",
-    "com.yucchiy.unicli-server": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
@@ -47,7 +46,8 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.pipeline": "0.3.1-exp.1"
   },
   "testables": [
     "tech.aspid.fasttools"

--- a/Aspid.FastTools/Packages/packages-lock.json
+++ b/Aspid.FastTools/Packages/packages-lock.json
@@ -127,6 +127,20 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.pipeline": {
+      "version": "0.3.1-exp.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.33",
+        "com.unity.nuget.mono-cecil": "1.11.6",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.render-pipelines.core": {
       "version": "17.4.0",
       "depth": 1,
@@ -224,13 +238,6 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
-    },
-    "com.yucchiy.unicli-server": {
-      "version": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "be0abbd15c319e1fd6c1843f4d57acbe90eedfce"
     },
     "tech.aspid.fasttools": {
       "version": "file:tech.aspid.fasttools",

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/AssemblyInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(assemblyName: "Aspid.MVVM.StarterKit.Unity.Editor")]
 [assembly: InternalsVisibleTo(assemblyName: "Aspid.FastTools.Unity.Editor.Tests")]
 [assembly: InternalsVisibleTo(assemblyName: "Aspid.FastTools.Unity.Editor.SerializeReferences.Tests")]
+[assembly: InternalsVisibleTo(assemblyName: "Aspid.FastTools.DevTests.CliCommands.Editor")]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/AssemblyInfo.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Yaml/AssemblyInfo.cs
@@ -6,3 +6,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor")]
 [assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor.SerializeReferences.Tests")]
 [assembly: InternalsVisibleTo("Aspid.FastTools.Unity.Editor.Tests")]
+[assembly: InternalsVisibleTo("Aspid.FastTools.DevTests.CliCommands.Editor")]


### PR DESCRIPTION
## Summary

- 🔧 Replace the third-party `com.yucchiy.unicli-server` UPM package with the official `com.unity.pipeline` `0.3.1-exp.1` — the live-Editor bridge for the new Unity CLI (`eval`, console logs, screenshots, test runner, package ops)
- 🔧 Drop the `unicli` Claude Code plugin and marketplace from `.claude/settings.json`
- ✨ Add a dev-only `sr_gate` CLI command (`unity command sr_gate --scope missing|required|full`) wrapping the SerializeReference gate scanner: runs in the live Editor and returns violations as structured JSON, no batchmode relaunch needed
- 🔧 New editor-only assembly `Aspid.FastTools.DevTests.CliCommands.Editor` under `Assets/DevTests/`; package internals exposed to it via `InternalsVisibleTo`

## Notes for review

- ⚠️ `com.unity.pipeline` is experimental; the command lives in `Assets/DevTests/` on purpose — nothing ships to package users and the package itself gains no dependency on it
- ✅ Verified live: `eval` / logs / screenshots / `run_tests` (310/310 passed), `sr_gate` finds the two known Required violations in `RequiredViolationsDevTest.prefab` and honors `--warn_only` / `--fail` severity overrides

<details>
<summary>🇷🇺 Описание на русском</summary>

## Кратко

- 🔧 Сторонний UPM-пакет `com.yucchiy.unicli-server` заменён официальным `com.unity.pipeline` `0.3.1-exp.1` — мост в живой редактор для нового Unity CLI (`eval`, логи консоли, скриншоты, тест-раннер, операции с пакетами)
- 🔧 Из `.claude/settings.json` убраны плагин и marketplace `unicli`
- ✨ Добавлена dev-команда `sr_gate` (`unity command sr_gate --scope missing|required|full`) — обёртка над сканером SerializeReference-гейта: работает в живом редакторе и возвращает нарушения структурированным JSON без batchmode-перезапуска
- 🔧 Новая editor-only сборка `Aspid.FastTools.DevTests.CliCommands.Editor` в `Assets/DevTests/`; internals пакета открыты ей через `InternalsVisibleTo`

## Заметки для ревью

- ⚠️ `com.unity.pipeline` — экспериментальный; команда сознательно живёт в `Assets/DevTests/` — пользователям пакета ничего не уезжает, у самого пакета зависимости не появляется
- ✅ Проверено вживую: `eval` / логи / скриншоты / `run_tests` (310/310), `sr_gate` находит два известных Required-нарушения в `RequiredViolationsDevTest.prefab` и уважает переопределения severity `--warn_only` / `--fail`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1JLXgHBRVUtJJquu1RnCm
