### PR TITLE
feat(editor): unify SerializeReference window design and keyboard nav

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Components/Aspid-FastTools-WindowFooter.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Components/Aspid-FastTools-WindowFooter.uss
@@ -30,6 +30,20 @@
     color:                                                var(--aspid-colors-text-light);
 }
 
+/* The keyboard-ring key, absolutely centred over the whole row (independent of the side links' widths) in the
+   quietest text tone — present for discoverability, but quieter than the version so it never competes. Click-
+   transparent from code so the links keep their hits. */
+.aspid-fasttools-window-footer__keys {
+    position:                                             absolute;
+    left:                                                 0;
+    right:                                                0;
+    top:                                                  0;
+    bottom:                                               0;
+    font-size:                                            11px;
+    color:                                                var(--aspid-colors-text-darkness);
+    -unity-text-align:                                    middle-center;
+}
+
 /* GitHub link: the signature green, brightening on hover. */
 .aspid-fasttools-window-footer__link {
     color:                                                var(--aspid-colors-status-success-text-dark);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-ReferenceGraph.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-ReferenceGraph.uss
@@ -153,6 +153,45 @@
     white-space:                                          normal;
 }
 
+/* Accent legend under the hint — decodes the two card tones (amber = broken/orphaned/required, blue = pending
+   migration). Rendered only when both bands are on screen at once (see ShowOverview), matching the Project
+   References legend. Tucked into the hint's 10px gap: its own 10px bottom margin replaces the spacing to the
+   cards below. */
+.aspid-fasttools-reference-graph__legend {
+    flex-direction:                                       row;
+    align-items:                                          center;
+    margin-top:                                           -4px;
+    margin-bottom:                                        10px;
+}
+
+.aspid-fasttools-reference-graph__legend--hidden {
+    display:                                              none;
+}
+
+.aspid-fasttools-reference-graph__legend-item {
+    flex-direction:                                       row;
+    align-items:                                          center;
+    margin-right:                                         16px;
+}
+
+/* Same 6px dot idiom as the Welcome sample-state markers; the muted -text-dark swatches match the card sweeps
+   rather than the bright title text, keeping the key quieter than the cards it explains. */
+.aspid-fasttools-reference-graph__legend-dot {
+    width:                                                6px;
+    height:                                               6px;
+    border-radius:                                        3px;
+    margin-right:                                         6px;
+    background-color:                                     var(--aspid-colors-status-warning-text-dark);
+}
+
+.aspid-fasttools-reference-graph__legend-dot--info {
+    background-color:                                     var(--aspid-colors-status-info-text-dark);
+}
+
+.aspid-fasttools-reference-graph__legend-text {
+    color:                                                var(--aspid-colors-text-dark);
+}
+
 /* --- Per-document group --- */
 /*.aspid-fasttools-reference-graph__document {*/
 /*    margin-bottom:                                        0px;*/
@@ -250,6 +289,12 @@
     border-color:                                         var(--aspid-colors-status-warning-shade-light);
 }
 
+/* A migration card's active frame follows its own accent — the calm info blue, not the broken-card amber
+   (mirrors the Project References __group--migrate --picking frame). */
+.aspid-fasttools-reference-graph__node--migrate.aspid-fasttools-reference-graph__node--picking.aspid-fasttools-background {
+    border-color:                                         var(--aspid-colors-status-info-shade-light);
+}
+
 /* A back-edge leaf (a cycle) is a single dim line, no bottom row — a fainter fill and a dimmer border sink it behind
    the live nodes. */
 .aspid-fasttools-reference-graph__node--back-edge.aspid-fasttools-background {
@@ -316,38 +361,101 @@
     color:                                                var(--aspid-colors-status-info-text-light);
 }
 
-/* [MovedFrom] one-click migrate: the pending-migration card's full-width action under its band, info-tinted — an
-   authoritative rename is a calm migration, never an amber alarm (mirrors the Project Audit __group-migrate row). */
-.aspid-fasttools-reference-graph__node-migrate {
-    margin:                                               2px 0 4px 0;
-    --aspid-fasttools-colors-gradient_button-bg: var(
-        --aspid-colors-status-info-dark
-    );
-    --aspid-fasttools-colors-gradient_button-accent: var(
-        --aspid-colors-status-info-text-light
-    );
+/* --- Band divider + underline sweep ---
+   The Project References group cards' idiom carried over: a dim hairline separates the band from the card body,
+   and an accent sweep riding exactly ON that line scales in from the left while the band is hovered. The sweep is
+   the band's sibling, so :hover can't reach it — code mirrors the band's hover onto the card's --header-hover
+   modifier, which the sweep rule listens to. The band carries no bottom margin, so the divider's own top margin
+   holds the band-to-line gap. */
+.aspid-fasttools-reference-graph__node-divider {
+    flex-grow:                                            0;
+    margin-top:                                           4px;
+    margin-bottom:                                        4px;
+    opacity:                                              0.5;
 }
 
-.aspid-fasttools-reference-graph__node-migrate
-    .aspid-fasttools-gradient-button__label {
-    -unity-text-align:                                    middle-center;
+/* Pulled up past the divider's 4px bottom margin plus its 1px line so the sweep sits exactly ON the line; the 4px
+   bottom margin gives the swallowed gap back, keeping the body rhythm intact. Neutral by default (a healthy /
+   empty card's quiet dropdown); the modifiers repaint it in the card's accent. */
+.aspid-fasttools-reference-graph__node-sweep {
+    height:                                               1px;
+    margin-top:                                           -5px;
+    margin-bottom:                                        4px;
+    background-color:                                     var(--aspid-colors-text-dark);
+    transform-origin:                                     left;
+    scale:                                                0 1;
+    transition-property:                                  scale;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
 }
 
-/* Smart Fix quick-apply on a missing card: success-tinted one-click suggestion, mirroring the Project Audit
-   __group-suggest row — the heuristic guess stays green-with-a-question while the authoritative migrate is blue. */
-.aspid-fasttools-reference-graph__node-suggest {
-    margin:                                               2px 0 4px 0;
-    --aspid-fasttools-colors-gradient_button-bg: var(
-        --aspid-colors-status-success-darkness
-    );
-    --aspid-fasttools-colors-gradient_button-accent: var(
-        --aspid-colors-status-success-text-light
-    );
+/* A missing / required band sweeps amber — the same "fix this" accent its band and type pill wear. */
+.aspid-fasttools-reference-graph__node-sweep--missing {
+    background-color:                                     var(--aspid-colors-status-warning-text-dark);
 }
 
-.aspid-fasttools-reference-graph__node-suggest
-    .aspid-fasttools-gradient-button__label {
-    -unity-text-align:                                    middle-center;
+/* A migration card sweeps in its calm info tone — nothing on it is broken. */
+.aspid-fasttools-reference-graph__node-sweep--migrate {
+    background-color:                                     var(--aspid-colors-status-info-text-dark);
+}
+
+.aspid-fasttools-reference-graph__node--header-hover .aspid-fasttools-reference-graph__node-sweep {
+    scale:                                                1 1;
+}
+
+/* Picker open: the dropdown is inserted between the band and the divider, which would strand the line and its
+   sweep under the whole selector — drop both while the card is picking. */
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-reference-graph__node-divider,
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-reference-graph__node-sweep {
+    display:                                              none;
+}
+
+/* Smart Fix / Migrate as a member of the row family: a bold, left-aligned accent verb over the same flat hover
+   fill as the Project References action rows, instead of a filled gradient pill floating over the glass card.
+   Each card keeps ONE accent: the Smart Fix verb stays in the broken card's warning amber (matching the inspector
+   notice's amber suggestion), and the --info modifier swaps in the migration card's calm info tone. Text lightens
+   with the fill on hover, both on the shared 0.25s ease-out beat. */
+.aspid-fasttools-reference-graph__node-action {
+    padding:                                              2px 4px;
+    border-radius:                                        3px;
+    cursor:                                               link;
+    -unity-font-style:                                    bold;
+    color:                                                var(--aspid-colors-status-warning-text-dark);
+    transition-property:                                  background-color, color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
+}
+
+.aspid-fasttools-reference-graph__node-action:hover {
+    background-color:                                     var(--aspid-colors-bg-dark);
+    color:                                                var(--aspid-colors-status-warning-text-light);
+}
+
+.aspid-fasttools-reference-graph__node-action--info {
+    color:                                                var(--aspid-colors-status-info-text-dark);
+}
+
+.aspid-fasttools-reference-graph__node-action--info:hover {
+    color:                                                var(--aspid-colors-status-info-text-light);
+}
+
+/* --- Keyboard navigation ---
+   Arrow keys walk one flat focus ring over every actionable element in the graph (Rescan, each document header,
+   node band, action row and orphan Clear); Enter activates the highlighted one, Escape drops the highlight. The
+   highlight mirrors each element's own hover treatment so keyboard focus and mouse hover read as one state: the
+   plain action rows take the flat hover fill below; the gradient-button ring members never carry the focused
+   class at all — SetNavFocus drives their hover in code through AspidGradientButton.Highlighted. */
+.aspid-fasttools-reference-graph__nav-target--focused {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* The action rows also lighten their accent text on hover — mirror that for the keyboard highlight too. */
+.aspid-fasttools-reference-graph__node-action.aspid-fasttools-reference-graph__nav-target--focused {
+    color:                                                var(--aspid-colors-status-warning-text-light);
+}
+
+.aspid-fasttools-reference-graph__node-action--info.aspid-fasttools-reference-graph__nav-target--focused {
+    color:                                                var(--aspid-colors-status-info-text-light);
 }
 
 /* The band's leading content (and the non-missing top row): the type pill + badges hugging the left, shrinkable so a
@@ -376,32 +484,38 @@
     -unity-font-style:                                    italic;
 }
 
-/* Bottom line: the field path, then the rid (+ an orphan's Clear), a touch below the band. Horizontal padding matches
-   the band's 4px so the path lines up under the type pill. */
+/* Bottom line: the field path, then the rid (+ an orphan's Clear), below the band's divider (which carries the
+   vertical gap). Horizontal padding matches the band's 4px so the path lines up under the type pill. */
 .aspid-fasttools-reference-graph__node-footer {
     flex-direction:                                       row;
     align-items:                                          center;
-    margin-top:                                           4px;
     padding:                                              0 4px;
 }
 
-/* The field/element path the reference sits under — a dim italic lead-in that grows so the rid pins to the right. */
+/* The field/element path the reference sits under — a dim italic lead-in that grows so the rid pins to the right.
+   min-width:0 lets it shrink below its content's intrinsic width; a long path stays on one line with its START
+   elided, so the leaf field — the part that identifies the slot — survives the cut (matches the Project References
+   entry paths). Footer text is selectable for copying; the I-beam signals that. */
 .aspid-fasttools-reference-graph__node-root-label {
     flex-grow:                                            1;
     flex-shrink:                                          1;
+    min-width:                                            0;
     overflow:                                             hidden;
     text-overflow:                                        ellipsis;
+    -unity-text-overflow-position:                        start;
     white-space:                                          nowrap;
     color:                                                var(--aspid-colors-text-dark);
     -unity-font-style:                                    italic;
+    cursor:                                               text;
 }
 
-/* The rid: a dim, small subtitle on the right of the bottom line. */
+/* The rid: a dim, small subtitle on the right of the bottom line. Selectable for copying, like the path. */
 .aspid-fasttools-reference-graph__node-rid {
     flex-shrink:                                          0;
     color:                                                var(--aspid-colors-text-dark);
     -unity-font-style:                                    normal;
     font-size:                                            10px;
+    cursor:                                               text;
 }
 
 /* --- Badges ---
@@ -526,21 +640,72 @@
     border-radius:                                        8px;
 }
 
-/* Match the Project Audit selector's item insets so the rows line up identically. The global type-selector item rule
-   that does this lives in the Project Audit stylesheet, which this window does not load, so it is restated here. */
-.aspid-fasttools-reference-graph__picker
-    .unity-collection-view__item.aspid-fasttools-type-selector__item {
+/* Match the Project Audit selector's row insets so the rows line up identically. The rows' visual body (the
+   fill-carrying content wrapper inside each transparent row shell) rounds and insets to match the window's card
+   idiom; the equivalent rule lives in the Project Audit stylesheet, which this window does not load. */
+.aspid-fasttools-reference-graph__picker .aspid-fasttools-type-selector__item-content {
     border-radius:                                        8px;
     padding-left:                                         8px;
-    margin-bottom:                                        2px;
 }
 
-/* Re-tint the selector list's default editor-blue hover/selection to the window's palette. */
-.aspid-fasttools-reference-graph__picker .unity-collection-view__item:hover {
-    background-color:                                     var(--aspid-colors-bg-dark);
+/* The picker chrome follows the host card's accent, so the whole active card speaks one hue: the focused-search
+   frame, the hover cues (magnifier, navigable breadcrumbs) and the keyboard-selected row go warning amber on a
+   broken / required card, and the --migrate rules below swap all of them to the migration card's calm info tone
+   (the picker's own default). Selection is recoloured via the picker's row_bg VARIABLE, never background-color:
+   the divider row routes its fill through an inset backplate that reads that variable, so painting the property
+   directly would flood its divider zone. The compound selectors mirror the Project References rules verbatim —
+   they exist purely for specificity over the base stylesheet's own variable-setting selection rule. */
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector__header--search-focused {
+    border-color:                                         var(--aspid-colors-status-warning-text-light);
 }
 
-.aspid-fasttools-reference-graph__picker .unity-collection-view__item--selected,
-.aspid-fasttools-reference-graph__picker .unity-collection-view__item--selected:hover {
-    background-color:                                     var(--aspid-colors-status-success-dark);
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector__search-button:hover {
+    -unity-background-image-tint-color:                   var(--aspid-colors-status-warning-text-light);
+}
+
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector__breadcrumb--link:hover {
+    color:                                                var(--aspid-colors-status-warning-text-lightness);
+}
+
+/* Hover rides the same accent one tone darker than selection, mirroring the base picker's hover/selection pair. */
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item.aspid-fasttools-type-selector__item:hover {
+    --aspid-fasttools-colors-type_selector-row_bg:        var(--aspid-colors-status-warning-shade-darkness);
+}
+
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item,
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item:hover,
+.aspid-fasttools-reference-graph__node--picking .aspid-fasttools-type-selector
+    .unity-collection-view:focus .unity-collection-view__item--selected.aspid-fasttools-type-selector__item {
+    --aspid-fasttools-colors-type_selector-row_bg:        var(--aspid-colors-status-warning-shade-dark);
+}
+
+/* A migration card also wears --picking while its picker is open, so these sit after the amber cues above and
+   swap them back to the card's info accent. */
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector__header--search-focused {
+    border-color:                                         var(--aspid-colors-status-info-text-light);
+}
+
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector__search-button:hover {
+    -unity-background-image-tint-color:                   var(--aspid-colors-status-info-text-light);
+}
+
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector__breadcrumb--link:hover {
+    color:                                                var(--aspid-colors-status-info-text-lightness);
+}
+
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item.aspid-fasttools-type-selector__item:hover {
+    --aspid-fasttools-colors-type_selector-row_bg:        var(--aspid-colors-status-info-shade-darkness);
+}
+
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item,
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item:hover,
+.aspid-fasttools-reference-graph__node--migrate .aspid-fasttools-type-selector
+    .unity-collection-view:focus .unity-collection-view__item--selected.aspid-fasttools-type-selector__item {
+    --aspid-fasttools-colors-type_selector-row_bg:        var(--aspid-colors-status-info-shade-dark);
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-ExcludedFolders.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-ExcludedFolders.uss
@@ -1,73 +1,98 @@
 /* --- Excluded scan folders list ---
-   Replaces the multiline "one path per line" TextField with a compact add/remove list. The whole control is a
-   translucent dark panel (the window's dotted canvas reads through it): folder rows stack over a single add row whose
-   "+" is pinned to the right edge; while empty the add row carries a dim "No excluded folders" hint instead. Self-
-   styled from the Aspid palette so it reads the same on the in-window Settings tab and the bare Project Settings page. */
-
-/* The panel: a translucent dark surface framed like the other settings inputs, sized to its content (the folder rows
-   plus the one add row) rather than a tall fixed box. No inner padding, so the zebra entries fill the frame edge to
-   edge; overflow:hidden clips their square corners to the panel's rounded frame. */
+   Replaces the multiline "one path per line" TextField with a compact add/remove list. A flat member of its settings
+   section card — no frame or fill of its own (the old panel read as a box-in-box inside the glass card): a header row
+   (caption + dim status hint + a "+" pinned right) over one indented flat row per excluded folder. The header is the
+   add target and washes green on hover; folder rows lift neutrally and wash red over their ✕ (delete intent). Self-
+   styled from the Aspid palette so it reads the same on the in-window Settings tab and the Preferences page; on the
+   branded surfaces the settings sheet adds the storage-scope stripe down the whole control's left edge. */
 .aspid-fasttools-excluded-folders {
-    padding:                                              0;
-    overflow:                                             hidden;
-    border-width:                                         1px;
-    border-radius:                                        8px;
-    border-color:                                         var(--aspid-colors-shade-dark);
-    background-color:                                     rgba(20, 20, 20, 0.55);
+    margin-bottom:                                        2px;
 }
 
-/* The panel's own header, pulled inside the frame so the caption rides with the list instead of floating above it. A
-   bold light caption over a hairline divider so it reads as the panel title rather than another list row; its left
-   inset lines up with the folder paths below. A fixed band height plus middle-left alignment centres the caption
-   vertically, so the gap above the text matches the gap below it (relying on padding alone leaves the text top-aligned
-   in its line box and the divider drifts low). */
-.aspid-fasttools-excluded-folders__title {
-    height:                                               24px;
-    padding:                                              0 6px;
-    color:                                                var(--aspid-colors-text-light);
-    -unity-font-style:                                    bold;
-    -unity-text-align:                                    middle-left;
-    border-bottom-width:                                  1px;
-    border-bottom-color:                                  var(--aspid-colors-shade-darkness);
-}
-
-/* Every list entry — each folder row and the persistent add row — is the same shell: a flat full-width element with a
-   min-height so short and tall entries line up and a left inset matching the header caption. Entries sit flush (no
-   margin / radius) so their alternating light / dark wash (zebra, applied per-index in code) fills the panel edge to
-   edge as one continuous stripe block over the dotted canvas. */
-.aspid-fasttools-excluded-folders__entry {
+/* The header row — the flat action-row idiom (the settings rows' geometry): caption left, dim hint and the "+" glyph
+   pinned right. The whole row is the add click target; its add state (--add, code-toggled so the keyboard ring can
+   mirror it) lifts the row with the same neutral fill as every other settings row — the green add intent lives on
+   the "+" glyph alone. */
+.aspid-fasttools-excluded-folders__header {
+    /* Starts 9px in — past the control's scope stripe (3px at the root's edge) plus 6px of clear air — so the
+       header's lit fill never touches the line; matches the settings rows' backplate inset. */
+    margin-left:                                          9px;
     flex-direction:                                       row;
     align-items:                                          center;
-    min-height:                                           24px;
-    padding:                                              2px 6px;
+    min-height:                                           26px;
+    padding:                                              2px 4px 2px 8px;
+    border-radius:                                        8px;
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
 }
 
-.aspid-fasttools-excluded-folders__entry--even {
-    background-color:                                     rgba(255, 255, 255, 0.05);
+.aspid-fasttools-excluded-folders__header--add {
+    background-color:                                     var(--aspid-colors-bg-dark);
 }
 
-.aspid-fasttools-excluded-folders__entry--odd {
-    background-color:                                     rgba(0, 0, 0, 0.18);
+/* The caption mirrors the settings rows' captions (same tone, filling the row so the hint and "+" pin right). */
+.aspid-fasttools-excluded-folders__header-caption {
+    flex-grow:                                            1;
+    color:                                                var(--aspid-colors-text-light);
+    -unity-text-align:                                    middle-left;
 }
 
-/* Full-row hover tints, toggled from code (USS can't repaint a row from a child's hover state). Exactly one is ever
-   set at a time, so single-class selectors suffice — no specificity juggling against a :hover. Neutral lift signals a
-   folder row is editable; the whole row turns red when its ✕ is hovered (delete intent) and green over the add row
-   (add intent). */
+/* Dim status hint beside the "+" while no folder is excluded; empty otherwise. */
+.aspid-fasttools-excluded-folders__hint {
+    margin-right:                                         6px;
+    color:                                                var(--aspid-colors-text-darkness);
+    -unity-text-align:                                    middle-right;
+}
+
+/* The "+" add glyph, pinned to the right of the header row: a small flat square that leads the row's green wash. */
+.aspid-fasttools-excluded-folders__add {
+    flex-shrink:                                          0;
+    width:                                                18px;
+    height:                                               18px;
+    margin:                                               0 2px 0 4px;
+    padding:                                              0;
+    border-width:                                         0;
+    border-radius:                                        3px;
+    background-color:                                     rgba(0, 0, 0, 0);
+    color:                                                var(--aspid-colors-text-light);
+    font-size:                                            16px;
+    -unity-text-align:                                    middle-center;
+}
+
+/* While the header is in its add state (hovered or keyboard-focused), the "+" brightens to the signature green so
+   the glyph leads the green wash. */
+.aspid-fasttools-excluded-folders__header--add .aspid-fasttools-excluded-folders__add {
+    color:                                                var(--aspid-colors-status-success-text-light);
+}
+
+/* Each folder row: a flat indented member under the header (the indent tucks the paths under the caption), the same
+   radius and 0.25s hover beat as the settings rows. The full-row tints are toggled from code (USS can't repaint a row
+   from a child's hover state); exactly one is ever set at a time. Neutral lift signals the row is editable; the row
+   washes red while its ✕ is hovered (delete intent) — the quarter-alpha wash of the settings danger hovers. */
+.aspid-fasttools-excluded-folders__entry {
+    /* The same 9px stripe inset as the header, so a lit folder row stays clear of the line too. */
+    margin-left:                                          9px;
+    flex-direction:                                       row;
+    align-items:                                          center;
+    min-height:                                           22px;
+    padding:                                              2px 4px 2px 20px;
+    border-radius:                                        8px;
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
+}
+
 .aspid-fasttools-excluded-folders__entry--hover {
-    background-color:                                     var(--aspid-colors-bg-lightness);
+    background-color:                                     var(--aspid-colors-bg-dark);
 }
 
 .aspid-fasttools-excluded-folders__entry--danger {
-    background-color:                                     var(--aspid-colors-status-error-dark);
+    background-color:                                     rgba(125, 35, 35, 0.25);
 }
 
-.aspid-fasttools-excluded-folders__entry--add {
-    background-color:                                     var(--aspid-colors-status-success-dark);
-}
-
-/* min-width:0 lets a long path shrink and ellipsize instead of shoving the remove button off the row; stretching it to
-   the full row height (with the text kept vertically centred) makes the whole left of the row a click target for
+/* min-width:0 lets a long path shrink and ellipsize instead of shoving the remove button off the row; stretching it
+   to the full row height (with the text kept vertically centred) makes the whole left of the row a click target for
    editing, with no dead band above or below the caption. */
 .aspid-fasttools-excluded-folders__path {
     flex-grow:                                            1;
@@ -81,8 +106,8 @@
     -unity-text-align:                                    middle-left;
 }
 
-/* The ✕ remove: a small flat square, dim at rest; it brightens to the error tone while its row is in the delete state
-   (see the --danger descendant rule below). */
+/* The ✕ remove: a small flat square, dim at rest; it brightens to the error tone while its row is in the delete
+   state (see the --danger descendant rule below). */
 .aspid-fasttools-excluded-folders__remove {
     flex-shrink:                                          0;
     width:                                                18px;
@@ -102,39 +127,4 @@
 .aspid-fasttools-excluded-folders__entry--danger .aspid-fasttools-excluded-folders__remove {
     background-color:                                     var(--aspid-colors-status-error-light);
     color:                                                var(--aspid-colors-status-error-text-light);
-}
-
-/* Dim hint shown in the add row while no folder is excluded; it grows to fill the row left of the "+". */
-.aspid-fasttools-excluded-folders__hint {
-    flex-grow:                                            1;
-    color:                                                var(--aspid-colors-text-darkness);
-    -unity-text-align:                                    middle-center;
-}
-
-/* The "+" add button, pinned to the right of the add row: a small flat square (just the plus glyph) that picks up the
-   signature green on hover. Same box size and right margin as the ✕ remove so the "+" lines up directly under the
-   column of remove crosses above it. */
-.aspid-fasttools-excluded-folders__add {
-    flex-shrink:                                          0;
-    width:                                                18px;
-    height:                                               18px;
-    margin:                                               0 2px 0 4px;
-    padding:                                              0;
-    border-width:                                         0;
-    border-radius:                                        3px;
-    background-color:                                     rgba(0, 0, 0, 0);
-    color:                                                var(--aspid-colors-text-light);
-    font-size:                                            16px;
-    -unity-text-align:                                    middle-center;
-}
-
-/* Hovering the "+" directly boxes it in a brighter green than the row wash — the add-side mirror of the ✕'s red box. */
-.aspid-fasttools-excluded-folders__add:hover {
-    background-color:                                     var(--aspid-colors-status-success-light);
-}
-
-/* While the add row is in its add state (hovered anywhere), the "+" brightens to the signature green so the glyph leads
-   the row's green wash. */
-.aspid-fasttools-excluded-folders__entry--add .aspid-fasttools-excluded-folders__add {
-    color:                                                var(--aspid-colors-status-success-text-light);
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-Window.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-Window.uss
@@ -71,15 +71,15 @@ Button.aspid-fasttools-serialize-reference-window__toolbar-button--active:hover 
 
 /* Underline accent: a 2px child bar pinned to the tab's bottom edge. Toggling a child's background-color via the
    parent's --active class repaints reliably, whereas flipping a border-bottom-color did not redraw until the next
-   relayout (the underline only appeared after a window resize). A grey baseline marks every (inactive) tab; the
-   active tab swaps it for the signature green. */
+   relayout (the underline only appeared after a window resize). Inactive tabs keep only a near-invisible
+   baseline (the card-border tone) so the active tab's signature green owns the hierarchy. */
 .aspid-fasttools-serialize-reference-window__tab-underline {
     position:                                             absolute;
     left:                                                 0;
     right:                                                0;
     bottom:                                               0;
     height:                                               2px;
-    background-color:                                     var(--aspid-colors-shade-light);
+    background-color:                                     var(--aspid-colors-shade-darkness);
 }
 
 Button.aspid-fasttools-serialize-reference-window__toolbar-button--active .aspid-fasttools-serialize-reference-window__tab-underline {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-Window.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference-Window.uss
@@ -147,3 +147,57 @@ Button.aspid-fasttools-serialize-reference-window__toolbar-button--square:hover 
 Button.aspid-fasttools-serialize-reference-window__toolbar-button--square.aspid-fasttools-serialize-reference-window__toolbar-button--active .aspid-fasttools-serialize-reference-window__tab-icon {
     -unity-background-image-tint-color:                   var(--aspid-colors-status-success-text-light);
 }
+
+/* --- Scrollbar ---
+   Every vertical scroller in the window re-dressed from Unity's bright default into the window's quiet family: no
+   step buttons, no track — just a slim translucent thumb that brightens while the scroller is hovered. The settings
+   sheet mirrors these rules for the Preferences page, which lives outside this window. Scoped to the scroller so no
+   real slider (a base-slider too) is touched. */
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical {
+    width:                                                12px;
+    margin:                                               0;
+    border-width:                                         0;
+    background-color:                                     rgba(0, 0, 0, 0);
+}
+
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical > .unity-scroller__low-button,
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical > .unity-scroller__high-button {
+    display:                                              none;
+}
+
+/* With the step buttons gone, the slider re-pins to the scroller's full height (the default offsets reserve room
+   for them). */
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical .unity-scroller__slider {
+    margin:                                               0;
+    padding:                                              0;
+    width:                                                12px;
+    min-width:                                            12px;
+    top:                                                  0;
+    bottom:                                               0;
+}
+
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical .unity-base-slider__tracker {
+    border-width:                                         0;
+    background-color:                                     rgba(0, 0, 0, 0);
+}
+
+/* The thumb: slim, rounded, translucent white so it reads over both the bare canvas and the glass cards; hover
+   brightens it on the shared 0.25s beat. The default focus halo is dropped with the rest of the chrome. */
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical .unity-base-slider__dragger {
+    left:                                                 3px;
+    width:                                                6px;
+    border-width:                                         0;
+    border-radius:                                        3px;
+    background-color:                                     rgba(255, 255, 255, 0.12);
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
+}
+
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical:hover .unity-base-slider__dragger {
+    background-color:                                     rgba(255, 255, 255, 0.28);
+}
+
+.aspid-fasttools-serialize-reference-window .unity-scroller--vertical .unity-base-slider__dragger-border {
+    display:                                              none;
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
@@ -799,6 +799,27 @@
     -unity-text-align:                                     middle-right;
 }
 
+/* --- Keyboard navigation ---
+   Arrow keys walk one flat focus ring over every actionable element in the audit (Rescan, each card's Fix all,
+   Smart Fix / Migrate rows, entry rows); Enter activates the highlighted one, Escape drops the highlight. The
+   highlight mirrors each element's own hover treatment so keyboard focus and mouse hover read as one state:
+   rows take the flat hover fill from the class below; the gradient-button ring members (Rescan, Fix all) never
+   carry the focused class at all — their hover is painted in code, and SetNavFocus drives it through
+   AspidGradientButton.Highlighted (the same accent overlay + label tint as a real mouse hover), because this
+   flat fill would show through their fading gradient as a gray pill. */
+.aspid-fasttools-repair-references__nav-target--focused {
+    background-color:                                      var(--aspid-colors-bg-dark);
+}
+
+/* The action rows also lighten their accent text on hover — mirror that for the keyboard highlight too. */
+.aspid-fasttools-repair-references__group-action.aspid-fasttools-repair-references__nav-target--focused {
+    color:                                                 var(--aspid-colors-status-warning-text-light);
+}
+
+.aspid-fasttools-repair-references__group-action--info.aspid-fasttools-repair-references__nav-target--focused {
+    color:                                                 var(--aspid-colors-status-info-text-light);
+}
+
 /* A compatible MonoScript dragged over the field highlights the header as a valid drop target. */
 .aspid-fasttools-serialize-reference--drop-target {
     background-color:                                      var(--aspid-colors-bg-light);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
@@ -791,12 +791,11 @@
     color:                                                 var(--aspid-colors-status-info-text-light);
 }
 
-/* A single broken reference inside a group: asset path on the left, dim rid on the right; the whole row pings. The
-   path wraps to as many lines as it needs while the rid stays pinned to the right, so align-items sits at the top to
-   anchor the rid to the path's first line rather than floating it against the middle of a multi-line block. */
+/* A single broken reference inside a group: asset path on the left, dim rid on the right; the whole row pings.
+   The path is start-elided to one line (see __group-entry-path), so the row is always single-line. */
 .aspid-fasttools-repair-references__group-entry {
     flex-direction:                                        row;
-    align-items:                                           flex-start;
+    align-items:                                           center;
     padding:                                               2px 4px;
     border-radius:                                         3px;
     cursor:                                                link;
@@ -810,15 +809,17 @@
     background-color:                                      var(--aspid-colors-bg-dark);
 }
 
-/* min-width:0 lets the path shrink below its content's intrinsic width so a long path wraps to multiple lines within
-   the row instead of overrunning it and shoving the rid off the right edge (default min-width:auto would refuse to
-   shrink). white-space:normal does the wrapping; the rid keeps its full width beside it. */
+/* min-width:0 lets the path shrink below its content's intrinsic width (default min-width:auto would refuse), and a
+   long path stays on one line: the START is elided so the filename — the part that identifies the asset — survives
+   the cut. The full path lives in the tooltip and in selection-copy. */
 .aspid-fasttools-repair-references__group-entry-path {
     flex-grow:                                             1;
     flex-shrink:                                           1;
     min-width:                                             0;
     color:                                                 var(--aspid-colors-text-light);
-    white-space:                                           normal;
+    overflow:                                              hidden;
+    text-overflow:                                         ellipsis;
+    -unity-text-overflow-position:                         start;
     /* Entry text is selectable for copying (paths are the payload); the I-beam signals that over the row's link cursor. */
     cursor:                                                text;
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
@@ -496,7 +496,8 @@
    full-bleed it reads as a square strip welded across the rounded card. Pull it level with the header pill and list
    panel instead: a rounded plate at the same 8px radius, inset to the list's width with a 5px gap above (the selector's
    own 5px bottom padding holds the matching gap below) and no top divider — so header, list and footer read as one
-   rounded stack rather than a bar pasted onto the bottom edge. The base footer's opaque dark fill is kept. */
+   rounded stack rather than a bar pasted onto the bottom edge. The base footer's opaque dark fill is kept: a
+   frame-only variant read too faint, an accent-tinted fill fought the list's accent states. */
 .aspid-fasttools-repair-references__picker--attached
     .aspid-fasttools-type-selector__footer {
     margin: 5px 0 0 0;
@@ -504,11 +505,11 @@
     border-radius: 8px;
 }
 
-.aspid-fasttools-type-selector
-    .unity-collection-view__item.aspid-fasttools-type-selector__item {
+/* The rows' visual body (the fill-carrying content wrapper inside each transparent row shell) rounds and insets
+   to match the window's card idiom. */
+.aspid-fasttools-type-selector .aspid-fasttools-type-selector__item-content {
     border-radius: 8px;
     padding-left: 8px;
-    margin-bottom: 2px;
 }
 
 /* --- Project-mode group cards ---
@@ -517,7 +518,8 @@
    darkness fill and its 10px --rounded). The warning read comes from the amber type header and the amber-tinted
    dotted canvas behind it, not a warm border — so the cards belong to the same family as the Scan panel above them.
    Layout: the whole header is one flat clickable row (the type name + entry/file counts on the left, the bulk
-   "Fix all (N) ▼" action on the right), an optional Smart Fix button below it, then a list of ping-only entry rows. */
+   "Fix all (N) ▼" action on the right), a dim divider carrying the hover sweep, an optional Smart Fix / Migrate
+   action row, then a list of ping-only entry rows. */
 .aspid-fasttools-repair-references__group.aspid-fasttools-background {
     flex-grow:                                             0;
     margin-bottom:                                         10px;
@@ -534,6 +536,77 @@
 .aspid-fasttools-repair-references__group--picking.aspid-fasttools-background {
     border-color: var(--aspid-colors-status-warning-shade-light);
     /*background-color:                                      rgba(20, 20, 20, 0.72);*/
+}
+
+/* A migration card's active frame follows its own header accent — the calm info blue, not the broken-card amber. */
+.aspid-fasttools-repair-references__group--migrate.aspid-fasttools-repair-references__group--picking.aspid-fasttools-background {
+    border-color: var(--aspid-colors-status-info-shade-light);
+}
+
+/* The picker chrome follows the host card's header accent too, so the whole active card speaks one hue: the
+   focused-search frame (no fill — just the border) and the keyboard-selected row go warning amber on a broken-type
+   card, and the --migrate rules below swap both to the migration card's calm info tone (the picker's own default).
+   Selection is recoloured via the picker's row_bg VARIABLE, never background-color: the divider row routes its
+   fill through an inset backplate that reads that variable, so painting the property directly would flood its
+   divider zone again. The rules carry the .aspid-fasttools-type-selector block class (and a :focus variant)
+   purely for specificity over the base stylesheet's own variable-setting selection rule, which loads deeper in
+   the hierarchy and would otherwise win the tie and keep the picker's default info blue. */
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector__header--search-focused {
+    border-color: var(--aspid-colors-status-warning-text-light);
+}
+
+/* The header's hover cues (the magnifier, the navigable breadcrumbs) light up in the card's accent too, instead
+   of the picker's default info blue. */
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector__search-button:hover {
+    -unity-background-image-tint-color: var(--aspid-colors-status-warning-text-light);
+}
+
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector__breadcrumb--link:hover {
+    color: var(--aspid-colors-status-warning-text-lightness);
+}
+/* Hover rides the same accent one tone darker than selection, mirroring the base picker's hover/selection pair.
+   The extra __item compound (the class sits on the same shell) pushes each rule above every base-stylesheet
+   state rule; within the host, hover stays before the selected rules so a hovered selected row keeps the
+   stronger selection tone. */
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item.aspid-fasttools-type-selector__item:hover {
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-warning-shade-darkness);
+}
+
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item,
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item:hover,
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-type-selector
+    .unity-collection-view:focus .unity-collection-view__item--selected.aspid-fasttools-type-selector__item {
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-warning-shade-dark);
+}
+
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector__header--search-focused {
+    border-color: var(--aspid-colors-status-info-text-light);
+}
+
+/* A migration card also wears --picking while its picker is open, so these sit after the amber hover cues above
+   and swap them back to the card's info accent. */
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector__search-button:hover {
+    -unity-background-image-tint-color: var(--aspid-colors-status-info-text-light);
+}
+
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector__breadcrumb--link:hover {
+    color: var(--aspid-colors-status-info-text-lightness);
+}
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item.aspid-fasttools-type-selector__item:hover {
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-info-shade-darkness);
+}
+
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item,
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector
+    .unity-collection-view__item--selected.aspid-fasttools-type-selector__item:hover,
+.aspid-fasttools-repair-references__group--migrate .aspid-fasttools-type-selector
+    .unity-collection-view:focus .unity-collection-view__item--selected.aspid-fasttools-type-selector__item {
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-info-shade-dark);
 }
 
 /* The header IS one clickable row, but flat — the gradient fill is set transparent so it matches the card surface
@@ -580,6 +653,50 @@
     );
 }
 
+/* --- Header divider + underline sweep ---
+   The Welcome sample cards' idiom carried over: a dim hairline separates the header row from the card body, and an
+   accent sweep riding exactly ON that line scales in from the left while the header button is hovered. The sweep is
+   the button's sibling, so :hover can't reach it — code mirrors the button's hover onto the card's --header-hover
+   modifier, which the sweep rule listens to. */
+/* Pulled 2px into the Fix all row's 6px bottom margin, so the header-to-line gap lands on Welcome's 4px. */
+.aspid-fasttools-repair-references__group-divider {
+    flex-grow:                                             0;
+    margin-top:                                            -2px;
+    margin-bottom:                                         4px;
+    opacity:                                               0.5;
+}
+
+/* Pulled up past the divider's 4px bottom margin plus its 1px line so the sweep sits exactly ON the line; the 4px
+   bottom margin gives the swallowed gap back, keeping the body rhythm intact. Amber — the broken-type alarm,
+   matching the header's hover accent. */
+.aspid-fasttools-repair-references__group-sweep {
+    height:                                                1px;
+    margin-top:                                            -5px;
+    margin-bottom:                                         4px;
+    background-color:                                      var(--aspid-colors-status-warning-text-dark);
+    transform-origin:                                      left;
+    scale:                                                 0 1;
+    transition-property:                                   scale;
+    transition-duration:                                   0.25s;
+    transition-timing-function:                            ease-out;
+}
+
+/* A migration card sweeps in its calm info tone — nothing on it is broken (matches its header/migrate accents). */
+.aspid-fasttools-repair-references__group-sweep--migrate {
+    background-color:                                      var(--aspid-colors-status-info-text-dark);
+}
+
+.aspid-fasttools-repair-references__group--header-hover .aspid-fasttools-repair-references__group-sweep {
+    scale:                                                 1 1;
+}
+
+/* Picker open: the dropdown is inserted between the header and the divider, which would strand the line and its
+   sweep under the whole selector — drop both while the card is picking. */
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-repair-references__group-divider,
+.aspid-fasttools-repair-references__group--picking .aspid-fasttools-repair-references__group-sweep {
+    display:                                               none;
+}
+
 /* The info line: the broken type name with the dimmed count beside it, hugging the left of the header row. */
 .aspid-fasttools-repair-references__group-header-row {
     flex-direction:                                        row;
@@ -605,37 +722,34 @@
     -unity-font-style:                                     normal;
 }
 
-/* Smart Fix quick-apply: a success-tinted one-click suggestion, full-width below the header button. */
-.aspid-fasttools-repair-references__group-suggest {
-    margin-bottom:                                         8px;
-    --aspid-fasttools-colors-gradient_button-bg: var(
-        --aspid-colors-status-success-darkness
-    );
-    --aspid-fasttools-colors-gradient_button-accent: var(
-        --aspid-colors-status-success-text-light
-    );
+/* Smart Fix / Migrate all as a member of the entry-row family: a bold, left-aligned accent verb over the same
+   flat hover fill as the ping rows below it, instead of a filled gradient pill floating over the glass card.
+   Each card keeps ONE accent: the Smart Fix verb stays in the broken card's warning amber (matching the inspector
+   notice's amber suggestion), and the --info modifier swaps in the migration card's calm info tone — an
+   authoritative [MovedFrom] rename is a pending migration, not an alarm (and never an error: nothing is actually
+   broken for Unity). Text lightens with the fill on hover, both on the shared 0.25s ease-out beat. */
+.aspid-fasttools-repair-references__group-action {
+    padding:                                               2px 4px;
+    border-radius:                                         3px;
+    cursor:                                                link;
+    -unity-font-style:                                     bold;
+    color:                                                 var(--aspid-colors-status-warning-text-dark);
+    transition-property:                                   background-color, color;
+    transition-duration:                                   0.25s;
+    transition-timing-function:                            ease-out;
 }
 
-.aspid-fasttools-repair-references__group-suggest
-    .aspid-fasttools-gradient-button__label {
-    -unity-text-align:                                     middle-center;
+.aspid-fasttools-repair-references__group-action:hover {
+    background-color:                                      var(--aspid-colors-bg-dark);
+    color:                                                 var(--aspid-colors-status-warning-text-light);
 }
 
-/* [MovedFrom] bulk migrate: same one-click slot as Smart Fix, but info-tinted — an authoritative rename is a calm
-   pending migration, not a success-coloured guess (and never an error: nothing is actually broken for Unity). */
-.aspid-fasttools-repair-references__group-migrate {
-    margin-bottom:                                         8px;
-    --aspid-fasttools-colors-gradient_button-bg: var(
-        --aspid-colors-status-info-dark
-    );
-    --aspid-fasttools-colors-gradient_button-accent: var(
-        --aspid-colors-status-info-text-light
-    );
+.aspid-fasttools-repair-references__group-action--info {
+    color:                                                 var(--aspid-colors-status-info-text-dark);
 }
 
-.aspid-fasttools-repair-references__group-migrate
-    .aspid-fasttools-gradient-button__label {
-    -unity-text-align:                                     middle-center;
+.aspid-fasttools-repair-references__group-action--info:hover {
+    color:                                                 var(--aspid-colors-status-info-text-light);
 }
 
 /* A single broken reference inside a group: asset path on the left, dim rid on the right; the whole row pings. The
@@ -647,6 +761,10 @@
     padding:                                               2px 4px;
     border-radius:                                         3px;
     cursor:                                                link;
+    /* The hover fill fades in and out on the window's shared 0.25s ease-out beat instead of snapping. */
+    transition-property:                                   background-color;
+    transition-duration:                                   0.25s;
+    transition-timing-function:                            ease-out;
 }
 
 .aspid-fasttools-repair-references__group-entry:hover {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/SerializeReferences/Aspid-FastTools-SerializeReference.uss
@@ -368,6 +368,45 @@
     white-space:                                           normal;
 }
 
+/* Accent legend under the hint — decodes the two card tones (amber = broken/required, blue = pending migration).
+   Rendered only when both bands are on screen at once (see RenderGroups), so an all-amber or all-blue result list
+   never carries a key explaining a color it doesn't show. Tucked into the hint's 10px gap: its own 10px bottom
+   margin replaces the spacing to the cards below. */
+.aspid-fasttools-repair-references__legend {
+    flex-direction:                                        row;
+    align-items:                                           center;
+    margin-top:                                            -4px;
+    margin-bottom:                                         10px;
+}
+
+.aspid-fasttools-repair-references__legend--hidden {
+    display:                                               none;
+}
+
+.aspid-fasttools-repair-references__legend-item {
+    flex-direction:                                        row;
+    align-items:                                           center;
+    margin-right:                                          16px;
+}
+
+/* Same 6px dot idiom as the Welcome sample-state markers; the muted -text-dark swatches match the header sweeps
+   rather than the bright title text, keeping the key quieter than the cards it explains. */
+.aspid-fasttools-repair-references__legend-dot {
+    width:                                                 6px;
+    height:                                                6px;
+    border-radius:                                         3px;
+    margin-right:                                          6px;
+    background-color:                                      var(--aspid-colors-status-warning-text-dark);
+}
+
+.aspid-fasttools-repair-references__legend-dot--info {
+    background-color:                                      var(--aspid-colors-status-info-text-dark);
+}
+
+.aspid-fasttools-repair-references__legend-text {
+    color:                                                 var(--aspid-colors-text-dark);
+}
+
 /* One receipt per bulk Fix all, stacked in the summary list (newest at the bottom); the margin both spaces stacked
    receipts apart and holds the gap from the last one to the group list / empty area below. The list container itself
    has no styling — empty until the first fix, so it leaves no footprint then. */
@@ -780,6 +819,8 @@
     min-width:                                             0;
     color:                                                 var(--aspid-colors-text-light);
     white-space:                                           normal;
+    /* Entry text is selectable for copying (paths are the payload); the I-beam signals that over the row's link cursor. */
+    cursor:                                                text;
 }
 
 /* flex-shrink:0 keeps the rid at its natural width and pinned to the right however many lines the path wraps to. */
@@ -788,6 +829,7 @@
     margin-left:                                           10px;
     color:                                                 var(--aspid-colors-text-dark);
     -unity-text-align:                                     middle-right;
+    cursor:                                                text;
 }
 
 /* A required-violation row's "Component.field" column — same dim, right-pinned treatment as __group-entry-rid, one
@@ -797,6 +839,7 @@
     margin-left:                                           10px;
     color:                                                 var(--aspid-colors-text-dark);
     -unity-text-align:                                     middle-right;
+    cursor:                                                text;
 }
 
 /* --- Keyboard navigation ---

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Types/Aspid-FastTools-TypeSelector.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Types/Aspid-FastTools-TypeSelector.uss
@@ -1,4 +1,8 @@
+/* row_bg: the per-row state fill (transparent at rest, hover grey, selection accent) — set by the state rules in
+   the Item section and painted by the row root / the divider row's backplate. Declared here so every row resolves
+   a value even at rest. */
 .aspid-fasttools-type-selector {
+    --aspid-fasttools-colors-type_selector-row_bg: rgba(0, 0, 0, 0);
     padding:                5px 2px;
     flex-grow:              1;
     flex-direction:         column;
@@ -214,46 +218,87 @@ ToolbarSearchField TextElement {
 }
 
 /* ------------------------------------------------------ Item ------------------------------------------------------ */
-/* The padding-left is kept tight so the rows sit close to the picker's left edge. Hover lifts the surface a small grey
-   step; the selected row lifts to a clearly lighter neutral grey, far enough above the hover tone to read as the picked
-   row without leaning on a colour accent. */
+/* Each row is a transparent SHELL (the collection-view item, which doubles as the makeItem root) holding one
+   __item-content wrapper that carries everything visual: the horizontal layout, the tight edge padding and the
+   state fill. The fill is carried by the --aspid-fasttools-colors-type_selector-row_bg variable — the hover and
+   selected rules SET it on the shell, the content wrapper PAINTS it (hosts recolour selection by overriding the
+   variable, never background-color). The split exists for the divider row: the ListView owns its items' box
+   (DynamicHeight slots rows by measured height, ignores their margins, and interferes with their padding), so
+   the divider zone is made of shell height alone — the shell grows and the content wrapper, pinned to its
+   bottom, stays an ordinary 22px row that hover/selection light up without ever flooding the divider's air. */
 .aspid-fasttools-type-selector .unity-collection-view__item {
     height:                 22px;
+    padding:                0;
+    align-items:            stretch;
+    justify-content:        flex-end;
+    flex-direction:         column;
+}
+
+/* The shell never paints — these mirror every state selector Unity's default theme fills at, so the stock grey
+   and selection blue can't leak through the transparent shell in any hover/selected/focused combination. */
+.aspid-fasttools-type-selector .unity-collection-view__item:hover,
+.aspid-fasttools-type-selector .unity-collection-view__item--selected,
+.aspid-fasttools-type-selector .unity-collection-view__item--selected:hover,
+.aspid-fasttools-type-selector .unity-collection-view:focus .unity-collection-view__item--selected {
+    background-color:       rgba(0, 0, 0, 0);
+}
+
+/* The row's visual body. The padding-left is kept tight so the rows sit close to the picker's left edge. */
+.aspid-fasttools-type-selector__item-content {
+    height:                 22px;
+    flex-shrink:            0;
     align-items:            center;
     flex-direction:         row;
     padding-left:           1px;
     padding-right:          5px;
+    background-color:       var(--aspid-fasttools-colors-type_selector-row_bg);
 }
 
+/* Hover lifts the surface a dim step of the picker's interactive accent — the same hue as the selection fill
+   below, one tone darker, so hovered and selected read as two strengths of one accent instead of grey vs colour. */
 .aspid-fasttools-type-selector .unity-collection-view__item:hover {
-    background-color:       var(--aspid-colors-bg-light);
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-info-shade-darkness);
 }
 
-/* The old selected grey sat only one step above hover and washed out against it; this lifts the selected row to a
-   clearly lighter neutral grey so the pick stands apart from a merely-hovered row by tone alone, no colour accent
-   needed. */
+/* The selected row wears the picker's interactive accent (the same info blue as the focused-search frame and the
+   link hovers) as a dark fill, so keyboard selection reads as "active" in the picker's own hue instead of a grey
+   step that washed out against hover. */
 .aspid-fasttools-type-selector .unity-collection-view__item--selected,
-.aspid-fasttools-type-selector .unity-collection-view__item--selected:hover {
-    background-color:       var(--aspid-colors-shade-light);
+.aspid-fasttools-type-selector .unity-collection-view__item--selected:hover,
+.aspid-fasttools-type-selector .unity-collection-view:focus .unity-collection-view__item--selected {
+    --aspid-fasttools-colors-type_selector-row_bg: var(--aspid-colors-status-info-shade-dark);
 }
 
-/* The first ordinary root category after the pinned block (<None>, Favorites, Recent) draws the divider
-   line that separates the pinned rows from the namespace hierarchy (toggled in code on the row root, which
-   doubles as the collection-view item): 1px line flush under the pinned block, 4px of air, then the usual
-   22px row — the height covers exactly border + padding + content so the row grid below is undisturbed.
-   The wrapper class rides along in the selector to outweigh the 22px height in the base row rule above. */
+/* The first ordinary root category after the pinned block (<None>, Favorites, Recent) carries the divider zone
+   as extra shell height above its bottom-pinned content: 4px of air, the 1px line, 4px of air, then the usual
+   22px row. The modifier is toggled in code on the shell. */
 .aspid-fasttools-type-selector
     .unity-collection-view__item.aspid-fasttools-type-selector__item--after-pinned {
-    height:                 27px;
-    padding-top:            4px;
-    border-top-width:       1px;
-    border-top-color:       var(--aspid-colors-shade-darkness);
+    height:                 31px;
 }
 
+/* The divider hairline: present in every row template, shown only on the row wearing --after-pinned. Absolutely
+   positioned in the divider zone (line at 4px: 4px of air to the pinned block above and to the content below),
+   so it takes no part in the row layout, ignores the content's border-radius and sits outside every fill. */
+.aspid-fasttools-type-selector__item-divider {
+    display:                none;
+    position:               absolute;
+    top:                    4px;
+    left:                   0;
+    right:                  0;
+    height:                 1px;
+    background-color:       var(--aspid-colors-shade-darkness);
+}
+
+.aspid-fasttools-type-selector__item--after-pinned > .aspid-fasttools-type-selector__item-divider {
+    display:                flex;
+}
+
+/* The block class on the shell exists for the modifier grammar (--after-pinned, --in-section, --current) and
+   descendant hooks; the shell's own layout lives in the collection-view__item rules above, the horizontal row
+   layout in __item-content. */
 .aspid-fasttools-type-selector__item {
     flex-grow:              1;
-    align-items:            center;
-    flex-direction:         row;
 }
 
 .aspid-fasttools-type-selector__item-icon {
@@ -365,8 +410,6 @@ ToolbarSearchField TextElement {
    the list — set apart only by its leading collapse chevron, a bold weight and a slightly dimmer caption. No caps, no
    shrunken font, no special fill, so the list stays visually uniform. */
 .aspid-fasttools-type-selector__section-title {
-    align-items:            center;
-    flex-direction:         row;
     background-color:       rgba(0, 0, 0, 0);
     cursor:                 link;
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
@@ -157,7 +157,7 @@
    corner radius — absolutely pinned to the row's left edge with a small vertical inset, so it stays a straight line
    whatever the row's rounding, and the rows' left padding keeps a clear gap between the line and the content. The
    scope utility classes are applied by the section builders; the stripes only paint inside this window — the Project
-   Settings page never loads this sheet. The legend in the reset footer decodes the two colours. */
+   Settings page never loads this sheet. The legend in the surface header decodes the two colours. */
 .aspid-fasttools-settings__scope-stripe {
     position:                                             absolute;
     /* Pinned inside the row's box (some field types clip children to their bounds, so it cannot hang outside);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
@@ -4,61 +4,136 @@
    on AspidSettingsUI, which both surfaces compose from. The per-area controls are the branded AspidSwitch and
    excluded-folders list (both self-styled) plus plain Unity fields — the Build / CI gate EnumField, the recents
    SliderInt, the theme-override ObjectField — whose native bright fills would float oddly over the dark canvas, so
-   this sheet repaints them into the dark palette, backs each row with a card, and stripes every row by its storage
-   scope. Every rule is scoped under the block class; the SerializeReference Project Settings page never adds it and
-   keeps its native Unity look. */
+   this sheet repaints them into the dark palette, groups each package area into a glass section card of flat rows,
+   and stripes every row by its storage scope. Every rule is scoped under the block class; the SerializeReference
+   Project Settings page never adds it and keeps its native Unity look. */
 .aspid-fasttools-settings {
     padding:                                              12px 12px 0 12px;
     flex-grow:                                            1;
 }
 
-/* Section title — groups the tab's controls under a named heading (the first is "References"). The tab is meant to grow
-   more sections (TypeSelector and other package areas); each is introduced by one of these. A bold bright caption over a
-   hairline divider, with no side margin so its left edge and the full-width divider line up with the control cards. */
-.aspid-fasttools-settings__section-title {
-    margin-top:                                           2px;
-    margin-bottom:                                        8px;
-    padding-bottom:                                       5px;
-    font-size:                                            13px;
-    color:                                                var(--aspid-colors-text-lightness);
-    -unity-font-style:                                    bold;
-    border-bottom-width:                                  1px;
-    border-bottom-color:                                  var(--aspid-colors-shade-dark);
+/* --- Surface header ---
+   The audit tabs' results-header idiom: an underlined heading sitting on the bare canvas (no card of its own — the
+   line under the AspidLabel carries the header weight), a dim one-line description under it, then the scope legend. */
+.aspid-fasttools-settings__header {
+    margin-bottom:                                        12px;
 }
 
-/* Section body — wraps one section's controls; the bottom margin spaces it from the next section's title. */
-.aspid-fasttools-settings__section-content {
+.aspid-fasttools-settings__header-title {
+    margin-bottom:                                        6px;
+}
+
+.aspid-fasttools-settings__header-description {
+    color:                                                var(--aspid-colors-text-dark);
+    white-space:                                          normal;
+}
+
+/* Section card — each package area (the first is "References") is one glass group card: the same translucent dark
+   fill, neutral hairline frame and 8px radius as the Project References group cards and the Scan panel, so the
+   window's dotted canvas reads through every card on every tab alike. The controls inside are flat rows, not nested
+   boxes. */
+.aspid-fasttools-settings__section {
     margin-bottom:                                        10px;
-}
-
-/* Each control row (caption + switch / dropdown / slider — plus the custom __row cards for non-field rows like the
-   clear-saved-lists actions) gets a faint rounded backing so the eye can trace a wide row from its caption on the left
-   to its control pinned on the right; the inset keeps the content off the row's edges and the margin spaces the rows
-   apart. Hover lifts the row a touch more. Only a section's direct children are cards — a field nested inside another
-   control (the slider's inline value box is itself a TextField, i.e. a .unity-base-field) must not pick up the card
-   chrome. */
-.aspid-fasttools-settings__section-content > .unity-base-field,
-.aspid-fasttools-settings__row {
-    margin-left:                                          0;
-    margin-right:                                         0;
-    margin-bottom:                                        4px;
-    padding:                                              4px 4px 4px 8px;
+    padding:                                              8px 10px;
     border-width:                                         1px;
     border-radius:                                        8px;
     border-color:                                         var(--aspid-colors-shade-darkness);
     background-color:                                     rgba(20, 20, 20, 0.55);
+}
+
+/* Section title — the card's static header row: a bold bright caption whose 4px side padding lines it up with the
+   flat rows' content below (the group cards' static-header geometry). The dividing line under it is its own element
+   (__section-divider), not a border. */
+.aspid-fasttools-settings__section-title {
+    padding:                                              4px 4px;
+    margin-bottom:                                        6px;
+    font-size:                                            13px;
+    color:                                                var(--aspid-colors-text-lightness);
+    -unity-font-style:                                    bold;
+}
+
+/* The dim hairline between the card's header and its rows — the group cards' header-divider geometry (pulled 2px
+   into the title's 6px bottom margin so the header-to-line gap lands on the shared 4px). No sweep rides it: a
+   settings header is static, there is nothing to hover. */
+.aspid-fasttools-settings__section-divider {
+    flex-grow:                                            0;
+    margin-top:                                           -2px;
+    margin-bottom:                                        4px;
+    opacity:                                              0.5;
+}
+
+/* The section body (__section-content) is a bare hook with no rules of its own — the card's padding and the title's
+   margin carry the spacing; it exists so the row selectors below can scope to a section's direct children. */
+
+/* Each control row (caption + switch / dropdown / slider — plus the custom __row rows like the clear-saved-lists
+   actions) is a flat member of its section card — no box of its own, just the scope stripe on its left edge and a
+   flat hover fill (the entry-row idiom of the other tabs) so the eye can trace a wide row from its caption to its
+   control pinned on the right. Only a section's direct children are rows — a field nested inside another control
+   (the slider's inline value box is itself a TextField, i.e. a .unity-base-field) must not pick up the row chrome. */
+.aspid-fasttools-settings__section-content > .unity-base-field,
+.aspid-fasttools-settings__row {
+    margin-left:                                          0;
+    margin-right:                                         0;
+    margin-bottom:                                        2px;
+    /* The 17px left inset = 3px stripe + 6px clear air + the backplate's 8px content inset, so captions sit 8px
+       inside the fill edge like any card content. */
+    padding:                                              4px 4px 4px 17px;
     /* Centre every row's caption against its control so the captions sit at one height across all rows. The switches
        already centre via inline styles; this brings the EnumField row (which has none) onto the same baseline. */
     align-items:                                          center;
+}
+
+/* The backplate carrying a scoped row's hover / keyboard-focus fill (mounted by WithScopeStripe behind the row's
+   content): inset 9px past the stripe so a lit row never touches the line, rounded at the cards' full 8px. The fill
+   cannot live on the row itself — its box starts at the stripe — and the stripe cannot move out into a margin
+   gutter: some field types (AspidSwitch, EnumField) clip children to their bounds. */
+.aspid-fasttools-settings__row-backplate {
+    position:                                             absolute;
+    left:                                                 9px;
+    right:                                                0;
+    top:                                                  0;
+    bottom:                                               0;
+    border-radius:                                        8px;
     /* The hover lift fades in and out on the window's shared 0.25s ease-out beat instead of snapping. */
     transition-property:                                  background-color;
     transition-duration:                                  0.25s;
     transition-timing-function:                           ease-out;
 }
 
-.aspid-fasttools-settings__section-content > .unity-base-field:hover,
-.aspid-fasttools-settings__row:hover {
-    background-color:                                     rgba(255, 255, 255, 0.14);
+.aspid-fasttools-settings__section-content > .unity-base-field:hover > .aspid-fasttools-settings__row-backplate,
+.aspid-fasttools-settings__row:hover > .aspid-fasttools-settings__row-backplate {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* The footer's reset row has no scope stripe (its two buttons act on different scopes), so no backplate is mounted —
+   its hover fill stays on the row itself — and the rows' 17px stripe gutter collapses away: the -4px margin cancels
+   the 4px text padding, landing the caption exactly on the header/card left grid while the hover fill keeps 4px of
+   air around the text. */
+.aspid-fasttools-settings__footer .aspid-fasttools-settings__row {
+    margin-left:                                          -4px;
+    padding-left:                                         4px;
+    border-radius:                                        8px;
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
+}
+
+.aspid-fasttools-settings__footer .aspid-fasttools-settings__row:hover {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* A row note — one dim line under a row surfacing what its tooltip would otherwise hide (the gate values' meaning,
+   what a team-wide toggle really does). The left padding lands the text on the rows' caption edge (3px scope stripe
+   + 8px inset); the negative top margin tucks it under its row, and the bottom margin re-opens the rhythm to the
+   next row. */
+.aspid-fasttools-settings__row-note {
+    margin-top:                                           -1px;
+    margin-bottom:                                        6px;
+    /* 17px = the rows' 9px stripe gutter + their 8px content inset, so the note sits on its row's caption edge. */
+    padding-left:                                         17px;
+    font-size:                                            11px;
+    color:                                                var(--aspid-colors-text-dark);
+    white-space:                                          normal;
 }
 
 /* Custom (non-BaseField) rows lay out like the field rows: caption left, controls pinned right. */
@@ -78,24 +153,39 @@
 /* --- Storage-scope marking ---
    The tab mixes settings persisted in the committed ProjectSettings asset (team-wide) with per-user EditorPrefs ones,
    so every row wears a scope stripe on its left edge: green = shared with the team, blue = just this machine. The
-   utility classes are applied by the section builders; the stripes only paint inside this window — the Project
-   Settings page never loads this sheet. The legend at the top of the tab decodes the two colours. */
-.aspid-fasttools-settings .aspid-fasttools-settings-scope--shared {
-    border-left-width:                                    3px;
-    border-left-color:                                    var(--aspid-colors-status-success-lightness);
+   stripe is a separate element mounted by WithScopeStripe — not a border-left, which would bend around the row's
+   corner radius — absolutely pinned to the row's left edge with a small vertical inset, so it stays a straight line
+   whatever the row's rounding, and the rows' left padding keeps a clear gap between the line and the content. The
+   scope utility classes are applied by the section builders; the stripes only paint inside this window — the Project
+   Settings page never loads this sheet. The legend in the reset footer decodes the two colours. */
+.aspid-fasttools-settings__scope-stripe {
+    position:                                             absolute;
+    /* Pinned inside the row's box (some field types clip children to their bounds, so it cannot hang outside);
+       the fill-carrying backplate starts 9px in, leaving 6px of clear air between the line and a lit row. */
+    left:                                                 0;
+    top:                                                  3px;
+    bottom:                                               3px;
+    width:                                                3px;
+    border-radius:                                        1px;
 }
 
-.aspid-fasttools-settings .aspid-fasttools-settings-scope--user {
-    border-left-width:                                    3px;
-    border-left-color:                                    var(--aspid-colors-status-info-lightness);
+.aspid-fasttools-settings__scope-stripe.aspid-fasttools-settings-scope--shared {
+    background-color:                                     var(--aspid-colors-status-success-lightness);
 }
 
-/* The scope legend: one dim line above the sections pairing each stripe colour with what it means for persistence.
-   Items flow in a row and wrap on narrow windows. */
+.aspid-fasttools-settings__scope-stripe.aspid-fasttools-settings-scope--user {
+    background-color:                                     var(--aspid-colors-status-info-lightness);
+}
+
+/* The scope legend: one dim line pairing each stripe colour with what it means for persistence. Lives in the surface
+   header, under the description — the reader meets the key before the first striped row. The 6px-dot idiom of the
+   window's other legends (the audit's amber/blue key, the Welcome sample markers), so every legend in the window
+   reads as one family. Items flow in a row and wrap on narrow windows. */
 .aspid-fasttools-settings__legend {
     flex-direction:                                       row;
     flex-wrap:                                            wrap;
-    margin-bottom:                                        8px;
+    /* The 1px left margin optically lands the dots on the header text edge (the text has no side padding). */
+    margin:                                               6px 0 0 1px;
 }
 
 .aspid-fasttools-settings__legend-item {
@@ -104,13 +194,21 @@
     margin-right:                                         16px;
 }
 
-/* Each legend swatch is a miniature of the rows' left stripe (same width, painted by the same scope class via
-   border-left) so the key and the marking read as one system. */
+/* Each legend dot is painted by the same scope class the rows' stripes wear (the fill rules below), so the key and
+   the marking stay one system. */
 .aspid-fasttools-settings__legend-swatch {
-    width:                                                0;
-    height:                                               12px;
+    width:                                                6px;
+    height:                                               6px;
     margin-right:                                         6px;
-    border-radius:                                        1px;
+    border-radius:                                        3px;
+}
+
+.aspid-fasttools-settings__legend-swatch.aspid-fasttools-settings-scope--shared {
+    background-color:                                     var(--aspid-colors-status-success-lightness);
+}
+
+.aspid-fasttools-settings__legend-swatch.aspid-fasttools-settings-scope--user {
+    background-color:                                     var(--aspid-colors-status-info-lightness);
 }
 
 .aspid-fasttools-settings__legend-text {
@@ -173,14 +271,18 @@
 
 /* --- Recent-items slider ---
    The SliderInt row joins the family: caption and control split 50/50 like the EnumField row, a slim dark track with
-   a muted round handle (the switch handle's palette), and the drag-value text box framed like the other inputs. */
-.aspid-fasttools-settings .unity-base-slider .unity-base-field__label {
+   a muted round handle (the switch handle's palette), and the drag-value text box framed like the other inputs.
+   Every slider rule is scoped under __section-content — NOT the surface root — because a ScrollView's scrollbar is
+   internally a .unity-base-slider too: root-scoped rules would repaint the tab's own vertical scroller into a stray
+   bright pill (the dragger fill + re-pinned geometry below). The scroller lives outside the section cards, so the
+   tighter scope reaches only the real settings slider. */
+.aspid-fasttools-settings__section-content .unity-base-slider .unity-base-field__label {
     flex-grow:                                            1;
     flex-basis:                                           0;
     min-width:                                            auto;
 }
 
-.aspid-fasttools-settings .unity-base-slider .unity-base-field__input {
+.aspid-fasttools-settings__section-content .unity-base-slider .unity-base-field__input {
     flex-grow:                                            1;
     flex-shrink:                                          1;
     flex-basis:                                           0;
@@ -191,7 +293,7 @@
    cleanly with top:50% + a minus-half-height margin; the handle's top offset is partly forced by BaseSlider itself,
    so its margin carries an extra -4px measured against the 22px input row to land the handle's centre exactly on the
    track's (change either height and this needs re-measuring). */
-.aspid-fasttools-settings .unity-base-slider__tracker {
+.aspid-fasttools-settings__section-content .unity-base-slider__tracker {
     top:                                                  50%;
     height:                                               4px;
     margin-top:                                           -2px;
@@ -200,7 +302,7 @@
     background-color:                                     var(--aspid-colors-shade-darkness);
 }
 
-.aspid-fasttools-settings .unity-base-slider__dragger {
+.aspid-fasttools-settings__section-content .unity-base-slider__dragger {
     top:                                                  50%;
     width:                                                12px;
     height:                                               12px;
@@ -213,18 +315,18 @@
 
 /* Unity's separate focus halo (the dragger-border element) is sized for the default handle and pokes out from under
    the smaller one as a stray blue disc — hide it; the handle carries the focus tint itself below. */
-.aspid-fasttools-settings .unity-base-slider__dragger-border {
+.aspid-fasttools-settings__section-content .unity-base-slider__dragger-border {
     display:                                              none;
 }
 
 /* Hovering the slider washes the handle's border in the muted signature green — the same accent family as the
    switches, the dropdown and the folder list; keyboard focus pulls in the bright accent, replacing the hidden
    default halo. */
-.aspid-fasttools-settings .unity-base-slider:hover .unity-base-slider__dragger {
+.aspid-fasttools-settings__section-content .unity-base-slider:hover .unity-base-slider__dragger {
     border-color:                                         var(--aspid-colors-status-success-shade-light);
 }
 
-.aspid-fasttools-settings .unity-base-slider:focus .unity-base-slider__dragger {
+.aspid-fasttools-settings__section-content .unity-base-slider:focus .unity-base-slider__dragger {
     border-color:                                         var(--aspid-colors-status-success-text-light);
 }
 
@@ -232,7 +334,7 @@
    settings inputs instead of Unity's bright default field. The height is set on the TextField itself and mirrored on
    its input — Unity sizes the slider's inline field shorter than our input, which otherwise clips the digit's
    bottom against the frame. */
-.aspid-fasttools-settings .unity-base-slider__text-field {
+.aspid-fasttools-settings__section-content .unity-base-slider__text-field {
     flex-grow:                                            0;
     flex-shrink:                                          0;
     width:                                                34px;
@@ -240,7 +342,7 @@
     margin:                                               0 0 0 8px;
 }
 
-.aspid-fasttools-settings .unity-base-slider__text-field .unity-base-text-field__input {
+.aspid-fasttools-settings__section-content .unity-base-slider__text-field .unity-base-text-field__input {
     height:                                               22px;
     padding:                                              0 4px;
     -unity-text-align:                                    middle-center;
@@ -251,7 +353,7 @@
     color:                                                var(--aspid-colors-text-lightness);
 }
 
-.aspid-fasttools-settings .unity-base-slider__text-field .unity-base-text-field__input:focus {
+.aspid-fasttools-settings__section-content .unity-base-slider__text-field .unity-base-text-field__input:focus {
     border-color:                                         var(--aspid-colors-status-success-text-light);
 }
 
@@ -356,6 +458,111 @@
 
 .aspid-fasttools-settings .unity-object-field__selector:hover {
     background-color:                                     rgba(255, 255, 255, 0.16);
+}
+
+/* --- Keyboard navigation ---
+   Arrow keys walk one flat focus ring over every actionable element on the tab (switch rows, the gate dropdown, the
+   excluded-folders panel, the slider row, the action buttons); Enter activates the highlighted one, ←/→ nudge the
+   highlighted slider, Escape drops the highlight. The highlight mirrors each element's own hover treatment so
+   keyboard focus and mouse hover read as one state (the other tabs' nav idiom). Rows take the flat hover fill: */
+.aspid-fasttools-settings__nav-target--focused > .aspid-fasttools-settings__row-backplate {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* The footer's reset row would take the flat fill directly if it ever joins the ring (it has no backplate). */
+.aspid-fasttools-settings__footer .aspid-fasttools-settings__row.aspid-fasttools-settings__nav-target--focused {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* Action buttons mirror their own hover families — signature green, red for destructive, blue for per-user scope. */
+.aspid-fasttools-settings__action.aspid-fasttools-settings__nav-target--focused {
+    border-color:                                         var(--aspid-colors-status-success-shade-light);
+    color:                                                var(--aspid-colors-status-success-text-light);
+    background-color:                                     rgba(20, 90, 45, 0.25);
+}
+
+.aspid-fasttools-settings__action--danger.aspid-fasttools-settings__nav-target--focused {
+    border-color:                                         var(--aspid-colors-status-error-text-dark);
+    color:                                                var(--aspid-colors-status-error-text-light);
+    background-color:                                     rgba(125, 35, 35, 0.25);
+}
+
+.aspid-fasttools-settings__action--info.aspid-fasttools-settings__nav-target--focused {
+    border-color:                                         var(--aspid-colors-status-info-text-dark);
+    color:                                                var(--aspid-colors-status-info-text-light);
+    background-color:                                     rgba(25, 75, 130, 0.25);
+}
+
+/* The excluded-folders control joins the ring per element: its add header highlights via the same neutral fill it
+   shows on mouse hover (Enter opens the add-folder picker) with the "+" brightening to green alongside, and each
+   folder row takes the flat neutral fill of its own hover (Enter re-picks the folder, Delete/Backspace removes it).
+   Two classes per rule outrank the control's self-styled base rules, whose sheet loads deeper. */
+.aspid-fasttools-excluded-folders__header.aspid-fasttools-settings__nav-target--focused {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+.aspid-fasttools-excluded-folders__header.aspid-fasttools-settings__nav-target--focused
+    .aspid-fasttools-excluded-folders__add {
+    color:                                                var(--aspid-colors-status-success-text-light);
+}
+
+.aspid-fasttools-excluded-folders__entry.aspid-fasttools-settings__nav-target--focused {
+    background-color:                                     var(--aspid-colors-bg-dark);
+}
+
+/* --- Scrollbar ---
+   The surface's vertical scroller re-dressed from Unity's bright default into the window's quiet family: no
+   step buttons, no track — just a slim translucent thumb that brightens while the scroller is hovered. Mirrors the
+   window sheet's scroller rules (which cover the window's other tabs) so the Preferences page — which loads only
+   this sheet — scrolls in the same chrome. Scoped to the scroller so the Recent-items slider (a base-slider too,
+   scoped under __section-content) is untouched. */
+.aspid-fasttools-settings .unity-scroller--vertical {
+    width:                                                12px;
+    margin:                                               0;
+    border-width:                                         0;
+    background-color:                                     rgba(0, 0, 0, 0);
+}
+
+.aspid-fasttools-settings .unity-scroller--vertical > .unity-scroller__low-button,
+.aspid-fasttools-settings .unity-scroller--vertical > .unity-scroller__high-button {
+    display:                                              none;
+}
+
+/* With the step buttons gone, the slider re-pins to the scroller's full height (the default offsets reserve room
+   for them). */
+.aspid-fasttools-settings .unity-scroller--vertical .unity-scroller__slider {
+    margin:                                               0;
+    padding:                                              0;
+    width:                                                12px;
+    min-width:                                            12px;
+    top:                                                  0;
+    bottom:                                               0;
+}
+
+.aspid-fasttools-settings .unity-scroller--vertical .unity-base-slider__tracker {
+    border-width:                                         0;
+    background-color:                                     rgba(0, 0, 0, 0);
+}
+
+/* The thumb: slim, rounded, translucent white so it reads over both the bare canvas and the glass cards; hover
+   brightens it on the shared 0.25s beat. The default focus halo is dropped with the rest of the chrome. */
+.aspid-fasttools-settings .unity-scroller--vertical .unity-base-slider__dragger {
+    left:                                                 3px;
+    width:                                                6px;
+    border-width:                                         0;
+    border-radius:                                        3px;
+    background-color:                                     rgba(255, 255, 255, 0.12);
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
+}
+
+.aspid-fasttools-settings .unity-scroller--vertical:hover .unity-base-slider__dragger {
+    background-color:                                     rgba(255, 255, 255, 0.28);
+}
+
+.aspid-fasttools-settings .unity-scroller--vertical .unity-base-slider__dragger-border {
+    display:                                              none;
 }
 
 /* --- Standalone canvas ---

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Aspid-FastTools-Settings.uss
@@ -50,6 +50,10 @@
     /* Centre every row's caption against its control so the captions sit at one height across all rows. The switches
        already centre via inline styles; this brings the EnumField row (which has none) onto the same baseline. */
     align-items:                                          center;
+    /* The hover lift fades in and out on the window's shared 0.25s ease-out beat instead of snapping. */
+    transition-property:                                  background-color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
 }
 
 .aspid-fasttools-settings__section-content > .unity-base-field:hover,
@@ -126,6 +130,10 @@
     border-color:                                         var(--aspid-colors-shade-dark);
     border-radius:                                        8px;
     color:                                                var(--aspid-colors-text-light);
+    /* The status wash (fill, frame and text together) fades on the same 0.25s ease-out beat as the row cards. */
+    transition-property:                                  background-color, border-color, color;
+    transition-duration:                                  0.25s;
+    transition-timing-function:                           ease-out;
 }
 
 .aspid-fasttools-settings__action:hover {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
@@ -2,14 +2,16 @@
     flex-grow: 1;
 }
 
+/* 12px matches the References tabs' content padding; inner sections keep vertical padding only so the
+   cards' side inset stays this single value across tabs. */
 .aspid-fasttools-welcome__content {
-    padding: 10px;
+    padding: 12px;
     flex-grow: 1;
     align-items: stretch;
 }
 
 .aspid-fasttools-welcome__hero {
-    padding: 10px;
+    padding: 10px 0;
     align-items: center;
     flex-direction: row;
 }
@@ -72,7 +74,7 @@ AspidAnimatedTitle {
 }
 
 .aspid-fasttools-welcome__card {
-    padding: 10px;
+    padding: 10px 0;
 }
 
 /* Sample cards share the References group-card surface: translucent dark fill, neutral border, 8px radius —

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
@@ -129,9 +129,9 @@ AspidAnimatedTitle {
     color: var(--aspid-colors-text-light);
 }
 
-/* Not-yet-imported marker ahead of the title: a single brand-blue dot quoting the dotted canvas — the
-   unread-marker idiom, so fresh samples catch the eye and the dot disappears once imported. */
-.aspid-fasttools-welcome__sample-import-dot {
+/* State marker ahead of the title: a single dot quoting the dotted canvas — the unread-marker idiom, brand
+   blue while the sample is still waiting to be imported, so fresh samples catch the eye. */
+.aspid-fasttools-welcome__sample-state-dot {
     width: 6px;
     height: 6px;
     flex-shrink: 0;
@@ -144,8 +144,19 @@ AspidAnimatedTitle {
 }
 
 /* Hovering the header verb turns the dot the Import accent green — "about to become imported". */
-.aspid-fasttools-welcome__sample--header-hover .aspid-fasttools-welcome__sample-import-dot {
+.aspid-fasttools-welcome__sample--header-hover .aspid-fasttools-welcome__sample-state-dot {
     background-color: var(--aspid-colors-status-success-text-dark);
+}
+
+/* Once imported the dot stays green — the sample is in the project. */
+.aspid-fasttools-welcome__sample-state-dot--imported {
+    background-color: var(--aspid-colors-status-success-text-dark);
+}
+
+/* An imported card's verb is Remove, so hovering it previews the destructive tone instead of the green
+   (equal specificity with the hover rule above — this one wins by coming later). */
+.aspid-fasttools-welcome__sample--header-hover .aspid-fasttools-welcome__sample-state-dot--imported {
+    background-color: var(--aspid-colors-status-error-text-dark);
 }
 
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
@@ -1,11 +1,3 @@
-:root {
-    --aspid-fasttools-colors-bg: rgb(0, 0, 0);
-}
-
-AspidAnimatedDotsBackground {
-    background-color: var(--aspid-fasttools-colors-bg);
-}
-
 .aspid-fasttools-welcome__scroll {
     flex-grow: 1;
 }
@@ -39,50 +31,72 @@ AspidAnimatedTitle {
     -unity-font-style: bold;
 }
 
+/* Keep the animated gradient inside the brand green family: the red/amber stops read as status colors
+   everywhere else in the window, so the title cycles dark → light green instead of the logo's traffic-light
+   triplet. Scoped under __hero to outrank the component's own :root defaults on specificity. */
+.aspid-fasttools-welcome__hero AspidAnimatedTitle {
+    --aspid-fasttools-colors-animated_title-color_1: var(--aspid-colors-status-success-text-darkness);
+    --aspid-fasttools-colors-animated_title-color_2: var(--aspid-colors-status-success-text-dark);
+    --aspid-fasttools-colors-animated_title-color_3: var(--aspid-colors-status-success-text-light);
+}
+
+/* The hero blurb reads directly over the dotted canvas — no plate behind it. */
 .aspid-fasttools-welcome__description {
     white-space: normal;
-    border-radius: 10px;
-    background-color: var(--aspid-fasttools-colors-bg);
 }
 
 .aspid-fasttools-welcome__card {
     padding: 10px;
-    border-radius: 10px;
 }
 
-/* Scoped under __card so it outranks the gradient button's own :root height/padding on the class tie,
-   letting a sample row grow past one line to fit its wrapped description. */
-.aspid-fasttools-welcome__card .aspid-fasttools-welcome__sample {
-    height: auto;
-    min-height: 36px;
+/* Sample cards share the References group-card surface: translucent dark fill, neutral border, 8px radius —
+   overriding AspidBox's opaque darkness fill and its 10px --rounded (the double class outranks the box's own rules). */
+.aspid-fasttools-welcome__sample.aspid-fasttools-background {
+    flex-grow: 0;
+    margin-bottom: 10px;
     padding: 8px 10px;
-    align-items: center;
+    border-radius: 8px;
+    border-width: 1px;
+    border-color: var(--aspid-colors-shade-darkness);
+    background-color: rgba(20, 20, 20, 0.55);
 }
 
-.aspid-fasttools-welcome__sample-body {
-    flex-grow: 1;
-}
-
-.aspid-fasttools-welcome__sample-header {
+.aspid-fasttools-welcome__sample-header-row {
     flex-direction: row;
     align-items: center;
 }
 
-.aspid-fasttools-welcome__sample-title {
+/* The whole header line is one flat clickable button, mirroring the References "Fix all" row: the gradient
+   fill is set transparent so it matches the card surface and the accent only drives the soft full-width hover
+   glow. Scoped under __sample because the button's own stylesheet sets height/padding/margin on :root, which
+   ties with a lone class — the descendant selector raises specificity to override them. */
+.aspid-fasttools-welcome__sample .aspid-fasttools-welcome__sample-header {
     flex-grow: 1;
+    flex-direction: row;
+    align-items: center;
+    height: auto;
+    margin: 0;
+    padding: 4px 4px;
+    --aspid-fasttools-colors-gradient_button-bg: rgba(0, 0, 0, 0);
+}
+
+/* The action verb ("Import ▼") right-aligns inside the header button's flex-grow label. */
+.aspid-fasttools-welcome__sample-header .aspid-fasttools-gradient-button__label {
+    -unity-text-align: middle-right;
+}
+
+/* An imported sample's header verb is "Remove" — a destructive direct action, so its hover glow goes error
+   instead of the default success accent. */
+.aspid-fasttools-welcome__sample .aspid-fasttools-welcome__sample-header--remove {
+    --aspid-fasttools-colors-gradient_button-accent: var(--aspid-colors-status-error-text-light);
+}
+
+.aspid-fasttools-welcome__sample-title {
     font-size: 14px;
     -unity-font-style: bold;
     color: var(--aspid-colors-text-light);
 }
 
-.aspid-fasttools-welcome__sample-action {
-    flex-shrink: 0;
-    margin-left: 10px;
-    font-size: 14px;
-    -unity-font-style: bold;
-    -unity-text-align: middle-right;
-    color: var(--aspid-colors-text-light);
-}
 
 .aspid-fasttools-welcome__sample-divider {
     flex-grow: 0;
@@ -90,8 +104,36 @@ AspidAnimatedTitle {
     margin-bottom: 2px;
 }
 
+/* The hover sweep: an accent hairline lying exactly on the divider line (pulled up over it by the negative
+   margin), scaling in from the left edge while the header button is hovered — the cards' echo of the tab
+   strip's active underline. Triggered by the --header-hover card modifier (mirrored from the button in code),
+   since the sweep is the button's sibling and :hover can't reach across. */
+.aspid-fasttools-welcome__sample-sweep {
+    height: 1px;
+    margin-top: -1px;
+    margin-bottom: 0;
+    background-color: var(--aspid-colors-status-success-text-dark);
+    transform-origin: left;
+    scale: 0 1;
+    transition-property: scale;
+    transition-duration: 0.25s;
+    transition-timing-function: ease-out;
+}
+
+.aspid-fasttools-welcome__sample--header-hover .aspid-fasttools-welcome__sample-sweep {
+    scale: 1 1;
+}
+
+/* A Remove card sweeps in the destructive tone, matching its header accent. */
+.aspid-fasttools-welcome__sample-sweep--remove {
+    background-color: var(--aspid-colors-status-error-text-dark);
+}
+
+/* Shares the header's 4px horizontal inset so the description's left edge lines up with the title above;
+   the 6px top margin (+2px divider margin) mirrors the 8px of air above the line. */
 .aspid-fasttools-welcome__sample-description {
-    margin-top: 2px;
+    margin-top: 6px;
+    padding: 0 4px;
     font-size: 12px;
     white-space: normal;
     -unity-font-style: normal;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss
@@ -45,6 +45,32 @@ AspidAnimatedTitle {
     white-space: normal;
 }
 
+/* Quick links under the blurb, styled like the footer's GitHub link: signature green, brighter on hover. */
+.aspid-fasttools-welcome__hero-links {
+    margin-top: 6px;
+    flex-direction: row;
+    align-items: center;
+}
+
+.aspid-fasttools-welcome__hero-link {
+    padding: 0;
+    cursor: link;
+    font-size: 13px;
+    -unity-font-style: bold;
+    color: var(--aspid-colors-status-success-text-dark);
+}
+
+.aspid-fasttools-welcome__hero-link:hover {
+    color: var(--aspid-colors-status-success-text-light);
+}
+
+.aspid-fasttools-welcome__hero-link-separator {
+    margin: 0 6px;
+    padding: 0;
+    font-size: 13px;
+    color: var(--aspid-colors-text-darkness);
+}
+
 .aspid-fasttools-welcome__card {
     padding: 10px;
 }
@@ -91,10 +117,35 @@ AspidAnimatedTitle {
     --aspid-fasttools-colors-gradient_button-accent: var(--aspid-colors-status-error-text-light);
 }
 
+/* The title + status badge line living as the header button's leading content. */
+.aspid-fasttools-welcome__sample-info {
+    flex-direction: row;
+    align-items: center;
+}
+
 .aspid-fasttools-welcome__sample-title {
     font-size: 14px;
     -unity-font-style: bold;
     color: var(--aspid-colors-text-light);
+}
+
+/* Not-yet-imported marker ahead of the title: a single brand-blue dot quoting the dotted canvas — the
+   unread-marker idiom, so fresh samples catch the eye and the dot disappears once imported. */
+.aspid-fasttools-welcome__sample-import-dot {
+    width: 6px;
+    height: 6px;
+    flex-shrink: 0;
+    margin-right: 8px;
+    border-radius: 3px;
+    background-color: var(--aspid-colors-status-info-text-dark);
+    transition-property: background-color;
+    transition-duration: 0.25s;
+    transition-timing-function: ease-out;
+}
+
+/* Hovering the header verb turns the dot the Import accent green — "about to become imported". */
+.aspid-fasttools-welcome__sample--header-hover .aspid-fasttools-welcome__sample-import-dot {
+    background-color: var(--aspid-colors-status-success-text-dark);
 }
 
 
@@ -110,8 +161,10 @@ AspidAnimatedTitle {
    since the sweep is the button's sibling and :hover can't reach across. */
 .aspid-fasttools-welcome__sample-sweep {
     height: 1px;
-    margin-top: -1px;
-    margin-bottom: 0;
+    /* Pulled up past the divider's 2px bottom margin plus its 1px line so the sweep sits exactly ON the
+       line; the 2px bottom margin gives the swallowed gap back, keeping the description rhythm intact. */
+    margin-top: -3px;
+    margin-bottom: 2px;
     background-color: var(--aspid-colors-status-success-text-dark);
     transform-origin: left;
     scale: 0 1;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uxml
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uxml
@@ -1,7 +1,6 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="True">
     <Style src="project://database/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Aspid-FastTools-Default-Dark.uss?fileID=7433441132597879392&amp;guid=a58072b37b804991bbb887d0fd65e2f8&amp;type=3#Aspid-FastTools-Default-Dark"/>
     <Style src="project://database/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uss?fileID=7433441132597879392&amp;guid=74929072ccf9442f6a07a76964c94928&amp;type=3#Aspid-FastTools-Welcome"/>
-    <Aspid.FastTools.UIElements.Editors.Internal.AspidAnimatedDotsBackground/>
     <ui:VisualElement name="welcome-content" class="aspid-fasttools-welcome__content">
         <ui:ScrollView name="welcome-scroll" class="aspid-fasttools-welcome__scroll">
             <ui:VisualElement name="welcome-hero" class="aspid-fasttools-welcome__hero">

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uxml
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Resources/UI/Windows/Welcome/Aspid-FastTools-Welcome.uxml
@@ -8,6 +8,13 @@
                 <ui:VisualElement class="aspid-fasttools-welcome__hero-text">
                     <Aspid.FastTools.UIElements.Editors.Internal.AspidAnimatedTitle text="Welcome to Aspid.FastTools"/>
                     <Aspid.FastTools.UIElements.Editors.Internal.AspidLabel text="A compact toolkit for reducing routine Unity code and editor setup. Typed selectors, enum helpers, string ID tooling, profiler markers, SerializedProperty utilities, IMGUI scopes, and UIElements extensions." label-font-style="Normal" label-theme="Light" line-size="None" selectable="true" class="aspid-fasttools-welcome__description"/>
+                    <ui:VisualElement name="welcome-links" class="aspid-fasttools-welcome__hero-links">
+                        <ui:Label name="welcome-link-docs" text="Documentation" class="aspid-fasttools-welcome__hero-link"/>
+                        <ui:Label text="·" class="aspid-fasttools-welcome__hero-link-separator"/>
+                        <ui:Label name="welcome-link-github" text="GitHub" class="aspid-fasttools-welcome__hero-link"/>
+                        <ui:Label text="·" class="aspid-fasttools-welcome__hero-link-separator"/>
+                        <ui:Label name="welcome-link-store" text="Asset Store" class="aspid-fasttools-welcome__hero-link"/>
+                    </ui:VisualElement>
                 </ui:VisualElement>
             </ui:VisualElement>
             <ui:VisualElement name="welcome-samples" class="aspid-fasttools-welcome__card">

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceIMGUIPropertyDrawer.cs
@@ -210,7 +210,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 var typeName = SerializeReferenceHelpers.GetMissingTypeDisplayName(property);
                 var canFix = SerializeReferenceHelpers.TryGetRepairLocation(property, out _, out _, out _);
 
-                // Smart Fix suggestion ("· → Pistol?"). The ranking is cached per (asset, rid), so this stays cheap
+                // Smart Fix suggestion ("· → Pistol"). The ranking is cached per (asset, rid), so this stays cheap
                 // across IMGUI's per-frame repaints; the candidate is pre-declared so it stays definitely assigned
                 // when the short-circuit skips the probe.
                 SerializeReferenceRepairSuggestions.RepairCandidate suggestion = default;
@@ -622,7 +622,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// <summary>
         /// Draws a compact single-row notice, mirroring the UIToolkit <see cref="SerializeReferenceNotice"/>: a terse
         /// message, then a bold, right-pinned clickable action word (underlined; it lightens on hover) and — for a
-        /// missing-type notice with a Smart Fix candidate — an optional trailing suggestion word ("· → Pistol?")
+        /// missing-type notice with a Smart Fix candidate — an optional trailing suggestion word ("· → Pistol")
         /// clustered just after it at the right edge. The full <paramref name="detail"/> rides each segment's hover
         /// tooltip. Without <paramref name="ridColor"/> the row is a warning: a yellow triangle icon and the warning
         /// amber palette (missing-type / required). With <paramref name="ridColor"/> it is the shared-reference variant:

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Extensions/SerializeReferenceHelpers.cs
@@ -617,13 +617,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         /// <summary>
-        /// The Smart Fix <paramref name="suggestion"/> label — the "<c>→ Name?</c>" affordance. Shared by the
+        /// The Smart Fix <paramref name="suggestion"/> label — the "<c>→ Name</c>" affordance. Shared by the
         /// UIToolkit and IMGUI notices and the Project References quick-apply button so the copy never drifts.
         /// The "<c>·</c>" that separates it from the inline Fix segment is NOT part of this label: it is decoration
         /// each notice renders itself, unclickable and never underlined.
         /// </summary>
         public static string GetSuggestionLabel(SerializeReferenceRepairSuggestions.RepairCandidate suggestion) =>
-            $"→ {TypeSelectorHelpers.GetTypeSelectorTitle(suggestion.Type)}?";
+            $"→ {TypeSelectorHelpers.GetTypeSelectorTitle(suggestion.Type)}";
 
         /// <summary>
         /// The hover-tooltip detail for a Smart Fix <paramref name="suggestion"/> — the full type identity and the

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceExcludedFoldersField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceExcludedFoldersField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine.UIElements;
+using System.Collections.Generic;
 using Aspid.FastTools.UIElements;
 using Aspid.FastTools.UIElements.Editors.Internal;
 
@@ -10,13 +11,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 {
     /// <summary>
     /// Editable list of scan-excluded project folders, replacing the free-text "one path per line" field with a proper
-    /// add/remove list. A compact translucent panel carries its own "Excluded scan folders" header, then stacks one
-    /// zebra-striped entry per excluded folder (path on the left, an ✕ remove on the right) over a matching add-row
-    /// entry whose "+" sits at the right edge; while empty the add row carries the "No excluded folders" hint instead.
-    /// Folder rows and the add row are the same entry element, and their light/dark wash alternates down the list so
-    /// adjacent rows read as separate elements. Clicking the add row (the "+" or its hint) opens a folder picker and
-    /// stores the project-relative path; clicking a folder row re-opens the picker to re-point that entry in place.
-    /// Reads and writes <see cref="SerializeReferenceSettings.ExcludedFolders"/> and rebuilds on
+    /// add/remove list. A flat member of its settings section card — no panel frame of its own: a header row pairs the
+    /// "Excluded scan folders" caption with a dim status hint and a "+" pinned at the right edge (the whole header is
+    /// the add target and washes green on hover), then one indented flat row per excluded folder (path on the left, an
+    /// ✕ remove on the right). Clicking the header opens a folder picker and stores the project-relative path;
+    /// clicking a folder row re-opens the picker to re-point that entry in place. Reads and writes
+    /// <see cref="SerializeReferenceSettings.ExcludedFolders"/> and rebuilds on
     /// <see cref="SerializeReferenceSettings.ExcludedFoldersChanged"/>, so the in-window Settings tab and the Project
     /// Settings page stay mirrored. Self-contained styling (palette + own USS) so it renders on both surfaces.
     /// </summary>
@@ -26,25 +26,34 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             "UI/SerializeReferences/Aspid-FastTools-SerializeReference-ExcludedFolders";
 
         private const string RootClass = "aspid-fasttools-excluded-folders";
-        private const string TitleClass = "aspid-fasttools-excluded-folders__title";
+        private const string HeaderClass = "aspid-fasttools-excluded-folders__header";
+        private const string HeaderCaptionClass = "aspid-fasttools-excluded-folders__header-caption";
+        private const string HeaderAddClass = "aspid-fasttools-excluded-folders__header--add";
         private const string ListClass = "aspid-fasttools-excluded-folders__list";
         private const string EntryClass = "aspid-fasttools-excluded-folders__entry";
-        private const string EntryEvenClass = "aspid-fasttools-excluded-folders__entry--even";
-        private const string EntryOddClass = "aspid-fasttools-excluded-folders__entry--odd";
         private const string EntryHoverClass = "aspid-fasttools-excluded-folders__entry--hover";
         private const string EntryDangerClass = "aspid-fasttools-excluded-folders__entry--danger";
-        private const string EntryAddClass = "aspid-fasttools-excluded-folders__entry--add";
         private const string HintClass = "aspid-fasttools-excluded-folders__hint";
         private const string PathClass = "aspid-fasttools-excluded-folders__path";
         private const string RemoveClass = "aspid-fasttools-excluded-folders__remove";
         private const string AddButtonClass = "aspid-fasttools-excluded-folders__add";
 
-        // The three mutually-exclusive full-row hover tints; SetTint is their single writer.
-        private static readonly string[] HoverTints = { EntryHoverClass, EntryDangerClass, EntryAddClass };
+        // The two mutually-exclusive full-row hover tints on folder rows; SetTint is their single writer.
+        private static readonly string[] HoverTints = { EntryHoverClass, EntryDangerClass };
 
         private readonly VisualElement _list;
-        private readonly VisualElement _addRow;
+        private readonly VisualElement _header;
         private readonly Label _hint;
+
+        // The current folder rows with their paths, refreshed by Rebuild — the source for GetNavTargets, so the
+        // keyboard ring can walk the rows exactly as the pointer can.
+        private readonly List<(VisualElement Row, string Path)> _rows = new();
+
+        /// <summary>
+        /// Raised after the folder rows are rebuilt (add / remove / external change). The hosting keyboard ring
+        /// listens to re-collect its targets, since every rebuild replaces the row elements.
+        /// </summary>
+        internal event Action RowsRebuilt;
 
         public SerializeReferenceExcludedFoldersField()
         {
@@ -52,22 +61,25 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddStyleSheetsFromResource(StyleSheetPath)
                 .AddAspidThemeStyleSheets();
 
-            var title = new Label("Excluded scan folders").AddClass(TitleClass);
-            _list = new VisualElement().AddClass(ListClass);
-
-            // The whole add row is the click target; the "+" is a passive glyph (a Label, not a Button) so its click
-            // bubbles up to the row instead of firing a second add.
+            // The whole header row is the add target (the flat action-row idiom); the "+" and the dim status hint are
+            // passive Labels so their clicks bubble up to the row instead of firing a second add. The green add-intent
+            // wash is code-toggled (--add) so the keyboard ring can mirror it via the same class family.
             _hint = new Label { tooltip = "Add folder" }.AddClass(HintClass);
+            var caption = new Label("Excluded scan folders").AddClass(HeaderCaptionClass);
             var addGlyph = new Label("+") { tooltip = "Add folder" }.AddClass(AddButtonClass);
-            _addRow = new VisualElement().AddClass(EntryClass)
+
+            _header = new VisualElement().AddClass(HeaderClass)
+                .AddChild(caption)
                 .AddChild(_hint)
                 .AddChild(addGlyph);
-            _addRow.RegisterCallback<ClickEvent>(_ => AddFolder());
-            TintWhileOver(_addRow, _addRow, EntryAddClass, null);
+            _header.RegisterCallback<ClickEvent>(_ => AddFolder());
+            _header.RegisterCallback<PointerEnterEvent>(_ => _header.AddToClassList(HeaderAddClass));
+            _header.RegisterCallback<PointerLeaveEvent>(_ => _header.RemoveFromClassList(HeaderAddClass));
 
-            Add(title);
+            _list = new VisualElement().AddClass(ListClass);
+
+            Add(_header);
             Add(_list);
-            Add(_addRow);
 
             Rebuild();
 
@@ -99,14 +111,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private void Rebuild()
         {
             _list.Clear();
+            _rows.Clear();
 
             var folders = SerializeReferenceSettings.ExcludedFolders;
             _hint.text = folders.Length == 0 ? "No excluded folders" : string.Empty;
 
-            for (var i = 0; i < folders.Length; i++)
+            foreach (var path in folders)
             {
-                var path = folders[i];
-
                 // The path label fills the row left of the ✕ (full height), so clicking it anywhere edits.
                 var label = new Label(path) { tooltip = path }.AddClass(PathClass);
                 label.RegisterCallback<ClickEvent>(_ => Edit(path));
@@ -120,20 +131,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 TintWhileOver(row, label, EntryHoverClass, null);
                 TintWhileOver(row, remove, EntryDangerClass, null);
 
-                ApplyStripe(row, i);
                 _list.Add(row);
+                _rows.Add((row, path));
             }
 
-            // The add row continues the zebra right after the last folder row.
-            ApplyStripe(_addRow, folders.Length);
-        }
-
-        // Zebra-stripes an entry by its position in the visible list so adjacent rows read as separate elements.
-        private static void ApplyStripe(VisualElement entry, int index)
-        {
-            var even = index % 2 == 0;
-            entry.EnableInClassList(EntryEvenClass, even);
-            entry.EnableInClassList(EntryOddClass, !even);
+            RowsRebuilt?.Invoke();
         }
 
         // Tints the whole entry while the pointer is over the zone (leaving falls back to fallback; null clears) —
@@ -148,6 +150,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private static void SetTint(VisualElement entry, string tint)
         {
             foreach (var cls in HoverTints) entry.EnableInClassList(cls, cls == tint);
+        }
+
+        /// <summary>
+        /// The control's keyboard-ring members in visual order, mirroring the pointer affordances exactly: the header
+        /// row first (activate = the add-folder picker), then one member per folder row (activate = the edit picker —
+        /// what clicking the row does; remove = what its ✕ does, for the ring's Delete/Backspace). Re-collect on
+        /// <see cref="RowsRebuilt"/> — a rebuild replaces every row element.
+        /// </summary>
+        internal IEnumerable<(VisualElement Element, Action Activate, Action Remove)> GetNavTargets()
+        {
+            yield return (_header, AddFolder, null);
+
+            foreach (var (row, path) in _rows)
+                yield return (row, () => Edit(path), () => Remove(path));
         }
 
         private void AddFolder()

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsProvider.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsProvider.cs
@@ -7,10 +7,10 @@ using System.Collections.Generic;
 namespace Aspid.FastTools.SerializeReferences.Editors
 {
     /// <summary>
-    /// The package's Project Settings page (<c>Project Settings → Aspid FastTools → SerializeReference</c>) — the
+    /// The package's Project Settings page (<c>Project Settings → Aspid.FastTools → SerializeReference</c>) — the
     /// team-wide half of the settings, matching the page's <see cref="SettingsScope.Project"/>: auto de-alias, the
     /// build/CI gate severity and the excluded scan folders, all persisted in the committed ProjectSettings asset.
-    /// The per-user controls live on the <c>Preferences → Aspid FastTools</c> page instead, and the window's Settings
+    /// The per-user controls live on the <c>Preferences → Aspid.FastTools</c> pages instead, and the window's Settings
     /// tab shows both scopes as the one full overview. <see cref="AspidSettingsUI.BuildProviderPage"/> composes the
     /// same branded page (dotted canvas, legend, sections, pinned reset footer) both Unity-native pages share.
     /// Backed by <see cref="SerializeReferenceSettings"/>.
@@ -29,7 +29,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         [SettingsProvider]
         public static SettingsProvider Create() =>
-            new("Project/Aspid FastTools/SerializeReference", SettingsScope.Project)
+            new("Project/Aspid.FastTools/SerializeReference", SettingsScope.Project)
             {
                 label = "SerializeReference",
                 keywords = new HashSet<string>(new[]

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Settings/SerializeReferenceSettingsUI.cs
@@ -27,7 +27,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         public static void BuildControls(VisualElement container, AspidSettingsScope scope = AspidSettingsScope.All)
         {
             if ((scope & AspidSettingsScope.User) != 0)
+            {
                 container.Add(CreateBreakageDetectionSwitch());
+                container.Add(AspidSettingsUI.CreateRowNote(
+                    "Watches for references broken by script renames / deletes and points at Repair."));
+            }
 
             if ((scope & AspidSettingsScope.Shared) == 0) return;
 
@@ -37,10 +41,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 tooltip = "Give a duplicated list element its own independent instance instead of sharing the original's rid.\n"
                     + "Stored in a committed ProjectSettings asset, so every teammate (and CI) sees the same behaviour.",
             };
-            autoDeAlias.AddClass(AspidSettingsUI.SharedScopeClass);
+            autoDeAlias.WithScopeStripe(AspidSettingsUI.SharedScopeClass);
             autoDeAlias.RegisterValueChangedCallback(evt => SerializeReferenceSettings.AutoDeAliasEnabled = evt.newValue);
             SyncFromSettings(autoDeAlias, () => SerializeReferenceSettings.AutoDeAliasEnabled);
             container.Add(autoDeAlias);
+            container.Add(AspidSettingsUI.CreateRowNote(
+                "A duplicated list element gets its own instance instead of sharing the original's reference."));
 
             var severity = new EnumField("Build / CI gate", SerializeReferenceSettings.BuildSeverity)
             {
@@ -48,13 +54,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     + "Stored in a committed ProjectSettings asset, so it travels to a clean CI runner. "
                     + "CLI flags -srGateWarnOnly / -srGateFail override it per run.",
             };
-            severity.AddClass(AspidSettingsUI.SharedScopeClass);
+            severity.WithScopeStripe(AspidSettingsUI.SharedScopeClass);
             severity.RegisterValueChangedCallback(evt => SerializeReferenceSettings.BuildSeverity = (GateSeverity)evt.newValue);
             SyncFromSettings<EnumField, Enum>(severity, () => SerializeReferenceSettings.BuildSeverity);
             container.Add(severity);
+            container.Add(AspidSettingsUI.CreateRowNote(
+                "Off — never check · Warn — log missing / unset-required references · Fail — abort the build / CI job."));
 
-            // The excluded-folders panel carries its own "Excluded scan folders" header inside its frame.
-            container.Add(new SerializeReferenceExcludedFoldersField().AddClass(AspidSettingsUI.SharedScopeClass));
+            // The excluded-folders control carries its own "Excluded scan folders" header row.
+            container.Add(new SerializeReferenceExcludedFoldersField().WithScopeStripe(AspidSettingsUI.SharedScopeClass));
         }
 
         // Built by one definition so the window tab and the Preferences page both render (and live-sync) the same
@@ -68,7 +76,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     + "toast pointing at Repair. Turn off to silence the domain-reload / import-time detection entirely.\n"
                     + "Per-user setting — stored locally, never committed.",
             };
-            breakageDetection.AddClass(AspidSettingsUI.UserScopeClass);
+            breakageDetection.WithScopeStripe(AspidSettingsUI.UserScopeClass);
             breakageDetection.RegisterValueChangedCallback(evt => SerializeReferenceSettings.BreakageDetectionEnabled = evt.newValue);
             SyncFromSettings(breakageDetection, () => SerializeReferenceSettings.BreakageDetectionEnabled);
             return breakageDetection;

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -398,7 +398,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             UpdateSuggestion(canFix);
         }
 
-        // The Smart Fix suggestion rides the missing notice as a second clickable segment ("· → Pistol?"): the
+        // The Smart Fix suggestion rides the missing notice as a second clickable segment ("· → Pistol"): the
         // highest ranked existing type the reference most likely became, applied through the same repair path as Fix.
         private void UpdateSuggestion(bool canFix)
         {

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceNotice.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceNotice.cs
@@ -10,7 +10,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// <summary>
     /// A compact, single-row warning notice for the <c>[TypeSelector]</c> drawer on <c>[SerializeReference]</c> fields: a small
     /// warning icon, a short yellow message and an underlined, clickable action word (e.g. <c>Fix</c>). A missing-type
-    /// notice can carry an optional second clickable segment — the <b>Smart Fix</b> suggestion (e.g. <c>· → Pistol?</c>) —
+    /// notice can carry an optional second clickable segment — the <b>Smart Fix</b> suggestion (e.g. <c>· → Pistol</c>) —
     /// that applies the best ranked repair candidate in one click. The full explanation is surfaced on hover through each
     /// segment's <see cref="VisualElement.tooltip"/>, so the inspector row stays terse while the detail is one hover away.
     /// Replaces the bulky <c>AspidHelpBox</c>-plus-button pair previously used for missing-type and shared-reference states.

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceAuditUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceAuditUI.cs
@@ -1,0 +1,66 @@
+using UnityEngine.UIElements;
+using Aspid.FastTools.UIElements;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.SerializeReferences.Editors
+{
+    /// <summary>
+    /// Shared building blocks for the two References audit tabs (Asset References / Project References), so their count
+    /// wording, selectable-label setup and the amber/blue accent legend read identically and can't drift apart. Each
+    /// tab keeps its own USS block, so the legend builder wears the block's class names passed as a
+    /// <see cref="LegendClasses"/>.
+    /// </summary>
+    internal static class SerializeReferenceAuditUI
+    {
+        /// <summary>
+        /// "1 entry" / "3 entries" — singular as-is, plural via a naive y→ies / +s rule (enough for the audit's fixed
+        /// nouns: reference, migration, violation, entry, file).
+        /// </summary>
+        public static string BuildCountText(int count, string noun) =>
+            count == 1 ? $"1 {noun}" : $"{count} {(noun.EndsWith("y") ? noun[..^1] + "ies" : noun + "s")}";
+
+        /// <summary>
+        /// Makes an audit row's text (asset paths, rids, field paths) selectable so it can be copied out; callers that
+        /// also carry a row click gate the click on an empty selection (a drag-select ends in a click too).
+        /// </summary>
+        public static Label MakeSelectable(Label label)
+        {
+            label.selection.isSelectable = true;
+            label.selection.doubleClickSelectsWord = true;
+            label.selection.tripleClickSelectsLine = true;
+            return label;
+        }
+
+        /// <summary>
+        /// One dot + caption pair of the accent legend: amber (default) for the broken/orphaned/required band, info
+        /// blue (<paramref name="info"/> true) for the pending-migration cards, wearing the block's own legend classes.
+        /// </summary>
+        public static VisualElement BuildLegendItem(string text, bool info, in LegendClasses classes)
+        {
+            var dot = new VisualElement().AddClass(classes.Dot);
+            if (info) dot.AddClass(classes.DotInfo);
+
+            return new VisualElement()
+                .AddClass(classes.Item)
+                .AddChild(dot)
+                .AddChild(new Label(text).AddClass(classes.Text));
+        }
+
+        /// <summary>The block-specific USS class names the shared legend builder wears (the two audit tabs use different BEM blocks).</summary>
+        internal readonly struct LegendClasses
+        {
+            public readonly string Item;
+            public readonly string Dot;
+            public readonly string DotInfo;
+            public readonly string Text;
+
+            public LegendClasses(string item, string dot, string dotInfo, string text)
+            {
+                Item = item;
+                Dot = dot;
+                DotInfo = dotInfo;
+                Text = text;
+            }
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceAuditUI.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceAuditUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fafdb669750e64c568558e5d9893c647

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using Aspid.FastTools.UIElements.Editors.Internal;
 using System.Linq;
 using Object = UnityEngine.Object;
+using static Aspid.FastTools.SerializeReferences.Editors.SerializeReferenceAuditUI;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.SerializeReferences.Editors
@@ -144,11 +145,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private AspidGradientButton _openPickerRow;
         private VisualElement _openPickerCard;
 
-        // Keyboard navigation: one flat focus ring over every actionable element in visual order — Rescan first,
-        // then each document header, node band, action row and orphan Clear. -1 means nothing is highlighted.
-        // Mirrors SerializeReferenceProjectView so the two references tabs drive identically from the keyboard.
-        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
-        private int _navIndex = -1;
+        // Keyboard navigation: one flat focus ring over every actionable element in visual order — Rescan first, then
+        // each document header, node band, action row and orphan Clear — shared with the other window tabs, so a
+        // member hidden inside a collapsed document band drops out of the ring (see NavRing).
+        private readonly NavRing _ring;
+
+        // The legend's block-specific USS class names for the shared item builder.
+        private static readonly LegendClasses LegendClassSet = new(LegendItemClass, LegendDotClass, LegendDotInfoClass, LegendTextClass);
 
         // Per-asset constraint map cache: BuildConstraintMap does a LoadAllAssetsAtPath + full SerializedObject walk,
         // so each Fix-Missing picker open must not re-scan. Cleared on every Rescan / apply so rewritten YAML is re-read.
@@ -223,8 +226,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _legend = new VisualElement()
                 .AddClass(LegendClass)
                 .AddClass(LegendHiddenClass)
-                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false))
-                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true));
+                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false, LegendClassSet))
+                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true, LegendClassSet));
 
             _overview = new VisualElement()
                 .AddClass(OverviewClass)
@@ -249,12 +252,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             root.AddChild(_scroll);
 
-            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach, re-grabbed when the picker
-            // closes) so key events reach OnNavKeyDown even before anything is highlighted; events from focused
-            // descendants bubble here too.
-            focusable = true;
-            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
-            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+            // The shared keyboard ring: the root holds focus (grabbed on attach, re-grabbed when the picker closes)
+            // so keys reach it before anything is highlighted. Suspended while a type picker owns the keyboard.
+            _ring = new NavRing(
+                host: this,
+                navTargetClass: NavTargetClass,
+                paint: PaintNavFocus,
+                scrollTo: element => _scroll.ScrollTo(element),
+                isSuspended: () => _openPicker is not null);
 
             Rescan();
         }
@@ -263,74 +268,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Keyboard navigation (mirrors SerializeReferenceProjectView)
         // ---------------------------------------------------------------------------------------------------------
 
-        private void OnNavKeyDown(KeyDownEvent evt)
+        // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat fill
+        // would just show through their fading gradient as a gray pill, so they take ONLY the programmatic hover and
+        // the plain rows take ONLY the class. A focused node band also lights its card's divider sweep.
+        private static void PaintNavFocus(VisualElement element, bool on)
         {
-            // The open type picker owns the keyboard (its own search + list navigation) — stay out of its way.
-            if (_openPicker is not null) return;
-
-            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
-            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
-
-            switch (evt.keyCode)
-            {
-                case KeyCode.DownArrow:
-                    MoveNavFocus(+1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.UpArrow:
-                    MoveNavFocus(-1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
-                    _navTargets[_navIndex].Activate();
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Escape when _navIndex >= 0:
-                    ClearNavFocus();
-                    evt.StopPropagation();
-                    break;
-            }
-        }
-
-        // First press (nothing highlighted) lands on Rescan whichever arrow is hit; after that the ring clamps at
-        // both ends instead of wrapping.
-        private void MoveNavFocus(int delta)
-        {
-            if (_navTargets.Count == 0) return;
-            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
-        }
-
-        private void SetNavFocus(int index, bool scrollTo = true)
-        {
-            if (_navIndex == index) return;
-
-            ClearNavFocus();
-            _navIndex = index;
-
-            var element = _navTargets[index].Element;
-            // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat
-            // fill would just show through their fading gradient as a gray pill, so they take ONLY the programmatic
-            // hover and the plain rows take ONLY the class.
-            if (element is AspidGradientButton button) button.Highlighted = true;
-            else element.AddToClassList(NavTargetFocusedClass);
-            SetBandSweep(element, on: true);
-            if (scrollTo) _scroll.ScrollTo(element);
-        }
-
-        private void ClearNavFocus()
-        {
-            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
-            {
-                var element = _navTargets[_navIndex].Element;
-                if (element is AspidGradientButton button) button.Highlighted = false;
-                else element.RemoveFromClassList(NavTargetFocusedClass);
-                SetBandSweep(element, on: false);
-            }
-
-            _navIndex = -1;
+            if (element is AspidGradientButton button) button.Highlighted = on;
+            else element.EnableInClassList(NavTargetFocusedClass, on);
+            SetBandSweep(element, on);
         }
 
         // A focused node band also lights its card's divider sweep — the same card-level hover mirror the mouse
@@ -345,23 +290,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // always slot 0; a highlight sitting on it survives the rebuild, so Enter-on-Rescan keeps its highlight.
         private void ResetNavTargets()
         {
-            var keepScanFocus = _navIndex == 0;
-            ClearNavFocus();
-            _navTargets.Clear();
+            var keepScanFocus = _ring.Index == 0;
+            _ring.Clear();
 
             RegisterNavTarget(_rescanButton, () => Rescan());
-            if (keepScanFocus) SetNavFocus(0, scrollTo: false);
+            if (keepScanFocus) _ring.Focus(0, scrollTo: false);
         }
 
-        private void RegisterNavTarget(VisualElement element, Action activate)
-        {
-            // EnableInClassList (not AddToClassList): Rescan is re-registered on every reset and must not stack copies.
-            element.EnableInClassList(NavTargetClass, true);
-            _navTargets.Add((element, activate));
-        }
-
-        private bool IsNavFocused(VisualElement element) =>
-            _navIndex >= 0 && _navIndex < _navTargets.Count && _navTargets[_navIndex].Element == element;
+        private void RegisterNavTarget(VisualElement element, Action activate) => _ring.Register(element, activate);
 
         private void SetTarget(Object target)
         {
@@ -674,22 +610,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (migrations > 0) parts.Add(BuildCountText(migrations, "pending migration"));
 
             return parts.Count > 0 ? string.Join(", ", parts) : "No missing references";
-        }
-
-        private static string BuildCountText(int count, string noun) =>
-            count == 1 ? $"1 {noun}" : $"{count} {(noun.EndsWith("y") ? noun[..^1] + "ies" : noun + "s")}";
-
-        // One dot + caption pair of the accent legend: amber (default) for the broken/orphaned/required band, info
-        // blue for the pending-migration cards.
-        private static VisualElement BuildLegendItem(string text, bool info)
-        {
-            var dot = new VisualElement().AddClass(LegendDotClass);
-            if (info) dot.AddClass(LegendDotInfoClass);
-
-            return new VisualElement()
-                .AddClass(LegendItemClass)
-                .AddChild(dot)
-                .AddChild(new Label(text).AddClass(LegendTextClass));
         }
 
         private static string BuildOverviewHint(int total, int missing, int orphans, int empties, int migrations, int required)
@@ -1028,24 +948,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (sweepModifier is not null) sweep.AddClass(sweepModifier);
             card.AddChild(sweep);
 
-            band.RegisterCallback<MouseEnterEvent>(_ => band.parent?.AddToClassList(NodeHeaderHoverClass));
-            // Composes with the keyboard ring: while the band is the nav-focused element the sweep stays lit after
-            // the mouse leaves (mirrors AspidGradientButton.Highlighted keeping the glow on).
-            band.RegisterCallback<MouseLeaveEvent>(_ =>
-            {
-                if (IsNavFocused(band)) return;
-                band.parent?.RemoveFromClassList(NodeHeaderHoverClass);
-            });
-        }
-
-        // Footer text (field paths, rids) is the payload users copy out of the graph, so it is selectable; a
-        // drag-select never conflicts with a click — node footers carry no row-level click action.
-        private static Label MakeSelectable(Label label)
-        {
-            label.selection.isSelectable = true;
-            label.selection.doubleClickSelectsWord = true;
-            label.selection.tripleClickSelectsLine = true;
-            return label;
+            // HoverSweep mirrors the band's hover onto the card modifier the sweep rule listens to, keeping it lit
+            // while the band is the nav-focused ring member.
+            HoverSweep.MirrorHover(band, () => band.parent, NodeHeaderHoverClass, () => _ring.IsFocused(band));
         }
 
         // A back-edge to a rid already on the current render path — a single dim, italic line (no footer) so cycles

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceGraphView.cs
@@ -64,13 +64,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string NodeClass = RootClass + "__node";
         private const string NodeBackEdgeClass = NodeClass + "--back-edge";
         private const string NodeEmptyClass = NodeClass + "--empty";
+        private const string NodeMigrateCardClass = NodeClass + "--migrate";
         private const string NodePickingClass = NodeClass + "--picking";
+        private const string NodeHeaderHoverClass = NodeClass + "--header-hover";
         private const string NodeBandClass = RootClass + "__node-band";
         private const string NodeBandMissingClass = NodeBandClass + "--missing";
         private const string NodeBandMigrateClass = NodeBandClass + "--migrate";
         private const string NodeBandRowClass = RootClass + "__node-band-row";
-        private const string NodeMigrateClass = RootClass + "__node-migrate";
-        private const string NodeSuggestClass = RootClass + "__node-suggest";
+        private const string NodeDividerClass = RootClass + "__node-divider";
+        private const string NodeSweepClass = RootClass + "__node-sweep";
+        private const string NodeSweepMissingClass = NodeSweepClass + "--missing";
+        private const string NodeSweepMigrateClass = NodeSweepClass + "--migrate";
+        private const string NodeActionClass = RootClass + "__node-action";
+        private const string NodeActionInfoClass = NodeActionClass + "--info";
         private const string NodeHeaderClass = RootClass + "__node-header";
         private const string NodeFooterClass = RootClass + "__node-footer";
         private const string NodeRootLabelClass = RootClass + "__node-root-label";
@@ -80,6 +86,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private const string BadgeClass = RootClass + "__badge";
         private const string BadgeSharedClass = BadgeClass + "--shared";
+
+        private const string LegendClass = RootClass + "__legend";
+        private const string LegendHiddenClass = LegendClass + "--hidden";
+        private const string LegendItemClass = RootClass + "__legend-item";
+        private const string LegendDotClass = RootClass + "__legend-dot";
+        private const string LegendDotInfoClass = LegendDotClass + "--info";
+        private const string LegendTextClass = RootClass + "__legend-text";
+        private const string NavTargetClass = RootClass + "__nav-target";
+        private const string NavTargetFocusedClass = NavTargetClass + "--focused";
 
         private const string ChipClass = RootClass + "__chip";
         private const string ClearOrphanClass = RootClass + "__clear-orphan";
@@ -116,15 +131,24 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private Object _target;
         private readonly ObjectField _assetField;
+        private readonly AspidGradientButton _rescanButton;
         private readonly VisualElement _empty;
         private readonly VisualElement _overview;
         private readonly AspidLabel _overviewTitle;
         private readonly Label _overviewHint;
+        private readonly VisualElement _legend;
         private readonly VisualElement _list;
+        private readonly ScrollView _scroll;
 
         private VisualElement _openPicker;
         private AspidGradientButton _openPickerRow;
         private VisualElement _openPickerCard;
+
+        // Keyboard navigation: one flat focus ring over every actionable element in visual order — Rescan first,
+        // then each document header, node band, action row and orphan Clear. -1 means nothing is highlighted.
+        // Mirrors SerializeReferenceProjectView so the two references tabs drive identically from the keyboard.
+        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
+        private int _navIndex = -1;
 
         // Per-asset constraint map cache: BuildConstraintMap does a LoadAllAssetsAtPath + full SerializedObject walk,
         // so each Fix-Missing picker open must not re-scan. Cleared on every Rescan / apply so rewritten YAML is re-read.
@@ -172,16 +196,16 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // dragging an asset in doesn't bubble to the button's Clickable and re-run Rescan.
             _assetField.RegisterCallback<PointerDownEvent>(evt => evt.StopPropagation());
 
-            var rescanButton = new AspidGradientButton("Rescan", _ => Rescan())
+            _rescanButton = new AspidGradientButton("Rescan", _ => Rescan())
                 .AddClass(RescanClass);
-            rescanButton.AddTrailingContent(_assetField);
-            rescanButton.FillWithTrailingContent();
+            _rescanButton.AddTrailingContent(_assetField);
+            _rescanButton.FillWithTrailingContent();
 
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(CardClass)
                 .AddChild(cardTitle)
                 .AddChild(cardDescription)
-                .AddChild(rescanButton);
+                .AddChild(_rescanButton);
 
             _empty = new VisualElement().AddClass(EmptyClass);
 
@@ -194,11 +218,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             _overviewHint = new Label(string.Empty).AddClass(OverviewHintClass);
 
+            // Color key for the two card accents; only shown when both are actually on screen (see ShowOverview) —
+            // the same amber/blue legend the Project References audit renders under its hint.
+            _legend = new VisualElement()
+                .AddClass(LegendClass)
+                .AddClass(LegendHiddenClass)
+                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false))
+                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true));
+
             _overview = new VisualElement()
                 .AddClass(OverviewClass)
                 .AddClass(OverviewHiddenClass)
                 .AddChild(_overviewTitle)
-                .AddChild(_overviewHint);
+                .AddChild(_overviewHint)
+                .AddChild(_legend);
 
             _list = new VisualElement().AddClass(ListClass);
 
@@ -211,13 +244,124 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddChild(_overview)
                 .AddChild(_list);
 
-            var scroll = new ScrollView().AddClass(ScrollClass);
-            scroll.AddChild(content);
+            _scroll = new ScrollView().AddClass(ScrollClass);
+            _scroll.AddChild(content);
 
-            root.AddChild(scroll);
+            root.AddChild(_scroll);
+
+            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach, re-grabbed when the picker
+            // closes) so key events reach OnNavKeyDown even before anything is highlighted; events from focused
+            // descendants bubble here too.
+            focusable = true;
+            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
+            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
 
             Rescan();
         }
+
+        // ---------------------------------------------------------------------------------------------------------
+        // Keyboard navigation (mirrors SerializeReferenceProjectView)
+        // ---------------------------------------------------------------------------------------------------------
+
+        private void OnNavKeyDown(KeyDownEvent evt)
+        {
+            // The open type picker owns the keyboard (its own search + list navigation) — stay out of its way.
+            if (_openPicker is not null) return;
+
+            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
+            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
+
+            switch (evt.keyCode)
+            {
+                case KeyCode.DownArrow:
+                    MoveNavFocus(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.UpArrow:
+                    MoveNavFocus(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
+                    _navTargets[_navIndex].Activate();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Escape when _navIndex >= 0:
+                    ClearNavFocus();
+                    evt.StopPropagation();
+                    break;
+            }
+        }
+
+        // First press (nothing highlighted) lands on Rescan whichever arrow is hit; after that the ring clamps at
+        // both ends instead of wrapping.
+        private void MoveNavFocus(int delta)
+        {
+            if (_navTargets.Count == 0) return;
+            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
+        }
+
+        private void SetNavFocus(int index, bool scrollTo = true)
+        {
+            if (_navIndex == index) return;
+
+            ClearNavFocus();
+            _navIndex = index;
+
+            var element = _navTargets[index].Element;
+            // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat
+            // fill would just show through their fading gradient as a gray pill, so they take ONLY the programmatic
+            // hover and the plain rows take ONLY the class.
+            if (element is AspidGradientButton button) button.Highlighted = true;
+            else element.AddToClassList(NavTargetFocusedClass);
+            SetBandSweep(element, on: true);
+            if (scrollTo) _scroll.ScrollTo(element);
+        }
+
+        private void ClearNavFocus()
+        {
+            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
+            {
+                var element = _navTargets[_navIndex].Element;
+                if (element is AspidGradientButton button) button.Highlighted = false;
+                else element.RemoveFromClassList(NavTargetFocusedClass);
+                SetBandSweep(element, on: false);
+            }
+
+            _navIndex = -1;
+        }
+
+        // A focused node band also lights its card's divider sweep — the same card-level hover mirror the mouse
+        // path drives in AddBandDivider — so keyboard focus and mouse hover render identically.
+        private static void SetBandSweep(VisualElement element, bool on)
+        {
+            if (element.ClassListContains(NodeBandClass))
+                element.parent?.EnableInClassList(NodeHeaderHoverClass, on);
+        }
+
+        // Every render pass rebuilds the ring from scratch (the old elements are gone with _list.Clear()). Rescan is
+        // always slot 0; a highlight sitting on it survives the rebuild, so Enter-on-Rescan keeps its highlight.
+        private void ResetNavTargets()
+        {
+            var keepScanFocus = _navIndex == 0;
+            ClearNavFocus();
+            _navTargets.Clear();
+
+            RegisterNavTarget(_rescanButton, () => Rescan());
+            if (keepScanFocus) SetNavFocus(0, scrollTo: false);
+        }
+
+        private void RegisterNavTarget(VisualElement element, Action activate)
+        {
+            // EnableInClassList (not AddToClassList): Rescan is re-registered on every reset and must not stack copies.
+            element.EnableInClassList(NavTargetClass, true);
+            _navTargets.Add((element, activate));
+        }
+
+        private bool IsNavFocused(VisualElement element) =>
+            _navIndex >= 0 && _navIndex < _navTargets.Count && _navTargets[_navIndex].Element == element;
 
         private void SetTarget(Object target)
         {
@@ -239,6 +383,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // Drop the constraint maps so a rescan after a fix / clear re-reads the rewritten YAML, not a stale map.
             _constraintCache.Clear();
             _list.Clear();
+            ResetNavTargets();
             _requiredViolations = Array.Empty<GateViolation>();
 
             var assetPath = _target ? AssetDatabase.GetAssetPath(_target) : null;
@@ -255,8 +400,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     info.Message = "This is a prefab instance — its managed references live in the source prefab.";
                     _list.AddChild(info);
 
-                    _list.AddChild(new AspidGradientButton("Open Source Prefab",
-                        _ => SetTarget(AssetDatabase.LoadAssetAtPath<Object>(sourcePath))));
+                    var openSource = new AspidGradientButton("Open Source Prefab",
+                        _ => SetTarget(AssetDatabase.LoadAssetAtPath<Object>(sourcePath)));
+                    RegisterNavTarget(openSource, () => SetTarget(AssetDatabase.LoadAssetAtPath<Object>(sourcePath)));
+                    _list.AddChild(openSource);
                     return;
                 }
 
@@ -501,21 +648,48 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     ? StatusStyle.Type.Info
                     : StatusStyle.Type.Success;
 
-            _overviewTitle.Text = broken > 0
-                ? broken == 1 ? "1 missing reference" : $"{broken} missing references"
-                : orphans > 0
-                    ? orphans == 1 ? "1 orphaned reference" : $"{orphans} orphaned references"
-                    : required > 0
-                        ? required == 1 ? "1 required field unassigned" : $"{required} required fields unassigned"
-                        : migrations > 0
-                            ? migrations == 1 ? "1 pending migration" : $"{migrations} pending migrations"
-                            : "No missing references";
+            _overviewTitle.Text = BuildOverviewTitle(broken, orphans, migrations, required);
 
             _overviewTitle.LabelStatus = status;
             _overviewTitle.LineStatus = status;
 
             _overviewHint.text = BuildOverviewHint(total, missing, orphans, empties, migrations, required);
+
+            // The amber/blue key only earns its row when both accents are on screen at once (see the Project
+            // References legend).
+            var hasAmber = broken > 0 || orphans > 0 || required > 0;
+            _legend.EnableInClassList(LegendHiddenClass, migrations == 0 || !hasAmber);
+
             _overview.RemoveClass(OverviewHiddenClass);
+        }
+
+        // Only non-zero parts make the headline, joined like the Project References results header — so an asset
+        // carrying several finding kinds names all of them instead of hiding the rest in the hint.
+        private static string BuildOverviewTitle(int broken, int orphans, int migrations, int required)
+        {
+            var parts = new List<string>(4);
+            if (broken > 0) parts.Add(BuildCountText(broken, "missing reference"));
+            if (orphans > 0) parts.Add(BuildCountText(orphans, "orphaned reference"));
+            if (required > 0) parts.Add(BuildCountText(required, "required violation"));
+            if (migrations > 0) parts.Add(BuildCountText(migrations, "pending migration"));
+
+            return parts.Count > 0 ? string.Join(", ", parts) : "No missing references";
+        }
+
+        private static string BuildCountText(int count, string noun) =>
+            count == 1 ? $"1 {noun}" : $"{count} {(noun.EndsWith("y") ? noun[..^1] + "ies" : noun + "s")}";
+
+        // One dot + caption pair of the accent legend: amber (default) for the broken/orphaned/required band, info
+        // blue for the pending-migration cards.
+        private static VisualElement BuildLegendItem(string text, bool info)
+        {
+            var dot = new VisualElement().AddClass(LegendDotClass);
+            if (info) dot.AddClass(LegendDotInfoClass);
+
+            return new VisualElement()
+                .AddClass(LegendItemClass)
+                .AddChild(dot)
+                .AddChild(new Label(text).AddClass(LegendTextClass));
         }
 
         private static string BuildOverviewHint(int total, int missing, int orphans, int empties, int migrations, int required)
@@ -565,6 +739,37 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             var body = new VisualElement().AddClass(DocumentBodyClass);
 
+            // The header is built (and registered on the nav ring) BEFORE the body cards, so the keyboard order
+            // matches the visual order — the band sits above the cards it collapses.
+            AspidGradientButton header = null;
+            if (showHeader)
+            {
+                // The self-reference lets the click handler flip its own chevron alongside toggling the body.
+                var collapsed = false;
+                var toggle = new Action(() =>
+                {
+                    collapsed = !collapsed;
+                    body.style.display = collapsed ? DisplayStyle.None : DisplayStyle.Flex;
+                    header.Text = collapsed ? DocumentChevronCollapsed : DocumentChevronExpanded;
+                });
+                header = new AspidGradientButton(DocumentChevronExpanded, _ => toggle())
+                    .AddClass(DocumentHeaderClass);
+                if (hasIssues) header.AddClass(DocumentHeaderIssuesClass);
+                header.tooltip = $"fileId {document.FileId}";
+                RegisterNavTarget(header, toggle);
+
+                // Ignored for picking so clicks fall through to the band's own handler.
+                header.AddLeadingContent(new VisualElement()
+                    .AddClass(DocumentHeaderRowClass)
+                    .SetPickingMode(PickingMode.Ignore)
+                    .AddChild(new Label(document.TypeName)
+                        .AddClass(DocumentTitleClass)
+                        .SetPickingMode(PickingMode.Ignore))
+                    .AddChild(new Label(BuildDocumentCountText(document, broken, migrations))
+                        .AddClass(DocumentCountClass)
+                        .SetPickingMode(PickingMode.Ignore)));
+            }
+
             // Missing roots render first. Two passes over the asset's field order keep the partition stable between
             // rescans; empty (unassigned) roots are not missing, so they fall to the second pass.
             foreach (var root in document.Roots)
@@ -591,31 +796,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (orphans is not null) body.AddChild(orphans);
 
             // Single-document asset: no header band — the ObjectField above already names it. Always expanded.
-            if (!showHeader)
+            if (header is null)
                 return new VisualElement().AddClass(DocumentClass).AddChild(body);
-
-            // The self-reference lets the click handler flip its own chevron alongside toggling the body.
-            AspidGradientButton header = null;
-            var collapsed = false;
-            header = new AspidGradientButton(DocumentChevronExpanded, _ =>
-            {
-                collapsed = !collapsed;
-                body.style.display = collapsed ? DisplayStyle.None : DisplayStyle.Flex;
-                header.Text = collapsed ? DocumentChevronCollapsed : DocumentChevronExpanded;
-            }).AddClass(DocumentHeaderClass);
-            if (hasIssues) header.AddClass(DocumentHeaderIssuesClass);
-            header.tooltip = $"fileId {document.FileId}";
-
-            // Ignored for picking so clicks fall through to the band's own handler.
-            header.AddLeadingContent(new VisualElement()
-                .AddClass(DocumentHeaderRowClass)
-                .SetPickingMode(PickingMode.Ignore)
-                .AddChild(new Label(document.TypeName)
-                    .AddClass(DocumentTitleClass)
-                    .SetPickingMode(PickingMode.Ignore))
-                .AddChild(new Label(BuildDocumentCountText(document, broken, migrations))
-                    .AddClass(DocumentCountClass)
-                    .SetPickingMode(PickingMode.Ignore)));
 
             return new VisualElement()
                 .AddClass(DocumentClass)
@@ -686,6 +868,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(NodeClass);
+            // Card-level modifier so card-wide states (the --picking accent frame, the picker's accent-follow rules)
+            // read the calm info tone on a migration card instead of the broken-card amber.
+            if (isMigration) card.AddClass(NodeMigrateCardClass);
 
             var typePreset = AspidLabelPreset.Default
                 .SetLabelSize(AspidLabelSizeStyle.Type.H5)
@@ -736,28 +921,29 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     .AddClass(isMigration ? NodeBandMigrateClass : NodeBandMissingClass);
                 band.AddLeadingContent(bandRow);
                 card.AddChild(band);
+                RegisterNavTarget(band, () => OpenMissingPicker(assetPath, fileId, rid, band));
+                AddBandDivider(card, band, isMigration ? NodeSweepMigrateClass : NodeSweepMissingClass);
 
                 if (isMigration)
                 {
                     // The same YAML rewrite a picker pick performs — no confirm, matching the picker's own apply.
-                    var migrate = new AspidGradientButton($"Migrate  →  {migrationTarget.Name}",
-                            _ => ApplyFix(assetPath, fileId, rid, migrationTarget.AssemblyQualifiedName))
-                        .AddClass(NodeMigrateClass);
-                    migrate.tooltip =
+                    card.AddChild(BuildNodeActionRow(
+                        $"Migrate → {migrationTarget.Name}",
                         $"This entry resolves to {migrationTarget.FullName} via its declared [MovedFrom] — Unity " +
                         "already migrates it in memory when the asset loads. Migrating rewrites the stored type " +
-                        "name in the file so it matches the code.";
-                    card.AddChild(migrate);
+                        "name in the file so it matches the code.",
+                        info: true,
+                        () => ApplyFix(assetPath, fileId, rid, migrationTarget.AssemblyQualifiedName)));
                 }
                 else if (TryGetNodeSuggestion(assetPath, document.FileId, rid, node.Value.StoredType, out var suggestion))
                 {
                     // Safe to hand straight to ApplyFix: Rank's pool is constraint-filtered, so the suggestion is
                     // always a type the picker itself would offer.
-                    var suggest = new AspidGradientButton(SerializeReferenceHelpers.GetSuggestionLabel(suggestion),
-                            _ => ApplyFix(assetPath, fileId, rid, suggestion.Type.AssemblyQualifiedName))
-                        .AddClass(NodeSuggestClass);
-                    suggest.tooltip = SerializeReferenceHelpers.GetSuggestionDetail(suggestion);
-                    card.AddChild(suggest);
+                    card.AddChild(BuildNodeActionRow(
+                        $"Smart Fix {SerializeReferenceHelpers.GetSuggestionLabel(suggestion)}",
+                        SerializeReferenceHelpers.GetSuggestionDetail(suggestion),
+                        info: false,
+                        () => ApplyFix(assetPath, fileId, rid, suggestion.Type.AssemblyQualifiedName)));
                 }
             }
             else if (!isOrphan)
@@ -771,12 +957,16 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     .AddClass(NodeBandClass);
                 band.AddLeadingContent(bandRow);
                 card.AddChild(band);
+                RegisterNavTarget(band, () => OpenLivePicker(assetPath, fileId, graphPath, band));
+                AddBandDivider(card, band, sweepModifier: null);
             }
             else
             {
                 // An orphan has no field pointing at it, so there is no live property to edit — its band stays static
-                // and the footer Clear (below) drops the dangling entry.
+                // and the footer Clear (below) drops the dangling entry. The divider still splits band from footer,
+                // but with no hover source there is no sweep.
                 card.AddChild(bandRow);
+                AddBandDivider(card, band: null, sweepModifier: null);
             }
 
             // Healthy and empty slots are cleared through their band's picker (<None>), so no separate button here.
@@ -784,26 +974,78 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             if (!string.IsNullOrEmpty(pathLabel))
             {
-                meta.AddChild(new Label($"{pathLabel}:")
-                    .AddClass(NodeRootLabelClass)
-                    .SetPickingMode(PickingMode.Ignore));
+                meta.AddChild(MakeSelectable(new Label($"{pathLabel}:")
+                    .AddClass(NodeRootLabelClass)));
             }
 
-            meta.AddChild(new Label($"rid {rid}")
-                .AddClass(NodeRidClass)
-                .SetPickingMode(PickingMode.Ignore));
+            meta.AddChild(MakeSelectable(new Label($"rid {rid}")
+                .AddClass(NodeRidClass)));
 
             if (isOrphan)
             {
                 // Drop a dangling RefIds entry no field points at. File edit, so it is confirmed and not undoable.
                 var fileId = document.FileId;
-                meta.AddChild(new AspidGradientButton("Clear", _ => ClearOrphan(assetPath, fileId, rid))
-                    .AddClass(ClearOrphanClass));
+                var clear = new AspidGradientButton("Clear", _ => ClearOrphan(assetPath, fileId, rid))
+                    .AddClass(ClearOrphanClass);
+                RegisterNavTarget(clear, () => ClearOrphan(assetPath, fileId, rid));
+                meta.AddChild(clear);
             }
 
             card.AddChild(meta);
 
             return card;
+        }
+
+        // A one-click action (Smart Fix / Migrate) as a flat accent verb over the same hover fill the Project
+        // References action rows use, instead of a filled gradient pill floating over the glass card. Each card
+        // keeps one accent: warning amber for a Smart Fix guess on a broken card, info for a pending migration.
+        private VisualElement BuildNodeActionRow(string text, string tooltipText, bool info, Action onClick)
+        {
+            var row = new Label(text).AddClass(NodeActionClass);
+            if (info) row.AddClass(NodeActionInfoClass);
+            row.tooltip = tooltipText;
+            row.RegisterCallback<ClickEvent>(_ => onClick());
+            RegisterNavTarget(row, onClick);
+            return row;
+        }
+
+        // The dim hairline between a card's band and its body, plus — when the band is interactive — the accent
+        // underline sweep that scales in while the band is hovered (the Project References group cards' idiom).
+        // The sweep is the band's sibling, so USS :hover can't reach it; the band mirrors its hover onto a card
+        // modifier the sweep rule listens to. Both hide while the picker is docked (see the --picking USS rules).
+        private void AddBandDivider(VisualElement card, AspidGradientButton band, string sweepModifier)
+        {
+            card.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
+                    .SetTheme(ThemeStyle.Type.Light)
+                    .SetSize(AspidDividingLineSizeStyle.Type.Thin))
+                .AddClass(NodeDividerClass));
+
+            if (band is null) return;
+
+            var sweep = new VisualElement()
+                .AddClass(NodeSweepClass)
+                .SetPickingMode(PickingMode.Ignore);
+            if (sweepModifier is not null) sweep.AddClass(sweepModifier);
+            card.AddChild(sweep);
+
+            band.RegisterCallback<MouseEnterEvent>(_ => band.parent?.AddToClassList(NodeHeaderHoverClass));
+            // Composes with the keyboard ring: while the band is the nav-focused element the sweep stays lit after
+            // the mouse leaves (mirrors AspidGradientButton.Highlighted keeping the glow on).
+            band.RegisterCallback<MouseLeaveEvent>(_ =>
+            {
+                if (IsNavFocused(band)) return;
+                band.parent?.RemoveFromClassList(NodeHeaderHoverClass);
+            });
+        }
+
+        // Footer text (field paths, rids) is the payload users copy out of the graph, so it is selectable; a
+        // drag-select never conflicts with a click — node footers carry no row-level click action.
+        private static Label MakeSelectable(Label label)
+        {
+            label.selection.isSelectable = true;
+            label.selection.doubleClickSelectsWord = true;
+            label.selection.tripleClickSelectsLine = true;
+            return label;
         }
 
         // A back-edge to a rid already on the current render path — a single dim, italic line (no footer) so cycles
@@ -875,6 +1117,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             {
                 // No recoverable field path to target — leave the slot a static "<None>" leaf.
                 card.AddChild(bandRow);
+                AddBandDivider(card, band: null, sweepModifier: null);
             }
             else
             {
@@ -887,20 +1130,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (isRequired) band.AddClass(NodeBandMissingClass);
                 band.AddLeadingContent(bandRow);
                 card.AddChild(band);
+                RegisterNavTarget(band, () => OpenLivePicker(assetPath, fileId, graphPath, band));
+                AddBandDivider(card, band, isRequired ? NodeSweepMissingClass : null);
             }
 
             var meta = new VisualElement().AddClass(NodeFooterClass);
 
             if (!string.IsNullOrEmpty(pathLabel))
             {
-                meta.AddChild(new Label($"{pathLabel}:")
-                    .AddClass(NodeRootLabelClass)
-                    .SetPickingMode(PickingMode.Ignore));
+                meta.AddChild(MakeSelectable(new Label($"{pathLabel}:")
+                    .AddClass(NodeRootLabelClass)));
             }
 
-            meta.AddChild(new Label("unassigned")
-                .AddClass(NodeRidClass)
-                .SetPickingMode(PickingMode.Ignore));
+            meta.AddChild(MakeSelectable(new Label("unassigned")
+                .AddClass(NodeRidClass)));
 
             card.AddChild(meta);
 
@@ -937,6 +1180,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             {
                 // Not reachable through the live serialization API — leave the band a static "<None>" line.
                 card.AddChild(bandRow);
+                AddBandDivider(card, band: null, sweepModifier: null);
             }
             else
             {
@@ -946,18 +1190,18 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     .AddClass(NodeBandMissingClass);
                 band.AddLeadingContent(bandRow);
                 card.AddChild(band);
+                RegisterNavTarget(band, () => OpenRequiredStringPicker(violation, band));
+                AddBandDivider(card, band, NodeSweepMissingClass);
             }
 
             var component = ResolveComponentName(violation, componentCache);
             var text = string.IsNullOrEmpty(component) ? violation.FieldPath : $"{component}.{violation.FieldPath}";
 
             var meta = new VisualElement().AddClass(NodeFooterClass);
-            meta.AddChild(new Label($"{text}:")
-                .AddClass(NodeRootLabelClass)
-                .SetPickingMode(PickingMode.Ignore));
-            meta.AddChild(new Label("unassigned")
-                .AddClass(NodeRidClass)
-                .SetPickingMode(PickingMode.Ignore));
+            meta.AddChild(MakeSelectable(new Label($"{text}:")
+                .AddClass(NodeRootLabelClass)));
+            meta.AddChild(MakeSelectable(new Label("unassigned")
+                .AddClass(NodeRidClass)));
             card.AddChild(meta);
 
             return card;
@@ -1223,17 +1467,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // Glyph-only swap (▼→▲) so the same replace works for every band label.
             if (anchor is not null) anchor.Text = anchor.Text.Replace(BandChevronCollapsed, BandChevronExpanded);
 
-            // Drop the picker right below the band inside the card (the ?? fallback keeps a sane target if the band is
-            // ever hosted outside a card). On a migration / suggestion card the one-click row stays welded under the
-            // band, so the picker slots in after it.
+            // Drop the picker directly below the band inside the card (the ?? fallback keeps a sane target if the
+            // band is ever hosted outside a card). The band's divider + sweep hide while the card is picking (USS
+            // --picking rules), and the action / footer rows sit below the docked selector — mirroring the Project
+            // References card whose picker docks under the header with the entry rows below it.
             var card = anchor?.parent;
             var container = card ?? _list;
-            var insertAt = container.IndexOf(anchor) + 1;
-            if (insertAt < container.childCount &&
-                (container[insertAt].ClassListContains(NodeMigrateClass) ||
-                 container[insertAt].ClassListContains(NodeSuggestClass)))
-                insertAt++;
-            container.InsertChild(insertAt, _openPicker);
+            container.InsertChild(container.IndexOf(anchor) + 1, _openPicker);
 
             if (card is not null)
             {
@@ -1256,6 +1496,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _openPicker = null;
             _openPickerRow = null;
             _openPickerCard = null;
+
+            // The dismissed picker leaves keyboard focus dangling on its (removed) search field; reclaim it so the
+            // arrow-key ring keeps working. Guarded — ClosePicker also runs from render paths before attach.
+            if (panel is not null) Focus();
         }
 
         private void ApplyFix(string assetPath, long fileId, long rid, string assemblyQualifiedName)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Aspid.FastTools.Types.Editors;
 using Aspid.FastTools.UIElements.Editors.Internal;
 using Object = UnityEngine.Object;
+using static Aspid.FastTools.SerializeReferences.Editors.SerializeReferenceAuditUI;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.SerializeReferences.Editors
@@ -101,9 +102,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private readonly ScrollView _scroll;
 
         // Keyboard navigation: one flat focus ring over every actionable element in visual order — Rescan first,
-        // then each card's Fix all / action row / entry rows. -1 means nothing is highlighted.
-        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
-        private int _navIndex = -1;
+        // then each card's Fix all / action row / entry rows — shared with the other window tabs.
+        private readonly NavRing _ring;
+
+        // The legend's block-specific USS class names for the shared item builder.
+        private static readonly LegendClasses LegendClassSet = new(LegendItemClass, LegendDotClass, LegendDotInfoClass, LegendTextClass);
 
         // Required-violations audit has no incrementally-maintained index like SerializeReferenceTypeUsageIndex, so it
         // is only (re)scanned on an explicit Scan/Rescan click, not on every Initialize() (tab switch would otherwise
@@ -167,8 +170,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _legend = new VisualElement()
                 .AddClass(LegendClass)
                 .AddClass(LegendHiddenClass)
-                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false))
-                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true));
+                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false, LegendClassSet))
+                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true, LegendClassSet));
 
             // Receipt stack: one help-box per bulk Fix all, kept across chained fixes and cleared only on a fresh scan.
             _summaries = new VisualElement().AddClass(SummaryListClass);
@@ -195,12 +198,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             root.AddChild(_scroll);
 
-            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach, re-grabbed when the picker
-            // closes) so key events reach OnNavKeyDown even before anything is highlighted; events from focused
-            // descendants bubble here too.
-            focusable = true;
-            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
-            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+            // The shared keyboard ring: the root holds focus (grabbed on attach, re-grabbed when the picker closes)
+            // so keys reach it before anything is highlighted. Suspended while a type picker owns the keyboard.
+            _ring = new NavRing(
+                host: this,
+                navTargetClass: NavTargetClass,
+                paint: PaintNavFocus,
+                scrollTo: element => _scroll.ScrollTo(element),
+                isSuspended: () => _openPicker is not null);
 
             ResetNavTargets();
         }
@@ -209,74 +214,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Keyboard navigation
         // ---------------------------------------------------------------------------------------------------------
 
-        private void OnNavKeyDown(KeyDownEvent evt)
+        // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat fill
+        // would just show through their fading gradient as a gray pill, so they take ONLY the programmatic hover and
+        // the plain rows take ONLY the class. A focused Fix all header also lights its card's divider sweep.
+        private static void PaintNavFocus(VisualElement element, bool on)
         {
-            // The open type picker owns the keyboard (its own search + list navigation) — stay out of its way.
-            if (_openPicker is not null) return;
-
-            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
-            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
-
-            switch (evt.keyCode)
-            {
-                case KeyCode.DownArrow:
-                    MoveNavFocus(+1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.UpArrow:
-                    MoveNavFocus(-1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
-                    _navTargets[_navIndex].Activate();
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Escape when _navIndex >= 0:
-                    ClearNavFocus();
-                    evt.StopPropagation();
-                    break;
-            }
-        }
-
-        // First press (nothing highlighted) lands on Rescan whichever arrow is hit; after that the ring clamps at
-        // both ends instead of wrapping.
-        private void MoveNavFocus(int delta)
-        {
-            if (_navTargets.Count == 0) return;
-            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
-        }
-
-        private void SetNavFocus(int index, bool scrollTo = true)
-        {
-            if (_navIndex == index) return;
-
-            ClearNavFocus();
-            _navIndex = index;
-
-            var element = _navTargets[index].Element;
-            // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat
-            // fill would just show through their fading gradient as a gray pill, so they take ONLY the programmatic
-            // hover and the plain rows take ONLY the class.
-            if (element is AspidGradientButton button) button.Highlighted = true;
-            else element.AddToClassList(NavTargetFocusedClass);
-            SetHeaderSweep(element, on: true);
-            if (scrollTo) _scroll.ScrollTo(element);
-        }
-
-        private void ClearNavFocus()
-        {
-            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
-            {
-                var element = _navTargets[_navIndex].Element;
-                if (element is AspidGradientButton button) button.Highlighted = false;
-                else element.RemoveFromClassList(NavTargetFocusedClass);
-                SetHeaderSweep(element, on: false);
-            }
-
-            _navIndex = -1;
+            if (element is AspidGradientButton button) button.Highlighted = on;
+            else element.EnableInClassList(NavTargetFocusedClass, on);
+            SetHeaderSweep(element, on);
         }
 
         // A focused Fix all header also lights its card's divider sweep — the same card-level hover mirror the
@@ -291,20 +236,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // always slot 0; a highlight sitting on it survives the rebuild, so Enter-on-Rescan keeps its highlight.
         private void ResetNavTargets()
         {
-            var keepScanFocus = _navIndex == 0;
-            ClearNavFocus();
-            _navTargets.Clear();
+            var keepScanFocus = _ring.Index == 0;
+            _ring.Clear();
 
             RegisterNavTarget(_scanButton, ScanProject);
-            if (keepScanFocus) SetNavFocus(0, scrollTo: false);
+            if (keepScanFocus) _ring.Focus(0, scrollTo: false);
         }
 
-        private void RegisterNavTarget(VisualElement element, Action activate)
-        {
-            // EnableInClassList (not AddToClassList): Rescan is re-registered on every reset and must not stack copies.
-            element.EnableInClassList(NavTargetClass, true);
-            _navTargets.Add((element, activate));
-        }
+        private void RegisterNavTarget(VisualElement element, Action activate) => _ring.Register(element, activate);
 
         // Cold index: open idle and wait for a deliberate Scan click — the cold sweep parses every asset's YAML behind
         // a blocking bar, so it must never run unasked. Warm index: re-deriving groups is a cheap in-memory filter, so
@@ -378,16 +317,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // Pending migrations sink to the very bottom, below the Required violations card too: the whole amber
             // band (broken groups, then required fields) stacks first and the calm blue one-click cards close the
             // list. Each band keeps the scanner's order.
-            var migrations = new List<ProjectGroup>();
+            var migrations = new List<(ProjectGroup Group, GroupMigration Migration)>();
             foreach (var group in groups)
             {
-                if (IsMigrationGroup(group)) migrations.Add(group);
-                else _list.AddChild(BuildGroupCard(group));
+                // Resolve constraint + migration ONCE per group and reuse it for the card and picker label below, so
+                // the partition and the card can never disagree on whether a group is a migration.
+                var migration = new GroupMigration(group);
+                if (migration.IsMigration) migrations.Add((group, migration));
+                else _list.AddChild(BuildGroupCard(group, migration));
             }
 
             // The header splits the migration entries out of the missing count — a [MovedFrom] rename with a
             // one-click fix shouldn't inflate the alarm number.
-            var migrationCount = migrations.Sum(group => group.Entries.Count);
+            var migrationCount = migrations.Sum(entry => entry.Group.Entries.Count);
             ShowResults(
                 BuildResultsHeaderText(missingCount - migrationCount, migrationCount, requiredCount),
                 SerializeReferenceCanvasStyle.Warning);
@@ -400,21 +342,29 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             if (requiredCount > 0)
                 _list.AddChild(BuildRequiredGroupCard(requiredViolations));
 
-            foreach (var group in migrations)
-                _list.AddChild(BuildGroupCard(group));
+            foreach (var (group, migration) in migrations)
+                _list.AddChild(BuildGroupCard(group, migration));
         }
 
-        // An authoritative [MovedFrom] rename whose target also fits the group's field constraint — the same gate
-        // BuildGroupCard applies before offering Migrate all (see there for why the constraint matters).
-        private static bool IsMigrationGroup(ProjectGroup group)
+        // Resolves a group's picker constraint and whether it reads as a one-click [MovedFrom] migration ONCE, so the
+        // partition in RenderGroups, the card body and the picker label share one computation and can never disagree.
+        // A migration is an authoritative [MovedFrom] rename whose target also fits the group's field constraint —
+        // Migrate all bypasses the picker's assignability guarantee, and an incompatible target would be nulled by
+        // Unity at load, so the constraint gate matters.
+        private readonly struct GroupMigration
         {
-            var constraint = group.ResolveConstraint();
-            return SerializeReferenceMovedFromResolver.TryResolve(group.StoredType, out var target) &&
-                (constraint == typeof(object) || constraint.IsAssignableFrom(target));
-        }
+            public readonly Type Constraint;
+            public readonly bool IsMigration;
+            public readonly Type Target; // the [MovedFrom] target when IsMigration; otherwise null.
 
-        private static string BuildCountText(int count, string noun) =>
-            count == 1 ? $"1 {noun}" : $"{count} {(noun.EndsWith("y") ? noun[..^1] + "ies" : noun + "s")}";
+            public GroupMigration(ProjectGroup group)
+            {
+                Constraint = group.ResolveConstraint();
+                IsMigration = SerializeReferenceMovedFromResolver.TryResolve(group.StoredType, out var target) &&
+                    (Constraint == typeof(object) || Constraint.IsAssignableFrom(target));
+                Target = IsMigration ? target : null;
+            }
+        }
 
         // Only non-zero parts make the header; brokenCount is the missing total MINUS the pending-migration entries,
         // which get their own calmer "pending migration" wording.
@@ -438,19 +388,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 hint += " Click a required-violation row to jump to its asset.";
 
             return hint;
-        }
-
-        // One dot + caption pair of the accent legend: amber (default) for the broken/required band, info blue for
-        // the pending-migration cards.
-        private static VisualElement BuildLegendItem(string text, bool info)
-        {
-            var dot = new VisualElement().AddClass(LegendDotClass);
-            if (info) dot.AddClass(LegendDotInfoClass);
-
-            return new VisualElement()
-                .AddClass(LegendItemClass)
-                .AddChild(dot)
-                .AddChild(new Label(text).AddClass(LegendTextClass));
         }
 
         // Shared "no missing references left" branch for ApplyGroupFix/ClearGroupToNull: stays in the results region
@@ -503,19 +440,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // A broken-type group card: the whole header is one clickable row that toggles the type picker, with the bulk
         // "Fix all (N) ▼" action on the right. Entries are deliberately not individually fixable in project mode —
         // the per-row Fix affordance is reserved for single-asset mode.
-        private VisualElement BuildGroupCard(ProjectGroup group)
+        private VisualElement BuildGroupCard(ProjectGroup group, GroupMigration migration)
         {
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(GroupClass);
 
-            var constraint = group.ResolveConstraint();
+            // Constraint + migration were resolved once in RenderGroups (see GroupMigration) and are reused here so
+            // the card can never disagree with the partition. A migration is an authoritative [MovedFrom] rename:
+            // Unity already migrates these in memory at load — only the files still store the old name — and its
+            // target fits the group's field constraint (Migrate all bypasses the picker's assignability guarantee).
+            var constraint = migration.Constraint;
             var displayName = group.DisplayName;
-
-            // An authoritative [MovedFrom] rename: Unity already migrates these in memory at load — only the files
-            // still store the old name. The target must also fit the group's field constraint: Migrate all bypasses
-            // the picker's assignability guarantee, and an incompatible target would be nulled by Unity at load.
-            var isMigration = SerializeReferenceMovedFromResolver.TryResolve(group.StoredType, out var migrationTarget) &&
-                (constraint == typeof(object) || constraint.IsAssignableFrom(migrationTarget));
+            var isMigration = migration.IsMigration;
+            var migrationTarget = migration.Target;
 
             // Card-level modifier so card-wide states (the --picking accent frame) can follow the card's own
             // accent — a migration card is info-toned end to end, never the broken-card amber.
@@ -524,11 +461,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // Built first so the type name + count can be docked into its body; the captured local is assigned before use.
             AspidGradientButton fixAll = null;
             fixAll = new AspidGradientButton(BuildFixAllLabel(group, expanded: false, isMigration),
-                    _ => ToggleGroupPicker(group, constraint, fixAll))
+                    _ => ToggleGroupPicker(group, constraint, fixAll, isMigration))
                 .AddClass(GroupFixAllClass);
             // A migration card keeps its calm info tone end to end — the amber Fix all accent is the "broken" alarm.
             if (isMigration) fixAll.AddClass(GroupFixAllMigrateClass);
-            RegisterNavTarget(fixAll, () => ToggleGroupPicker(group, constraint, fixAll));
+            RegisterNavTarget(fixAll, () => ToggleGroupPicker(group, constraint, fixAll, isMigration));
             fixAll.tooltip = constraint == typeof(object)
                 ? $"{displayName}\nMixed or unresolvable field types — the picker is unconstrained (any managed-reference type)."
                 : $"{displayName}\nConstrained to {constraint.FullName}.";
@@ -594,28 +531,19 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         // The accent hairline that scales in under a flat header button while it is hovered — shared idiom with the
-        // Welcome sample cards. The sweep is the button's sibling, so USS :hover can't reach it; the button mirrors
-        // its hover onto a container modifier (resolved lazily via parent, at event time) the sweep rule listens to.
+        // Welcome sample cards. The sweep is the button's sibling, so USS :hover can't reach it; HoverSweep mirrors
+        // the hover onto the card modifier (the header's live parent) the sweep rule listens to, keeping it lit while
+        // the header is the nav-focused ring member.
         private VisualElement CreateHeaderSweep(AspidGradientButton header, string sweepClass, string hoverClass)
         {
             var sweep = new VisualElement()
                 .AddClass(sweepClass)
                 .SetPickingMode(PickingMode.Ignore);
 
-            header.RegisterCallback<MouseEnterEvent>(_ => header.parent?.AddToClassList(hoverClass));
-            // Composes with the keyboard ring: while the header is the nav-focused element the sweep stays lit
-            // after the mouse leaves (mirrors AspidGradientButton.Highlighted keeping the glow on).
-            header.RegisterCallback<MouseLeaveEvent>(_ =>
-            {
-                if (IsNavFocused(header)) return;
-                header.parent?.RemoveFromClassList(hoverClass);
-            });
+            HoverSweep.MirrorHover(header, () => header.parent, hoverClass, () => _ring.IsFocused(header));
 
             return sweep;
         }
-
-        private bool IsNavFocused(VisualElement element) =>
-            _navIndex >= 0 && _navIndex < _navTargets.Count && _navTargets[_navIndex].Element == element;
 
         // A one-click bulk action (Smart Fix / Migrate all) as a member of the entry-row family: a left-aligned
         // accent verb over the same flat hover fill as the ping rows below it, instead of a filled gradient pill
@@ -664,17 +592,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return row;
         }
 
-        // The path is the payload users most often need outside Unity, so entry-row text is selectable for copying.
-        // A drag-select ends in the same ClickEvent as a plain click, so the row's jump only fires when the click
-        // lands on text without leaving a selection behind.
-        private static Label MakeSelectable(Label label)
-        {
-            label.selection.isSelectable = true;
-            label.selection.doubleClickSelectsWord = true;
-            label.selection.tripleClickSelectsLine = true;
-            return label;
-        }
-
         private void RegisterEntryRowClick(VisualElement row, string assetPath)
         {
             row.RegisterCallback<ClickEvent>(evt =>
@@ -715,7 +632,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         }
 
         // The group's bulk picker, inline below the Fix all button, constrained to the group's intersected field type.
-        private void ToggleGroupPicker(ProjectGroup group, Type constraint, AspidGradientButton button)
+        private void ToggleGroupPicker(ProjectGroup group, Type constraint, AspidGradientButton button, bool isMigration)
         {
             var wasOpen = _openPickerRow == button;
             ClosePicker();
@@ -735,7 +652,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             });
 
             OpenPickerBelow(button, view);
-            button.Text = BuildFixAllLabel(group, expanded: true, IsMigrationGroup(group));
+            button.Text = BuildFixAllLabel(group, expanded: true, isMigration);
         }
 
         // Rewrites every entry in the group to newType after a mandatory confirmation. Rewrites are batched per file

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
@@ -44,6 +44,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string ResultsHiddenClass = ResultsClass + "--hidden";
         private const string ResultsHeaderClass = RootClass + "__results-header";
         private const string ResultsHintClass = RootClass + "__results-hint";
+        private const string LegendClass = RootClass + "__legend";
+        private const string LegendHiddenClass = LegendClass + "--hidden";
+        private const string LegendItemClass = RootClass + "__legend-item";
+        private const string LegendDotClass = RootClass + "__legend-dot";
+        private const string LegendDotInfoClass = LegendDotClass + "--info";
+        private const string LegendTextClass = RootClass + "__legend-text";
         private const string SummaryListClass = RootClass + "__summary-list";
         private const string SummaryClass = RootClass + "__summary";
         private const string SummaryUndoClass = RootClass + "__summary-undo";
@@ -86,6 +92,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private readonly AspidLabel _resultsHeader;
         private readonly VisualElement _summaries;
         private readonly Label _resultsHint;
+        private readonly VisualElement _legend;
         private readonly VisualElement _list;
         private VisualElement _openPicker;
         private AspidGradientButton _openPickerRow;
@@ -156,6 +163,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
             _resultsHint = new Label(string.Empty).AddClass(ResultsHintClass);
 
+            // Color key for the two card accents; only shown when both are actually on screen (see RenderGroups).
+            _legend = new VisualElement()
+                .AddClass(LegendClass)
+                .AddClass(LegendHiddenClass)
+                .AddChild(BuildLegendItem("Broken — pick a replacement", info: false))
+                .AddChild(BuildLegendItem("Renamed — one-click migrate", info: true));
+
             // Receipt stack: one help-box per bulk Fix all, kept across chained fixes and cleared only on a fresh scan.
             _summaries = new VisualElement().AddClass(SummaryListClass);
 
@@ -165,6 +179,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddClass(ResultsClass)
                 .AddChild(_resultsHeader)
                 .AddChild(_resultsHint)
+                .AddChild(_legend)
                 .AddChild(_summaries)
                 .AddChild(_list);
 
@@ -360,9 +375,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 return;
             }
 
-            ShowResults(BuildResultsHeaderText(missingCount, requiredCount), SerializeReferenceCanvasStyle.Warning);
-            _resultsHint.text = BuildResultsHintText(canceled, requiredCount > 0);
-
             // Pending migrations sink to the very bottom, below the Required violations card too: the whole amber
             // band (broken groups, then required fields) stacks first and the calm blue one-click cards close the
             // list. Each band keeps the scanner's order.
@@ -372,6 +384,18 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (IsMigrationGroup(group)) migrations.Add(group);
                 else _list.AddChild(BuildGroupCard(group));
             }
+
+            // The header splits the migration entries out of the missing count — a [MovedFrom] rename with a
+            // one-click fix shouldn't inflate the alarm number.
+            var migrationCount = migrations.Sum(group => group.Entries.Count);
+            ShowResults(
+                BuildResultsHeaderText(missingCount - migrationCount, migrationCount, requiredCount),
+                SerializeReferenceCanvasStyle.Warning);
+            _resultsHint.text = BuildResultsHintText(canceled, requiredCount > 0);
+
+            // The amber/blue key only earns its row when both accents are on screen at once.
+            var hasAmber = groups.Count > migrations.Count || requiredCount > 0;
+            _legend.EnableInClassList(LegendHiddenClass, migrations.Count == 0 || !hasAmber);
 
             if (requiredCount > 0)
                 _list.AddChild(BuildRequiredGroupCard(requiredViolations));
@@ -392,25 +416,41 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private static string BuildCountText(int count, string noun) =>
             count == 1 ? $"1 {noun}" : $"{count} {(noun.EndsWith("y") ? noun[..^1] + "ies" : noun + "s")}";
 
-        private static string BuildResultsHeaderText(int missingCount, int requiredCount)
+        // Only non-zero parts make the header; brokenCount is the missing total MINUS the pending-migration entries,
+        // which get their own calmer "pending migration" wording.
+        private static string BuildResultsHeaderText(int brokenCount, int migrationCount, int requiredCount)
         {
-            var missingText = BuildCountText(missingCount, "missing reference");
-            var requiredText = BuildCountText(requiredCount, "required violation");
+            var parts = new List<string>(3);
+            if (brokenCount > 0) parts.Add(BuildCountText(brokenCount, "missing reference"));
+            if (migrationCount > 0) parts.Add(BuildCountText(migrationCount, "pending migration"));
+            if (requiredCount > 0) parts.Add(BuildCountText(requiredCount, "required violation"));
 
-            if (missingCount > 0 && requiredCount > 0) return $"{missingText}, {requiredText}";
-            return missingCount > 0 ? missingText : requiredText;
+            return string.Join(", ", parts);
         }
 
         private static string BuildResultsHintText(bool canceled, bool hasRequiredViolations)
         {
             var hint = canceled
-                ? "Scan canceled — showing partial results. Each group is a broken type; Fix all re-points every entry (or pick <None> to clear them to null) across every file at once."
-                : "Each group is a broken stored type. Fix all picks one replacement and re-points every entry across every affected file at once — or pick <None> to clear them to null.";
+                ? "Scan canceled — showing partial results. Fix all re-points a group's every entry to one replacement, or to <None>."
+                : "Each group is a broken stored type — Fix all re-points its every entry to one replacement, or to <None>.";
 
             if (hasRequiredViolations)
-                hint += " Required violations below list every unset [TypeSelector(Required = true)] field the same scan found — click a row to jump to its asset.";
+                hint += " Click a required-violation row to jump to its asset.";
 
             return hint;
+        }
+
+        // One dot + caption pair of the accent legend: amber (default) for the broken/required band, info blue for
+        // the pending-migration cards.
+        private static VisualElement BuildLegendItem(string text, bool info)
+        {
+            var dot = new VisualElement().AddClass(LegendDotClass);
+            if (info) dot.AddClass(LegendDotInfoClass);
+
+            return new VisualElement()
+                .AddClass(LegendItemClass)
+                .AddChild(dot)
+                .AddChild(new Label(text).AddClass(LegendTextClass));
         }
 
         // Shared "no missing references left" branch for ApplyGroupFix/ClearGroupToNull: stays in the results region
@@ -427,6 +467,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 requiredViolations.Count == 0 ? "No missing references" : $"No missing references, {BuildCountText(requiredViolations.Count, "required violation")}",
                 SerializeReferenceCanvasStyle.Success);
             _resultsHint.text = "Nothing left to repair. Rescan to sweep the project again and confirm it's clean.";
+            _legend.AddClass(LegendHiddenClass);
 
             if (requiredViolations.Count > 0)
                 _list.AddChild(BuildRequiredGroupCard(requiredViolations));
@@ -610,29 +651,67 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         {
             var row = new VisualElement().AddClass(GroupEntryClass);
 
-            var path = new Label(entry.AssetPath)
-                .AddClass(GroupEntryPathClass);
+            var path = MakeSelectable(new Label(entry.AssetPath)
+                .AddClass(GroupEntryPathClass));
             path.tooltip = entry.AssetPath;
 
-            var rid = new Label($"rid {entry.Entry.Rid}")
-                .AddClass(GroupEntryRidClass)
-                .SetPickingMode(PickingMode.Ignore);
-
-            void Jump()
-            {
-                var asset = AssetDatabase.LoadMainAssetAtPath(entry.AssetPath);
-                if (asset is null) return;
-
-                // Cross-link: jump to the asset's full Inspect graph; ping as a fallback when hosted standalone.
-                if (OnInspectAsset is not null) OnInspectAsset(asset);
-                else EditorGUIUtility.PingObject(asset);
-            }
+            var rid = MakeSelectable(new Label($"rid {entry.Entry.Rid}")
+                .AddClass(GroupEntryRidClass));
 
             row.AddChild(path).AddChild(rid);
-            row.RegisterCallback<ClickEvent>(_ => Jump());
-            RegisterNavTarget(row, Jump);
+            RegisterEntryRowClick(row, entry.AssetPath);
 
             return row;
+        }
+
+        // The path is the payload users most often need outside Unity, so entry-row text is selectable for copying.
+        // A drag-select ends in the same ClickEvent as a plain click, so the row's jump only fires when the click
+        // lands on text without leaving a selection behind.
+        private static Label MakeSelectable(Label label)
+        {
+            label.selection.isSelectable = true;
+            label.selection.doubleClickSelectsWord = true;
+            label.selection.tripleClickSelectsLine = true;
+            return label;
+        }
+
+        private void RegisterEntryRowClick(VisualElement row, string assetPath)
+        {
+            row.RegisterCallback<ClickEvent>(evt =>
+            {
+                if (evt.target is TextElement text && text.selection.HasSelection()) return;
+                JumpToAsset(assetPath);
+            });
+
+            RegisterNavTarget(row, () => JumpToAsset(assetPath));
+            row.AddManipulator(new ContextualMenuManipulator(evt => PopulateEntryContextMenu(evt, assetPath)));
+        }
+
+        // Right-click alternatives to the row's default left-click jump. Runs after the selectable labels populate
+        // their own items (bubble-up), so the menu is wiped first to drop their Copy entry — Cmd+C on a selection
+        // still copies, and the menu stays the same three items wherever the click lands.
+        private void PopulateEntryContextMenu(ContextualMenuPopulateEvent evt, string assetPath)
+        {
+            for (var i = evt.menu.MenuItems().Count - 1; i >= 0; i--)
+                evt.menu.RemoveItemAt(i);
+
+            evt.menu.AppendAction("Open in Asset References", _ => JumpToAsset(assetPath));
+
+            evt.menu.AppendAction(
+                "Open in Prefab Mode",
+                _ => UnityEditor.SceneManagement.PrefabStageUtility.OpenPrefab(assetPath),
+                assetPath.EndsWith(".prefab", StringComparison.OrdinalIgnoreCase)
+                    ? DropdownMenuAction.Status.Normal
+                    : DropdownMenuAction.Status.Disabled);
+
+            evt.menu.AppendAction("Select in Project", _ =>
+            {
+                var asset = AssetDatabase.LoadMainAssetAtPath(assetPath);
+                if (asset is null) return;
+
+                Selection.activeObject = asset;
+                EditorGUIUtility.PingObject(asset);
+            });
         }
 
         // The group's bulk picker, inline below the Fix all button, constrained to the group's intersected field type.
@@ -1108,7 +1187,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         // Flat read-only list of every unset [TypeSelector(Required = true)] field, fed by the same headless scanner
         // as the build/CI gate. No bulk fix here — unlike a broken type, an empty required field has nothing sensible
-        // to auto-assign, so the row's only affordance is jumping to the offending asset.
+        // to auto-assign, so the row's only affordance is jumping to the offending asset (where the graph's inline
+        // Assign Required picker lives).
         private VisualElement BuildRequiredGroupCard(IReadOnlyList<GateViolation> violations)
         {
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
@@ -1121,7 +1201,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddClass(GroupHeaderClass)
                 .SetPickingMode(PickingMode.Ignore);
 
-            var count = new Label(BuildCountText(violations.Count, "entry"))
+            var files = violations.Select(violation => violation.AssetPath).Distinct(StringComparer.Ordinal).Count();
+            var count = new Label($"{BuildCountText(violations.Count, "entry")} · {(files == 1 ? "1 file" : $"{files} files")}")
                 .AddClass(GroupCountClass)
                 .SetPickingMode(PickingMode.Ignore);
 
@@ -1157,29 +1238,28 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         {
             var row = new VisualElement().AddClass(GroupEntryClass);
 
-            var path = new Label(violation.AssetPath)
-                .AddClass(GroupEntryPathClass);
+            var path = MakeSelectable(new Label(violation.AssetPath)
+                .AddClass(GroupEntryPathClass));
             path.tooltip = violation.AssetPath;
 
-            var field = new Label(BuildRequiredViolationFieldText(violation, componentCache))
-                .AddClass(GroupEntryFieldClass)
-                .SetPickingMode(PickingMode.Ignore);
-
-            void Jump()
-            {
-                var asset = AssetDatabase.LoadMainAssetAtPath(violation.AssetPath);
-                if (asset is null) return;
-
-                // Cross-link: jump to the asset's full Inspect graph; ping as a fallback when hosted standalone.
-                if (OnInspectAsset is not null) OnInspectAsset(asset);
-                else EditorGUIUtility.PingObject(asset);
-            }
+            var field = MakeSelectable(new Label(BuildRequiredViolationFieldText(violation, componentCache))
+                .AddClass(GroupEntryFieldClass));
 
             row.AddChild(path).AddChild(field);
-            row.RegisterCallback<ClickEvent>(_ => Jump());
-            RegisterNavTarget(row, Jump);
+            RegisterEntryRowClick(row, violation.AssetPath);
 
             return row;
+        }
+
+        // Cross-link shared by every read-only audit row: jump to the asset's full Inspect graph; ping as a
+        // fallback when hosted standalone.
+        private void JumpToAsset(string assetPath)
+        {
+            var asset = AssetDatabase.LoadMainAssetAtPath(assetPath);
+            if (asset is null) return;
+
+            if (OnInspectAsset is not null) OnInspectAsset(asset);
+            else EditorGUIUtility.PingObject(asset);
         }
 
         // "Component.field" for the entry row's right column; GateViolation itself carries no owning-object type,

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
@@ -52,15 +52,20 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string PickerAttachedClass = PickerClass + "--attached";
 
         private const string GroupClass = RootClass + "__group";
+        private const string GroupMigrateClass = GroupClass + "--migrate";
         private const string GroupPickingClass = GroupClass + "--picking";
+        private const string GroupHeaderHoverClass = GroupClass + "--header-hover";
+        private const string GroupDividerClass = RootClass + "__group-divider";
+        private const string GroupSweepClass = RootClass + "__group-sweep";
+        private const string GroupSweepMigrateClass = GroupSweepClass + "--migrate";
         private const string GroupHeaderRowClass = RootClass + "__group-header-row";
         private const string GroupHeaderRowStaticClass = GroupHeaderRowClass + "--static";
         private const string GroupHeaderClass = RootClass + "__group-header";
         private const string GroupCountClass = RootClass + "__group-count";
         private const string GroupFixAllClass = RootClass + "__group-fix-all";
         private const string GroupFixAllMigrateClass = GroupFixAllClass + "--migrate";
-        private const string GroupSuggestClass = RootClass + "__group-suggest";
-        private const string GroupMigrateClass = RootClass + "__group-migrate";
+        private const string GroupActionClass = RootClass + "__group-action";
+        private const string GroupActionInfoClass = GroupActionClass + "--info";
         private const string GroupEntryClass = RootClass + "__group-entry";
         private const string GroupEntryPathClass = RootClass + "__group-entry-path";
         private const string GroupEntryRidClass = RootClass + "__group-entry-rid";
@@ -239,11 +244,30 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             ShowResults(BuildResultsHeaderText(missingCount, requiredCount), SerializeReferenceCanvasStyle.Warning);
             _resultsHint.text = BuildResultsHintText(canceled, requiredCount > 0);
 
+            // Pending migrations sink to the very bottom, below the Required violations card too: the whole amber
+            // band (broken groups, then required fields) stacks first and the calm blue one-click cards close the
+            // list. Each band keeps the scanner's order.
+            var migrations = new List<ProjectGroup>();
             foreach (var group in groups)
-                _list.AddChild(BuildGroupCard(group));
+            {
+                if (IsMigrationGroup(group)) migrations.Add(group);
+                else _list.AddChild(BuildGroupCard(group));
+            }
 
             if (requiredCount > 0)
                 _list.AddChild(BuildRequiredGroupCard(requiredViolations));
+
+            foreach (var group in migrations)
+                _list.AddChild(BuildGroupCard(group));
+        }
+
+        // An authoritative [MovedFrom] rename whose target also fits the group's field constraint — the same gate
+        // BuildGroupCard applies before offering Migrate all (see there for why the constraint matters).
+        private static bool IsMigrationGroup(ProjectGroup group)
+        {
+            var constraint = group.ResolveConstraint();
+            return SerializeReferenceMovedFromResolver.TryResolve(group.StoredType, out var target) &&
+                (constraint == typeof(object) || constraint.IsAssignableFrom(target));
         }
 
         private static string BuildCountText(int count, string noun) =>
@@ -332,9 +356,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             var isMigration = SerializeReferenceMovedFromResolver.TryResolve(group.StoredType, out var migrationTarget) &&
                 (constraint == typeof(object) || constraint.IsAssignableFrom(migrationTarget));
 
+            // Card-level modifier so card-wide states (the --picking accent frame) can follow the card's own
+            // accent — a migration card is info-toned end to end, never the broken-card amber.
+            if (isMigration) card.AddClass(GroupMigrateClass);
+
             // Built first so the type name + count can be docked into its body; the captured local is assigned before use.
             AspidGradientButton fixAll = null;
-            fixAll = new AspidGradientButton(BuildFixAllLabel(group, expanded: false),
+            fixAll = new AspidGradientButton(BuildFixAllLabel(group, expanded: false, isMigration),
                     _ => ToggleGroupPicker(group, constraint, fixAll))
                 .AddClass(GroupFixAllClass);
             // A migration card keeps its calm info tone end to end — the amber Fix all accent is the "broken" alarm.
@@ -364,33 +392,71 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             fixAll.AddLeadingContent(info);
             card.AddChild(fixAll);
 
+            // Header divider + its underline sweep (the Welcome cards' idiom): the sweep rides the divider line,
+            // amber for a broken group, the calm info tone on a migration card. Both hide while the picker is
+            // docked — the dropdown is inserted right after the header and they would land under it.
+            card.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
+                    .SetTheme(ThemeStyle.Type.Light)
+                    .SetSize(AspidDividingLineSizeStyle.Type.Thin))
+                .AddClass(GroupDividerClass));
+
+            var sweep = CreateHeaderSweep(fixAll, GroupSweepClass, GroupHeaderHoverClass);
+            if (isMigration) sweep.AddClass(GroupSweepMigrateClass);
+            card.AddChild(sweep);
+
             if (isMigration)
             {
                 // Not a guess, so it replaces the Smart Fix row: same confirm + diff preview + Undo flow as a picked fix.
-                var migrate = new AspidGradientButton(
-                        $"Migrate all ({group.Entries.Count}) → {migrationTarget.Name}",
-                        _ => ApplyGroupFix(group, migrationTarget))
-                    .AddClass(GroupMigrateClass);
-                migrate.tooltip =
+                card.AddChild(BuildGroupActionRow(
+                    $"Migrate all ({group.Entries.Count}) → {migrationTarget.Name}",
                     $"Every entry resolves to {migrationTarget.FullName} via its declared [MovedFrom] — Unity already " +
                     "migrates them in memory when the asset loads. Migrating rewrites the stored type name in the " +
-                    "files so they match the code; the attribute can be removed once no file stores the old name.";
-                card.AddChild(migrate);
+                    "files so they match the code; the attribute can be removed once no file stores the old name.",
+                    info: true,
+                    () => ApplyGroupFix(group, migrationTarget)));
             }
             else if (TryGetGroupSuggestion(group, constraint, out var suggestion))
             {
                 // Reuse the shared label/detail builders so the Smart Fix copy never drifts from the inspector notice.
-                var suggest = new AspidGradientButton(SerializeReferenceHelpers.GetSuggestionLabel(suggestion),
-                        _ => ApplyGroupFix(group, suggestion.Type))
-                    .AddClass(GroupSuggestClass);
-                suggest.tooltip = SerializeReferenceHelpers.GetSuggestionDetail(suggestion);
-                card.AddChild(suggest);
+                card.AddChild(BuildGroupActionRow(
+                    $"Smart Fix {SerializeReferenceHelpers.GetSuggestionLabel(suggestion)}",
+                    SerializeReferenceHelpers.GetSuggestionDetail(suggestion),
+                    info: false,
+                    () => ApplyGroupFix(group, suggestion.Type)));
             }
 
             foreach (var entry in group.Entries)
                 card.AddChild(BuildGroupEntryRow(entry));
 
             return card;
+        }
+
+        // The accent hairline that scales in under a flat header button while it is hovered — shared idiom with the
+        // Welcome sample cards. The sweep is the button's sibling, so USS :hover can't reach it; the button mirrors
+        // its hover onto a container modifier (resolved lazily via parent, at event time) the sweep rule listens to.
+        private static VisualElement CreateHeaderSweep(AspidGradientButton header, string sweepClass, string hoverClass)
+        {
+            var sweep = new VisualElement()
+                .AddClass(sweepClass)
+                .SetPickingMode(PickingMode.Ignore);
+
+            header.RegisterCallback<MouseEnterEvent>(_ => header.parent?.AddToClassList(hoverClass));
+            header.RegisterCallback<MouseLeaveEvent>(_ => header.parent?.RemoveFromClassList(hoverClass));
+
+            return sweep;
+        }
+
+        // A one-click bulk action (Smart Fix / Migrate all) as a member of the entry-row family: a left-aligned
+        // accent verb over the same flat hover fill as the ping rows below it, instead of a filled gradient pill
+        // floating over the glass card. Each card keeps one accent: warning amber for a Smart Fix guess on a
+        // broken card, info for a pending migration.
+        private static VisualElement BuildGroupActionRow(string text, string tooltipText, bool info, Action onClick)
+        {
+            var row = new Label(text).AddClass(GroupActionClass);
+            if (info) row.AddClass(GroupActionInfoClass);
+            row.tooltip = tooltipText;
+            row.RegisterCallback<ClickEvent>(_ => onClick());
+            return row;
         }
 
         private static string BuildGroupCountText(ProjectGroup group)
@@ -402,9 +468,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             return $"{entryText} · {fileText}";
         }
 
-        // "Fix all (N)" plus a trailing chevron; only the glyph changes when the picker opens (ClosePicker relies on that).
-        private static string BuildFixAllLabel(ProjectGroup group, bool expanded) =>
-            $"Fix all ({group.Entries.Count})  {(expanded ? FixArrowExpanded : FixArrowCollapsed)}";
+        // The header verb plus a trailing chevron; only the glyph changes when the picker opens (ClosePicker relies
+        // on that). A broken group's picker fixes ("Fix all"); on a migration card nothing is broken and the picker
+        // is the manual escape hatch beside the one-click Migrate all row, so its verb is "Reassign all".
+        private static string BuildFixAllLabel(ProjectGroup group, bool expanded, bool isMigration) =>
+            $"{(isMigration ? "Reassign all" : "Fix all")} ({group.Entries.Count})  {(expanded ? FixArrowExpanded : FixArrowCollapsed)}";
 
         // Read-only entry row: clicking jumps to the asset — the bulk Fix above is the only mutation in project mode.
         private VisualElement BuildGroupEntryRow(ProjectEntry entry)
@@ -454,7 +522,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             });
 
             OpenPickerBelow(button, view);
-            button.Text = BuildFixAllLabel(group, expanded: true);
+            button.Text = BuildFixAllLabel(group, expanded: true, IsMigrationGroup(group));
         }
 
         // Rewrites every entry in the group to newType after a mandatory confirmation. Rewrites are batched per file
@@ -931,6 +999,13 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             info.pickingMode = PickingMode.Ignore;
 
             card.AddChild(info);
+
+            // Same header divider as the Fix-all cards, keeping every card's header/body split on one line — but no
+            // sweep: this header row is static, there is nothing to hover.
+            card.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
+                    .SetTheme(ThemeStyle.Type.Light)
+                    .SetSize(AspidDividingLineSizeStyle.Type.Thin))
+                .AddClass(GroupDividerClass));
 
             // Per-card memo, keyed by asset path: several violations commonly share one asset (e.g. a prefab with
             // multiple unset required fields), so this keeps LoadAllAssetsAtPath to once per distinct file instead of

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceProjectView.cs
@@ -70,6 +70,8 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private const string GroupEntryPathClass = RootClass + "__group-entry-path";
         private const string GroupEntryRidClass = RootClass + "__group-entry-rid";
         private const string GroupEntryFieldClass = RootClass + "__group-entry-field";
+        private const string NavTargetClass = RootClass + "__nav-target";
+        private const string NavTargetFocusedClass = NavTargetClass + "--focused";
 
         // Chevron on the "Fix all (N)" dropdown button; only the glyph differs between the two states.
         private const string FixArrowCollapsed = "▼";
@@ -89,6 +91,12 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private AspidGradientButton _openPickerRow;
         private VisualElement _openPickerCard;
         private readonly AspidGradientButton _scanButton;
+        private readonly ScrollView _scroll;
+
+        // Keyboard navigation: one flat focus ring over every actionable element in visual order — Rescan first,
+        // then each card's Fix all / action row / entry rows. -1 means nothing is highlighted.
+        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
+        private int _navIndex = -1;
 
         // Required-violations audit has no incrementally-maintained index like SerializeReferenceTypeUsageIndex, so it
         // is only (re)scanned on an explicit Scan/Rescan click, not on every Initialize() (tab switch would otherwise
@@ -167,10 +175,120 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddChild(_empty)
                 .AddChild(_results);
 
-            var scroll = new ScrollView().AddClass(ScrollClass);
-            scroll.AddChild(content);
+            _scroll = new ScrollView().AddClass(ScrollClass);
+            _scroll.AddChild(content);
 
-            root.AddChild(scroll);
+            root.AddChild(_scroll);
+
+            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach, re-grabbed when the picker
+            // closes) so key events reach OnNavKeyDown even before anything is highlighted; events from focused
+            // descendants bubble here too.
+            focusable = true;
+            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
+            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+
+            ResetNavTargets();
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+        // Keyboard navigation
+        // ---------------------------------------------------------------------------------------------------------
+
+        private void OnNavKeyDown(KeyDownEvent evt)
+        {
+            // The open type picker owns the keyboard (its own search + list navigation) — stay out of its way.
+            if (_openPicker is not null) return;
+
+            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
+            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
+
+            switch (evt.keyCode)
+            {
+                case KeyCode.DownArrow:
+                    MoveNavFocus(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.UpArrow:
+                    MoveNavFocus(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
+                    _navTargets[_navIndex].Activate();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Escape when _navIndex >= 0:
+                    ClearNavFocus();
+                    evt.StopPropagation();
+                    break;
+            }
+        }
+
+        // First press (nothing highlighted) lands on Rescan whichever arrow is hit; after that the ring clamps at
+        // both ends instead of wrapping.
+        private void MoveNavFocus(int delta)
+        {
+            if (_navTargets.Count == 0) return;
+            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
+        }
+
+        private void SetNavFocus(int index, bool scrollTo = true)
+        {
+            if (_navIndex == index) return;
+
+            ClearNavFocus();
+            _navIndex = index;
+
+            var element = _navTargets[index].Element;
+            // Gradient buttons paint their hover in code (accent overlay + tinted labels); the focused class's flat
+            // fill would just show through their fading gradient as a gray pill, so they take ONLY the programmatic
+            // hover and the plain rows take ONLY the class.
+            if (element is AspidGradientButton button) button.Highlighted = true;
+            else element.AddToClassList(NavTargetFocusedClass);
+            SetHeaderSweep(element, on: true);
+            if (scrollTo) _scroll.ScrollTo(element);
+        }
+
+        private void ClearNavFocus()
+        {
+            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
+            {
+                var element = _navTargets[_navIndex].Element;
+                if (element is AspidGradientButton button) button.Highlighted = false;
+                else element.RemoveFromClassList(NavTargetFocusedClass);
+                SetHeaderSweep(element, on: false);
+            }
+
+            _navIndex = -1;
+        }
+
+        // A focused Fix all header also lights its card's divider sweep — the same card-level hover mirror the
+        // mouse path drives in CreateHeaderSweep — so keyboard focus and mouse hover render identically.
+        private static void SetHeaderSweep(VisualElement element, bool on)
+        {
+            if (element.ClassListContains(GroupFixAllClass))
+                element.parent?.EnableInClassList(GroupHeaderHoverClass, on);
+        }
+
+        // Every render pass rebuilds the ring from scratch (the old elements are gone with _list.Clear()). Rescan is
+        // always slot 0; a highlight sitting on it survives the rebuild, so Enter-on-Rescan keeps its highlight.
+        private void ResetNavTargets()
+        {
+            var keepScanFocus = _navIndex == 0;
+            ClearNavFocus();
+            _navTargets.Clear();
+
+            RegisterNavTarget(_scanButton, ScanProject);
+            if (keepScanFocus) SetNavFocus(0, scrollTo: false);
+        }
+
+        private void RegisterNavTarget(VisualElement element, Action activate)
+        {
+            // EnableInClassList (not AddToClassList): Rescan is re-registered on every reset and must not stack copies.
+            element.EnableInClassList(NavTargetClass, true);
+            _navTargets.Add((element, activate));
         }
 
         // Cold index: open idle and wait for a deliberate Scan click — the cold sweep parses every asset's YAML behind
@@ -226,6 +344,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private void RenderGroups(List<ProjectGroup> groups, IReadOnlyList<GateViolation> requiredViolations, bool canceled)
         {
             _list.Clear();
+            ResetNavTargets();
 
             var missingCount = groups.Sum(group => group.Entries.Count);
             var requiredCount = requiredViolations.Count;
@@ -301,6 +420,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private void ShowMissingReferencesClean()
         {
             _list.Clear();
+            ResetNavTargets();
             var requiredViolations = RequiredViolationsForRender;
 
             ShowResults(
@@ -367,6 +487,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddClass(GroupFixAllClass);
             // A migration card keeps its calm info tone end to end — the amber Fix all accent is the "broken" alarm.
             if (isMigration) fixAll.AddClass(GroupFixAllMigrateClass);
+            RegisterNavTarget(fixAll, () => ToggleGroupPicker(group, constraint, fixAll));
             fixAll.tooltip = constraint == typeof(object)
                 ? $"{displayName}\nMixed or unresolvable field types — the picker is unconstrained (any managed-reference type)."
                 : $"{displayName}\nConstrained to {constraint.FullName}.";
@@ -434,28 +555,38 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // The accent hairline that scales in under a flat header button while it is hovered — shared idiom with the
         // Welcome sample cards. The sweep is the button's sibling, so USS :hover can't reach it; the button mirrors
         // its hover onto a container modifier (resolved lazily via parent, at event time) the sweep rule listens to.
-        private static VisualElement CreateHeaderSweep(AspidGradientButton header, string sweepClass, string hoverClass)
+        private VisualElement CreateHeaderSweep(AspidGradientButton header, string sweepClass, string hoverClass)
         {
             var sweep = new VisualElement()
                 .AddClass(sweepClass)
                 .SetPickingMode(PickingMode.Ignore);
 
             header.RegisterCallback<MouseEnterEvent>(_ => header.parent?.AddToClassList(hoverClass));
-            header.RegisterCallback<MouseLeaveEvent>(_ => header.parent?.RemoveFromClassList(hoverClass));
+            // Composes with the keyboard ring: while the header is the nav-focused element the sweep stays lit
+            // after the mouse leaves (mirrors AspidGradientButton.Highlighted keeping the glow on).
+            header.RegisterCallback<MouseLeaveEvent>(_ =>
+            {
+                if (IsNavFocused(header)) return;
+                header.parent?.RemoveFromClassList(hoverClass);
+            });
 
             return sweep;
         }
+
+        private bool IsNavFocused(VisualElement element) =>
+            _navIndex >= 0 && _navIndex < _navTargets.Count && _navTargets[_navIndex].Element == element;
 
         // A one-click bulk action (Smart Fix / Migrate all) as a member of the entry-row family: a left-aligned
         // accent verb over the same flat hover fill as the ping rows below it, instead of a filled gradient pill
         // floating over the glass card. Each card keeps one accent: warning amber for a Smart Fix guess on a
         // broken card, info for a pending migration.
-        private static VisualElement BuildGroupActionRow(string text, string tooltipText, bool info, Action onClick)
+        private VisualElement BuildGroupActionRow(string text, string tooltipText, bool info, Action onClick)
         {
             var row = new Label(text).AddClass(GroupActionClass);
             if (info) row.AddClass(GroupActionInfoClass);
             row.tooltip = tooltipText;
             row.RegisterCallback<ClickEvent>(_ => onClick());
+            RegisterNavTarget(row, onClick);
             return row;
         }
 
@@ -487,8 +618,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddClass(GroupEntryRidClass)
                 .SetPickingMode(PickingMode.Ignore);
 
-            row.AddChild(path).AddChild(rid);
-            row.RegisterCallback<ClickEvent>(_ =>
+            void Jump()
             {
                 var asset = AssetDatabase.LoadMainAssetAtPath(entry.AssetPath);
                 if (asset is null) return;
@@ -496,7 +626,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 // Cross-link: jump to the asset's full Inspect graph; ping as a fallback when hosted standalone.
                 if (OnInspectAsset is not null) OnInspectAsset(asset);
                 else EditorGUIUtility.PingObject(asset);
-            });
+            }
+
+            row.AddChild(path).AddChild(rid);
+            row.RegisterCallback<ClickEvent>(_ => Jump());
+            RegisterNavTarget(row, Jump);
 
             return row;
         }
@@ -1031,8 +1165,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 .AddClass(GroupEntryFieldClass)
                 .SetPickingMode(PickingMode.Ignore);
 
-            row.AddChild(path).AddChild(field);
-            row.RegisterCallback<ClickEvent>(_ =>
+            void Jump()
             {
                 var asset = AssetDatabase.LoadMainAssetAtPath(violation.AssetPath);
                 if (asset is null) return;
@@ -1040,7 +1173,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 // Cross-link: jump to the asset's full Inspect graph; ping as a fallback when hosted standalone.
                 if (OnInspectAsset is not null) OnInspectAsset(asset);
                 else EditorGUIUtility.PingObject(asset);
-            });
+            }
+
+            row.AddChild(path).AddChild(field);
+            row.RegisterCallback<ClickEvent>(_ => Jump());
+            RegisterNavTarget(row, Jump);
 
             return row;
         }
@@ -1135,6 +1272,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             _openPicker = null;
             _openPickerRow = null;
             _openPickerCard = null;
+
+            // The dismissed picker leaves keyboard focus dangling on its (removed) search field; reclaim it so the
+            // arrow-key ring keeps working. Guarded — ClosePicker also runs from render paths before attach.
+            if (panel is not null) Focus();
         }
 
         private static Type ResolveType(string assemblyQualifiedName) =>
@@ -1144,6 +1285,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private void ShowEmptyState(bool success, string title, string message)
         {
+            ResetNavTargets();
             _results.AddClass(ResultsHiddenClass);
             _empty.RemoveClass(EmptyHiddenClass);
             _empty.Clear();

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceWindow.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SerializeReferenceWindow.cs
@@ -51,6 +51,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // The Aspid brand mark shown beside the window title; padded variant so it doesn't dominate the tab.
         private const string WindowIconPath = "Icons/aspid_icon_window_tab_green_1022x1011";
 
+        // Below this the toolbar tabs and cards degrade into slivers; applied in CreateGUI so every instance
+        // gets it — including panes restored from a saved layout, which never pass through Reveal.
+        private static readonly Vector2 MinWindowSize = new(480f, 360f);
+
         // ShortcutManager ids for the tab-switch bindings. They surface under this category in Edit > Shortcuts and are
         // user-rebindable; the visible tab badges read the live binding back from these ids (see BindingLabel).
         private const string ShortcutCategory = "Aspid FastTools/Managed References/";
@@ -126,15 +130,18 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
         private static SerializeReferenceWindow Reveal()
         {
+            // Title and minSize are owned by CreateGUI, so every instance gets them — including panes restored
+            // from a saved layout or created by scripts, which never pass through here.
             var window = GetWindow<SerializeReferenceWindow>();
-            window.titleContent = new GUIContent("Aspid FastTools", Resources.Load<Texture2D>(WindowIconPath));
-            window.minSize = new Vector2(480f, 360f);
             window.Show();
             return window;
         }
 
         private void CreateGUI()
         {
+            minSize = MinWindowSize;
+            titleContent = new GUIContent("Aspid FastTools", Resources.Load<Texture2D>(WindowIconPath));
+
             var root = rootVisualElement;
             root.AddAspidThemeStyleSheets()
                 .AddStyleSheetsFromResource(WindowStyleSheetPath)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SettingsView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SettingsView.cs
@@ -1,5 +1,10 @@
+using System;
+using UnityEngine;
+using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
+using System.Collections.Generic;
+using Aspid.FastTools.UIElements.Editors.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.SerializeReferences.Editors
@@ -12,21 +17,226 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     /// scope legend and every package area's section from one definition per area, and
     /// <see cref="AspidSettingsUI.BuildResetFooter"/> pins the per-scope reset under the scroll. The window's dotted
     /// canvas already sits behind this tab, so unlike the Unity-native pages it brings no canvas of its own.
+    /// On top of the surface the tab runs the window's keyboard ring (the Project/Asset References idiom): ↑/↓ walk
+    /// one flat focus ring over every actionable element, Enter activates the highlighted one (toggles a switch,
+    /// cycles the gate, opens the add-folder picker, presses a button), ←/→ nudge the highlighted slider, Escape
+    /// drops the highlight.
     /// </summary>
     internal sealed class SettingsView : VisualElement
     {
+        private readonly ScrollView _scroll;
+
+        // Keyboard navigation: one flat focus ring in visual order. Activate fires on Enter; Adjust (sliders only)
+        // on ←/→ with the step sign; Remove (excluded-folder rows only) on Delete/Backspace.
+        private readonly List<(VisualElement Element, Action Activate, Action<int> Adjust, Action Remove)> _navTargets = new();
+        private int _navIndex = -1;
+
         public SettingsView()
         {
             // Repaint the plain Unity fields into the window's dark palette so they don't float bright over the canvas.
             this.AsSurface();
 
-            // No in-content "Settings" heading: the active gear tab already names the mode.
-            var scroll = new ScrollView(ScrollViewMode.Vertical) { style = { flexGrow = 1 } };
-            AspidSettingsUI.BuildSurfaceContent(scroll.contentContainer);
-            Add(scroll);
+            _scroll = new ScrollView(ScrollViewMode.Vertical) { style = { flexGrow = 1 } };
+            AspidSettingsUI.BuildSurfaceContent(_scroll.contentContainer);
+            Add(_scroll);
 
             // Pinned under the scroll, so the reset affordance stays reachable however long the tab grows.
             Add(AspidSettingsUI.BuildResetFooter());
+
+            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach) so key events reach
+            // OnNavKeyDown even before anything is highlighted; events from focused descendants bubble here too.
+            focusable = true;
+            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
+            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+
+            // The surface's controls are stable for the tab's lifetime (the excluded-folders panel rebuilds only its
+            // internal rows), so the ring is collected once, in tree (= visual) order.
+            CollectNavTargets(this);
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+        // Keyboard navigation
+        // ---------------------------------------------------------------------------------------------------------
+
+        private void OnNavKeyDown(KeyDownEvent evt)
+        {
+            // A control being edited owns the keyboard: arrows/Enter inside the slider (or its inline value box)
+            // adjust and commit there — stay out of the way. Escape still clears the ring below because an editing
+            // control never keeps focus past Escape.
+            if (IsEditingControlFocused()) return;
+
+            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
+            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
+
+            switch (evt.keyCode)
+            {
+                case KeyCode.DownArrow:
+                    MoveNavFocus(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.UpArrow:
+                    MoveNavFocus(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.LeftArrow when _navIndex >= 0 && _navTargets[_navIndex].Adjust is { } decrease:
+                    decrease(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.RightArrow when _navIndex >= 0 && _navTargets[_navIndex].Adjust is { } increase:
+                    increase(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0 && _navTargets[_navIndex].Activate is { } activate:
+                    activate();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Delete or KeyCode.Backspace when _navIndex >= 0 && _navTargets[_navIndex].Remove is { } remove:
+                    remove();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Escape when _navIndex >= 0:
+                    ClearNavFocus();
+                    evt.StopPropagation();
+                    break;
+            }
+        }
+
+        private bool IsEditingControlFocused()
+        {
+            if (focusController?.focusedElement is not VisualElement focused) return false;
+
+            for (var element = focused; element != null; element = element.parent)
+                if (element is ITextEdition or TextElement or SliderInt)
+                    return true;
+
+            return false;
+        }
+
+        // First press (nothing highlighted) lands on the first row whichever arrow is hit; after that the ring
+        // clamps at both ends instead of wrapping.
+        private void MoveNavFocus(int delta)
+        {
+            if (_navTargets.Count == 0) return;
+            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
+        }
+
+        private void SetNavFocus(int index)
+        {
+            if (_navIndex == index) return;
+
+            ClearNavFocus();
+            _navIndex = index;
+
+            var element = _navTargets[index].Element;
+            element.AddToClassList(AspidSettingsUI.NavTargetFocusedClass);
+
+            // The ring also covers the reset footer pinned OUTSIDE the scroll; ScrollTo throws on non-descendants.
+            if (IsInScrollContent(element))
+                _scroll.ScrollTo(element);
+        }
+
+        private bool IsInScrollContent(VisualElement element)
+        {
+            for (var parent = element.parent; parent != null; parent = parent.parent)
+                if (parent == _scroll.contentContainer)
+                    return true;
+
+            return false;
+        }
+
+        private void ClearNavFocus()
+        {
+            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
+                _navTargets[_navIndex].Element.RemoveFromClassList(AspidSettingsUI.NavTargetFocusedClass);
+
+            _navIndex = -1;
+        }
+
+        // Walks the tree in order and registers every actionable control by type, stopping the descent at each one so
+        // its internals (a switch's thumb, a button's label) never become ring members of their own. Enter mirrors
+        // what a click on the element does; the slider instead takes ←/→ (its natural axis). The excluded-folders
+        // control contributes several members (its add header and each folder row) and replaces its row elements on
+        // every list change, so the whole ring re-collects on its RowsRebuilt.
+        private void CollectNavTargets(VisualElement element)
+        {
+            switch (element)
+            {
+                case AspidSwitch toggle:
+                    RegisterNavTarget(toggle, () => toggle.value = !toggle.value);
+                    return;
+
+                case EnumField dropdown:
+                    RegisterNavTarget(dropdown, () => CycleEnum(dropdown));
+                    return;
+
+                case SliderInt slider:
+                    RegisterNavTarget(
+                        slider,
+                        activate: null,
+                        adjust: delta => slider.value = Mathf.Clamp(slider.value + delta, slider.lowValue, slider.highValue));
+                    return;
+
+                case SerializeReferenceExcludedFoldersField folders:
+                    foreach (var (target, activate, remove) in folders.GetNavTargets())
+                        RegisterNavTarget(target, activate, remove: remove);
+
+                    // -= then += keeps the subscription single across re-collections (this case re-runs on every
+                    // rebuild of the ring).
+                    folders.RowsRebuilt -= RebuildNavTargets;
+                    folders.RowsRebuilt += RebuildNavTargets;
+                    return;
+
+                case Button button when button.ClassListContains(AspidSettingsUI.ActionClass):
+                    RegisterNavTarget(button, () => Submit(button));
+                    return;
+            }
+
+            foreach (var child in element.Children())
+                CollectNavTargets(child);
+        }
+
+        private void RegisterNavTarget(VisualElement element, Action activate, Action<int> adjust = null, Action remove = null)
+        {
+            // EnableInClassList (not AddToClassList): stable elements are re-registered on every ring rebuild and
+            // must not stack copies.
+            element.EnableInClassList(AspidSettingsUI.NavTargetClass, true);
+            _navTargets.Add((element, activate, adjust, remove));
+        }
+
+        // Re-collects the whole ring after the excluded-folders rows are replaced. A highlight is restored to the
+        // same position, clamped — so deleting a folder row with the keyboard lands the highlight on the next row
+        // instead of dropping it.
+        private void RebuildNavTargets()
+        {
+            var restore = _navIndex;
+            ClearNavFocus();
+            _navTargets.Clear();
+            CollectNavTargets(this);
+
+            if (restore >= 0 && _navTargets.Count > 0)
+                SetNavFocus(Mathf.Min(restore, _navTargets.Count - 1));
+        }
+
+        // Enter on the gate dropdown steps to the next value (wrapping) instead of opening the popup — the popup is
+        // a native menu the ring can't reach into, while cycling keeps the whole interaction on the keyboard.
+        private static void CycleEnum(EnumField dropdown)
+        {
+            var values = Enum.GetValues(dropdown.value.GetType());
+            var index = Array.IndexOf(values, dropdown.value);
+            dropdown.value = (Enum)values.GetValue((index + 1) % values.Length);
+        }
+
+        // Presses a Button exactly as the keyboard would: Clickable listens for the submit navigation event.
+        private static void Submit(Button button)
+        {
+            using var evt = new NavigationSubmitEvent { target = button };
+            button.SendEvent(evt);
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SettingsView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Windows/SettingsView.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using Aspid.FastTools.Editors;
-using System.Collections.Generic;
 using Aspid.FastTools.UIElements.Editors.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -26,10 +25,9 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     {
         private readonly ScrollView _scroll;
 
-        // Keyboard navigation: one flat focus ring in visual order. Activate fires on Enter; Adjust (sliders only)
-        // on ←/→ with the step sign; Remove (excluded-folder rows only) on Delete/Backspace.
-        private readonly List<(VisualElement Element, Action Activate, Action<int> Adjust, Action Remove)> _navTargets = new();
-        private int _navIndex = -1;
+        // Keyboard navigation: one flat focus ring in visual order, shared with the other window tabs. Activate fires
+        // on Enter; Adjust (sliders only) on ←/→ with the step sign; Remove (excluded-folder rows only) on Delete/Backspace.
+        private readonly NavRing _ring;
 
         public SettingsView()
         {
@@ -43,11 +41,14 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             // Pinned under the scroll, so the reset affordance stays reachable however long the tab grows.
             Add(AspidSettingsUI.BuildResetFooter());
 
-            // Arrow-key navigation: the root holds keyboard focus (grabbed on attach) so key events reach
-            // OnNavKeyDown even before anything is highlighted; events from focused descendants bubble here too.
-            focusable = true;
-            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
-            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+            // The shared keyboard ring: the root holds focus (grabbed on attach) so keys reach it before anything is
+            // highlighted. A focused row takes the focused class; the ring also covers the reset footer pinned OUTSIDE
+            // the scroll, where ScrollTo throws on non-descendants — so the scroll is gated on containment.
+            _ring = new NavRing(
+                host: this,
+                navTargetClass: AspidSettingsUI.NavTargetClass,
+                paint: (element, on) => element.EnableInClassList(AspidSettingsUI.NavTargetFocusedClass, on),
+                scrollTo: element => { if (IsInScrollContent(element)) _scroll.ScrollTo(element); });
 
             // The surface's controls are stable for the tab's lifetime (the excluded-folders panel rebuilds only its
             // internal rows), so the ring is collected once, in tree (= visual) order.
@@ -58,89 +59,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         // Keyboard navigation
         // ---------------------------------------------------------------------------------------------------------
 
-        private void OnNavKeyDown(KeyDownEvent evt)
-        {
-            // A control being edited owns the keyboard: arrows/Enter inside the slider (or its inline value box)
-            // adjust and commit there — stay out of the way. Escape still clears the ring below because an editing
-            // control never keeps focus past Escape.
-            if (IsEditingControlFocused()) return;
-
-            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
-            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
-
-            switch (evt.keyCode)
-            {
-                case KeyCode.DownArrow:
-                    MoveNavFocus(+1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.UpArrow:
-                    MoveNavFocus(-1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.LeftArrow when _navIndex >= 0 && _navTargets[_navIndex].Adjust is { } decrease:
-                    decrease(-1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.RightArrow when _navIndex >= 0 && _navTargets[_navIndex].Adjust is { } increase:
-                    increase(+1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0 && _navTargets[_navIndex].Activate is { } activate:
-                    activate();
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Delete or KeyCode.Backspace when _navIndex >= 0 && _navTargets[_navIndex].Remove is { } remove:
-                    remove();
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Escape when _navIndex >= 0:
-                    ClearNavFocus();
-                    evt.StopPropagation();
-                    break;
-            }
-        }
-
-        private bool IsEditingControlFocused()
-        {
-            if (focusController?.focusedElement is not VisualElement focused) return false;
-
-            for (var element = focused; element != null; element = element.parent)
-                if (element is ITextEdition or TextElement or SliderInt)
-                    return true;
-
-            return false;
-        }
-
-        // First press (nothing highlighted) lands on the first row whichever arrow is hit; after that the ring
-        // clamps at both ends instead of wrapping.
-        private void MoveNavFocus(int delta)
-        {
-            if (_navTargets.Count == 0) return;
-            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
-        }
-
-        private void SetNavFocus(int index)
-        {
-            if (_navIndex == index) return;
-
-            ClearNavFocus();
-            _navIndex = index;
-
-            var element = _navTargets[index].Element;
-            element.AddToClassList(AspidSettingsUI.NavTargetFocusedClass);
-
-            // The ring also covers the reset footer pinned OUTSIDE the scroll; ScrollTo throws on non-descendants.
-            if (IsInScrollContent(element))
-                _scroll.ScrollTo(element);
-        }
-
         private bool IsInScrollContent(VisualElement element)
         {
             for (var parent = element.parent; parent != null; parent = parent.parent)
@@ -148,14 +66,6 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     return true;
 
             return false;
-        }
-
-        private void ClearNavFocus()
-        {
-            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
-                _navTargets[_navIndex].Element.RemoveFromClassList(AspidSettingsUI.NavTargetFocusedClass);
-
-            _navIndex = -1;
         }
 
         // Walks the tree in order and registers every actionable control by type, stopping the descent at each one so
@@ -168,15 +78,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             switch (element)
             {
                 case AspidSwitch toggle:
-                    RegisterNavTarget(toggle, () => toggle.value = !toggle.value);
+                    _ring.Register(toggle, () => toggle.value = !toggle.value);
                     return;
 
                 case EnumField dropdown:
-                    RegisterNavTarget(dropdown, () => CycleEnum(dropdown));
+                    _ring.Register(dropdown, () => CycleEnum(dropdown));
                     return;
 
                 case SliderInt slider:
-                    RegisterNavTarget(
+                    _ring.Register(
                         slider,
                         activate: null,
                         adjust: delta => slider.value = Mathf.Clamp(slider.value + delta, slider.lowValue, slider.highValue));
@@ -184,7 +94,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
 
                 case SerializeReferenceExcludedFoldersField folders:
                     foreach (var (target, activate, remove) in folders.GetNavTargets())
-                        RegisterNavTarget(target, activate, remove: remove);
+                        _ring.Register(target, activate, remove: remove);
 
                     // -= then += keeps the subscription single across re-collections (this case re-runs on every
                     // rebuild of the ring).
@@ -193,7 +103,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                     return;
 
                 case Button button when button.ClassListContains(AspidSettingsUI.ActionClass):
-                    RegisterNavTarget(button, () => Submit(button));
+                    _ring.Register(button, () => Submit(button));
                     return;
             }
 
@@ -201,26 +111,17 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 CollectNavTargets(child);
         }
 
-        private void RegisterNavTarget(VisualElement element, Action activate, Action<int> adjust = null, Action remove = null)
-        {
-            // EnableInClassList (not AddToClassList): stable elements are re-registered on every ring rebuild and
-            // must not stack copies.
-            element.EnableInClassList(AspidSettingsUI.NavTargetClass, true);
-            _navTargets.Add((element, activate, adjust, remove));
-        }
-
         // Re-collects the whole ring after the excluded-folders rows are replaced. A highlight is restored to the
         // same position, clamped — so deleting a folder row with the keyboard lands the highlight on the next row
         // instead of dropping it.
         private void RebuildNavTargets()
         {
-            var restore = _navIndex;
-            ClearNavFocus();
-            _navTargets.Clear();
+            var restore = _ring.Index;
+            _ring.Clear();
             CollectNavTargets(this);
 
-            if (restore >= 0 && _navTargets.Count > 0)
-                SetNavFocus(Mathf.Min(restore, _navTargets.Count - 1));
+            if (restore >= 0 && _ring.Count > 0)
+                _ring.Focus(Mathf.Min(restore, _ring.Count - 1));
         }
 
         // Enter on the gate dropdown steps to the next value (wrapping) instead of opening the popup — the popup is

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidFastToolsPreferencesProvider.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidFastToolsPreferencesProvider.cs
@@ -1,26 +1,28 @@
 using UnityEditor;
+using Aspid.FastTools.Types.Editors;
+using Aspid.FastTools.SerializeReferences.Editors;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.FastTools.Editors
 {
     /// <summary>
-    /// The package's settings page at <c>Preferences → Aspid FastTools</c> — the per-user half of the settings,
-    /// matching the page's <see cref="SettingsScope.User"/>: the References controls stored locally (breakage
-    /// detection, the attribute-free dropdown), Type Selector, Appearance and Welcome. The team-wide controls live on
-    /// the <c>Project Settings → Aspid FastTools → SerializeReference</c> page instead, and the window's Settings tab
-    /// shows both scopes as the one full overview. <see cref="AspidSettingsUI.BuildProviderPage"/> composes the same
-    /// branded page (dotted canvas, legend, sections, pinned reset footer) both Unity-native pages share; every
-    /// surface mirrors the others live from one definition per control. Supersedes the old theme-only provider at
-    /// this path; its controls now form the Appearance section.
+    /// The package's settings pages under <c>Preferences → Aspid.FastTools</c> — the per-user half of the settings,
+    /// matching the pages' <see cref="SettingsScope.User"/>. The root page is the full per-user overview (every
+    /// area's section plus the reset footer); under it one focused child page per package area — SerializeReference,
+    /// Type Selector, Welcome — mirrors the Project Settings tree's shape. The team-wide controls live on the
+    /// <c>Project Settings → Aspid.FastTools → SerializeReference</c> page instead, and the window's Settings tab
+    /// shows both scopes as the one full overview. <see cref="AspidSettingsUI.BuildProviderPage"/> /
+    /// <see cref="AspidSettingsUI.BuildAreaProviderPage"/> compose the same branded page every surface shares;
+    /// all of them mirror each other live from one definition per control.
     /// </summary>
     internal static class AspidFastToolsPreferencesProvider
     {
-        private const string SettingsPath = "Preferences/Aspid FastTools";
+        private const string SettingsPath = "Preferences/Aspid.FastTools";
 
         [SettingsProvider]
         public static SettingsProvider Create() => new(SettingsPath, SettingsScope.User)
         {
-            label = "Aspid FastTools",
+            label = "Aspid.FastTools",
 
             activateHandler = static (_, root) =>
                 AspidSettingsUI.BuildProviderPage(root, AspidSettingsScope.User),
@@ -37,5 +39,47 @@ namespace Aspid.FastTools.Editors
                 "Dropdown",
             },
         };
+
+        [SettingsProvider]
+        public static SettingsProvider CreateSerializeReference() =>
+            new(SettingsPath + "/SerializeReference", SettingsScope.User)
+            {
+                label = "SerializeReference",
+
+                activateHandler = static (_, root) => AspidSettingsUI.BuildAreaProviderPage(
+                    root,
+                    title: "SerializeReference",
+                    content => SerializeReferenceSettingsUI.BuildControls(content, AspidSettingsScope.User)),
+
+                keywords = new[] { "Aspid", "FastTools", "Serialize", "Reference", "Breakage", "Repair" },
+            };
+
+        [SettingsProvider]
+        public static SettingsProvider CreateTypeSelector() =>
+            new(SettingsPath + "/Type Selector", SettingsScope.User)
+            {
+                label = "Type Selector",
+
+                activateHandler = static (_, root) => AspidSettingsUI.BuildAreaProviderPage(
+                    root,
+                    title: "Type Selector",
+                    TypeSelectorSettingsView.BuildControls),
+
+                keywords = new[] { "Aspid", "FastTools", "Type Selector", "Favorites", "Recent", "Dropdown" },
+            };
+
+        [SettingsProvider]
+        public static SettingsProvider CreateWelcome() =>
+            new(SettingsPath + "/Welcome", SettingsScope.User)
+            {
+                label = "Welcome",
+
+                activateHandler = static (_, root) => AspidSettingsUI.BuildAreaProviderPage(
+                    root,
+                    title: "Welcome",
+                    WelcomeSettingsUI.BuildControls),
+
+                keywords = new[] { "Aspid", "FastTools", "Welcome", "Auto", "Show" },
+            };
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
@@ -11,8 +11,8 @@ namespace Aspid.FastTools.Editors
 {
     /// <summary>
     /// The shared vocabulary and composition of the package's settings surfaces — the SerializeReference window's
-    /// Settings tab, the <c>Preferences → Aspid FastTools</c> page and the
-    /// <c>Project Settings → Aspid FastTools → SerializeReference</c> page. Owns the surface's stylesheet path and USS
+    /// Settings tab, the <c>Preferences → Aspid.FastTools</c> page and the
+    /// <c>Project Settings → Aspid.FastTools → SerializeReference</c> page. Owns the surface's stylesheet path and USS
     /// class names (sections, legend, row/action primitives, and the storage-scope markers), the one definition of
     /// the surface's content (<see cref="BuildSurfaceContent"/>: the legend and every package area's section, filtered
     /// by <see cref="AspidSettingsScope"/>), its per-scope reset footer (<see cref="BuildResetFooter"/>), the branded
@@ -111,6 +111,40 @@ namespace Aspid.FastTools.Editors
         /// </summary>
         public static void BuildProviderPage(VisualElement root, AspidSettingsScope scope)
         {
+            BuildProviderHost(root, surface =>
+            {
+                var scroll = new ScrollView(ScrollViewMode.Vertical) { style = { flexGrow = 1 } };
+                BuildSurfaceContent(scroll.contentContainer, scope);
+
+                surface.Add(scroll);
+                surface.Add(BuildResetFooter(scope));
+            });
+        }
+
+        /// <summary>
+        /// Composes a Unity settings page for one package area — the child pages under
+        /// <c>Preferences → Aspid.FastTools</c>: the branded host, the area's name as the underlined page header
+        /// (with the scope legend for the page's per-user rows) and one untitled section card that
+        /// <paramref name="buildControls"/> fills — the card skips its own title so the page header isn't repeated
+        /// right under itself. No reset footer: the per-scope reset lives on the parent aggregate page.
+        /// </summary>
+        public static void BuildAreaProviderPage(VisualElement root, string title, Action<VisualElement> buildControls)
+        {
+            BuildProviderHost(root, surface =>
+            {
+                var scroll = new ScrollView(ScrollViewMode.Vertical) { style = { flexGrow = 1 } };
+                var content = scroll.contentContainer;
+
+                content.Add(BuildSurfaceHeader(AspidSettingsScope.User, title, description: null));
+                AddSection(content, title: null, buildControls);
+                surface.Add(scroll);
+            });
+        }
+
+        // The branded page host every Unity-native settings page shares: the window's dotted canvas as the backdrop
+        // (the branded cards read wrong over Unity's native grey panel) with the surface that fill composes over it.
+        private static void BuildProviderHost(VisualElement root, Action<VisualElement> fill)
+        {
             // The theme sheets make a user override apply to this page too.
             root.AddAspidThemeStyleSheets();
             root.style.flexGrow = 1;
@@ -126,12 +160,12 @@ namespace Aspid.FastTools.Editors
             canvas.SetTone(SerializeReferenceCanvasStyle.Info);
 
             var surface = new VisualElement().AddClass(RootClass);
-            var scroll = new ScrollView(ScrollViewMode.Vertical) { style = { flexGrow = 1 } };
-            BuildSurfaceContent(scroll.contentContainer, scope);
+            fill(surface);
 
-            surface.Add(scroll);
-            surface.Add(BuildResetFooter(scope));
-            host.AddChild(canvas).AddChild(surface);
+            // The window's version footer closes the page too — sans the keyboard-ring key: the Unity-native pages
+            // don't run the ring. A sibling of the surface, not a child, so its hairline spans the page edge to edge
+            // clear of the surface's side padding (the window mounts it at root level the same way).
+            host.AddChild(canvas).AddChild(surface).AddChild(new AspidWindowFooter(showKeysHint: false));
             root.Add(host);
         }
 
@@ -144,9 +178,12 @@ namespace Aspid.FastTools.Editors
         /// </summary>
         public static void BuildSurfaceContent(VisualElement container, AspidSettingsScope scope = AspidSettingsScope.All)
         {
-            container.Add(BuildSurfaceHeader(scope));
+            container.Add(BuildSurfaceHeader(
+                scope,
+                title: "Settings",
+                description: "Every FastTools setting in one place. The stripe on each row shows where the value is stored."));
 
-            AddSection(container, "References", content => SerializeReferenceSettingsUI.BuildControls(content, scope));
+            AddSection(container, "SerializeReference", content => SerializeReferenceSettingsUI.BuildControls(content, scope));
 
             // The remaining areas are per-user through and through, so a shared-only surface simply has no sections
             // for them rather than empty headers.
@@ -166,39 +203,42 @@ namespace Aspid.FastTools.Editors
         /// row stripes below. Only the scopes the surface renders get a legend item, so a single-scope page never
         /// explains a stripe it doesn't show.
         /// </summary>
-        private static VisualElement BuildSurfaceHeader(AspidSettingsScope scope)
+        private static VisualElement BuildSurfaceHeader(AspidSettingsScope scope, string title, string description)
         {
-            var title = new AspidLabel("Settings", AspidLabelPreset.Default
+            var heading = new AspidLabel(title, AspidLabelPreset.Default
                     .SetLabelTheme(ThemeStyle.Type.Lightness)
                     .SetLabelSize(AspidLabelSizeStyle.Type.H4)
                     .SetLineTheme(ThemeStyle.Type.Dark))
                 .AddClass(HeaderTitleClass);
 
-            var description = new Label(
-                    "Every FastTools setting in one place. The stripe on each row shows where the value is stored.")
-                .AddClass(HeaderDescriptionClass);
+            var header = new VisualElement().AddClass(HeaderClass)
+                .AddChild(heading);
 
-            return new VisualElement().AddClass(HeaderClass)
-                .AddChild(title)
-                .AddChild(description)
-                .AddChild(BuildScopeLegend(scope));
+            if (description != null)
+                header.AddChild(new Label(description).AddClass(HeaderDescriptionClass));
+
+            return header.AddChild(BuildScopeLegend(scope));
         }
 
         /// <summary>
         /// Appends a titled settings section: a glass group card — the window's card idiom (the Project References
         /// group cards, the Welcome sample cards) — with the section title as its static header row, the shared dim
         /// header divider under it, and a content container that <paramref name="buildContent"/> fills with flat
-        /// settings rows. Each package area (References, Type Selector, Appearance, Welcome) gets its own card so a
-        /// surface reads as one grouped composition from a single definition per area.
+        /// settings rows. Each package area (SerializeReference, Type Selector, Appearance, Welcome) gets its own
+        /// card so a surface reads as one grouped composition from a single definition per area. A <c>null</c>
+        /// <paramref name="title"/> skips the header row — the per-area provider pages already carry the area's name
+        /// as the page header.
         /// </summary>
         public static void AddSection(VisualElement container, string title, Action<VisualElement> buildContent)
         {
-            var card = new VisualElement().AddClass(SectionClass)
-                .AddChild(new Label(title).AddClass(SectionTitleClass))
-                .AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
-                        .SetTheme(ThemeStyle.Type.Light)
-                        .SetSize(AspidDividingLineSizeStyle.Type.Thin))
-                    .AddClass(SectionDividerClass));
+            var card = new VisualElement().AddClass(SectionClass);
+
+            if (title != null)
+                card.AddChild(new Label(title).AddClass(SectionTitleClass))
+                    .AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
+                            .SetTheme(ThemeStyle.Type.Light)
+                            .SetSize(AspidDividingLineSizeStyle.Type.Thin))
+                        .AddClass(SectionDividerClass));
 
             var content = new VisualElement().AddClass(SectionContentClass);
             buildContent(content);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
@@ -25,55 +25,55 @@ namespace Aspid.FastTools.Editors
         /// <summary>
         /// The settings surface stylesheet — dark-branded cards, scoped under <see cref="RootClass"/>.
         /// </summary>
-        public const string StyleSheetPath = "UI/Windows/Aspid-FastTools-Settings";
+        internal const string StyleSheetPath = "UI/Windows/Aspid-FastTools-Settings";
 
-        public const string RootClass = "aspid-fasttools-settings";
+        internal const string RootClass = "aspid-fasttools-settings";
 
         // Canvas pair for pages hosting the surface outside the SerializeReference window (which owns its own
         // dotted canvas): the host fills the page, the background gives the dots their black base.
-        public const string CanvasClass = "aspid-fasttools-settings-canvas";
-        public const string CanvasBackgroundClass = "aspid-fasttools-settings-canvas__background";
-        public const string HeaderClass = "aspid-fasttools-settings__header";
-        public const string HeaderTitleClass = "aspid-fasttools-settings__header-title";
-        public const string HeaderDescriptionClass = "aspid-fasttools-settings__header-description";
-        public const string SectionClass = "aspid-fasttools-settings__section";
-        public const string SectionTitleClass = "aspid-fasttools-settings__section-title";
-        public const string SectionDividerClass = "aspid-fasttools-settings__section-divider";
-        public const string SectionContentClass = "aspid-fasttools-settings__section-content";
-        public const string LegendClass = "aspid-fasttools-settings__legend";
-        public const string LegendItemClass = "aspid-fasttools-settings__legend-item";
-        public const string LegendSwatchClass = "aspid-fasttools-settings__legend-swatch";
-        public const string LegendTextClass = "aspid-fasttools-settings__legend-text";
-        public const string FooterClass = "aspid-fasttools-settings__footer";
+        internal const string CanvasClass = "aspid-fasttools-settings-canvas";
+        internal const string CanvasBackgroundClass = "aspid-fasttools-settings-canvas__background";
+        internal const string HeaderClass = "aspid-fasttools-settings__header";
+        internal const string HeaderTitleClass = "aspid-fasttools-settings__header-title";
+        internal const string HeaderDescriptionClass = "aspid-fasttools-settings__header-description";
+        internal const string SectionClass = "aspid-fasttools-settings__section";
+        internal const string SectionTitleClass = "aspid-fasttools-settings__section-title";
+        internal const string SectionDividerClass = "aspid-fasttools-settings__section-divider";
+        internal const string SectionContentClass = "aspid-fasttools-settings__section-content";
+        internal const string LegendClass = "aspid-fasttools-settings__legend";
+        internal const string LegendItemClass = "aspid-fasttools-settings__legend-item";
+        internal const string LegendSwatchClass = "aspid-fasttools-settings__legend-swatch";
+        internal const string LegendTextClass = "aspid-fasttools-settings__legend-text";
+        internal const string FooterClass = "aspid-fasttools-settings__footer";
 
         // Storage-scope markers, applied by the per-area builders to every settings row.
-        public const string SharedScopeClass = "aspid-fasttools-settings-scope--shared";
-        public const string UserScopeClass = "aspid-fasttools-settings-scope--user";
+        internal const string SharedScopeClass = "aspid-fasttools-settings-scope--shared";
+        internal const string UserScopeClass = "aspid-fasttools-settings-scope--user";
 
         // The stripe element a scoped row mounts on its left edge, and the backplate that carries the row's
         // hover/keyboard-focus fill clear of the stripe (see WithScopeStripe).
-        public const string ScopeStripeClass = "aspid-fasttools-settings__scope-stripe";
-        public const string RowBackplateClass = "aspid-fasttools-settings__row-backplate";
+        internal const string ScopeStripeClass = "aspid-fasttools-settings__scope-stripe";
+        internal const string RowBackplateClass = "aspid-fasttools-settings__row-backplate";
 
         // Keyboard ring markers (the other tabs' nav idiom): the window's Settings tab walks a flat focus ring over
         // the actionable elements; the focused class mirrors each element's hover treatment in USS.
-        public const string NavTargetClass = "aspid-fasttools-settings__nav-target";
-        public const string NavTargetFocusedClass = "aspid-fasttools-settings__nav-target--focused";
+        internal const string NavTargetClass = "aspid-fasttools-settings__nav-target";
+        internal const string NavTargetFocusedClass = "aspid-fasttools-settings__nav-target--focused";
 
         // Row primitives for non-BaseField settings rows (e.g. action rows of buttons), styled to match the field
         // rows. Danger = red hover family for destructive actions; info = blue for per-user-scope actions.
-        public const string RowClass = "aspid-fasttools-settings__row";
-        public const string RowCaptionClass = "aspid-fasttools-settings__row-caption";
-        public const string RowNoteClass = "aspid-fasttools-settings__row-note";
-        public const string ActionClass = "aspid-fasttools-settings__action";
-        public const string ActionDangerClass = "aspid-fasttools-settings__action--danger";
-        public const string ActionInfoClass = "aspid-fasttools-settings__action--info";
+        internal const string RowClass = "aspid-fasttools-settings__row";
+        internal const string RowCaptionClass = "aspid-fasttools-settings__row-caption";
+        internal const string RowNoteClass = "aspid-fasttools-settings__row-note";
+        internal const string ActionClass = "aspid-fasttools-settings__action";
+        internal const string ActionDangerClass = "aspid-fasttools-settings__action--danger";
+        internal const string ActionInfoClass = "aspid-fasttools-settings__action--info";
 
         /// <summary>
         /// Dresses <paramref name="element"/> as a settings surface: loads the shared stylesheet and applies
         /// <see cref="RootClass"/>, under which every rule in the sheet is scoped.
         /// </summary>
-        public static T AsSurface<T>(this T element) where T : VisualElement =>
+        internal static T AsSurface<T>(this T element) where T : VisualElement =>
             element.AddStyleSheetsFromResource(StyleSheetPath).AddClass(RootClass);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Aspid.FastTools.Editors
         /// row itself, so a lit row never touches its stripe. (The stripe also cannot hang outside the row's box in a
         /// margin gutter: some field types, e.g. AspidSwitch and EnumField, clip children to their bounds.)
         /// </summary>
-        public static T WithScopeStripe<T>(this T element, string scopeClass) where T : VisualElement
+        internal static T WithScopeStripe<T>(this T element, string scopeClass) where T : VisualElement
         {
             element.AddClass(scopeClass);
 
@@ -109,7 +109,7 @@ namespace Aspid.FastTools.Editors
         /// footer pinned under it. One definition, so the two Unity-native pages stay pixel-identical to each other
         /// and to the window's Settings tab.
         /// </summary>
-        public static void BuildProviderPage(VisualElement root, AspidSettingsScope scope)
+        internal static void BuildProviderPage(VisualElement root, AspidSettingsScope scope)
         {
             BuildProviderHost(root, surface =>
             {
@@ -128,7 +128,7 @@ namespace Aspid.FastTools.Editors
         /// <paramref name="buildControls"/> fills — the card skips its own title so the page header isn't repeated
         /// right under itself. No reset footer: the per-scope reset lives on the parent aggregate page.
         /// </summary>
-        public static void BuildAreaProviderPage(VisualElement root, string title, Action<VisualElement> buildControls)
+        internal static void BuildAreaProviderPage(VisualElement root, string title, Action<VisualElement> buildControls)
         {
             BuildProviderHost(root, surface =>
             {
@@ -176,7 +176,7 @@ namespace Aspid.FastTools.Editors
         /// page (<see cref="AspidSettingsScope.User"/>) and the Project Settings page
         /// (<see cref="AspidSettingsScope.Shared"/>) render the same control definitions and mirror each other live.
         /// </summary>
-        public static void BuildSurfaceContent(VisualElement container, AspidSettingsScope scope = AspidSettingsScope.All)
+        internal static void BuildSurfaceContent(VisualElement container, AspidSettingsScope scope = AspidSettingsScope.All)
         {
             container.Add(BuildSurfaceHeader(
                 scope,
@@ -229,7 +229,7 @@ namespace Aspid.FastTools.Editors
         /// <paramref name="title"/> skips the header row — the per-area provider pages already carry the area's name
         /// as the page header.
         /// </summary>
-        public static void AddSection(VisualElement container, string title, Action<VisualElement> buildContent)
+        internal static void AddSection(VisualElement container, string title, Action<VisualElement> buildContent)
         {
             var card = new VisualElement().AddClass(SectionClass);
 
@@ -250,7 +250,7 @@ namespace Aspid.FastTools.Editors
         /// row's values or a team-wide toggle's real effect. For the few rows whose caption alone doesn't carry the
         /// stakes; self-explanatory rows stay bare so the notes keep their weight.
         /// </summary>
-        public static Label CreateRowNote(string text) => new Label(text).AddClass(RowNoteClass);
+        internal static Label CreateRowNote(string text) => new Label(text).AddClass(RowNoteClass);
 
         /// <summary>
         /// The one-line key to the rows' scope stripes: each item pairs a dot painted by the same scope class the
@@ -258,7 +258,7 @@ namespace Aspid.FastTools.Editors
         /// the reader meets the key before the first striped row. Only the scopes the surface renders get an item,
         /// so a single-scope page never explains a stripe it doesn't show.
         /// </summary>
-        public static VisualElement BuildScopeLegend(AspidSettingsScope scope = AspidSettingsScope.All)
+        internal static VisualElement BuildScopeLegend(AspidSettingsScope scope = AspidSettingsScope.All)
         {
             var legend = new VisualElement().AddClass(LegendClass);
 
@@ -286,7 +286,7 @@ namespace Aspid.FastTools.Editors
         /// EditorPrefs. Pinned by the caller under its scroll, so the affordance stays reachable however long the
         /// surface grows.
         /// </summary>
-        public static VisualElement BuildResetFooter(AspidSettingsScope scope = AspidSettingsScope.All)
+        internal static VisualElement BuildResetFooter(AspidSettingsScope scope = AspidSettingsScope.All)
         {
             var row = new VisualElement().AddClass(RowClass)
                 .AddChild(new Label("Reset to defaults").AddClass(RowCaptionClass));
@@ -366,7 +366,7 @@ namespace Aspid.FastTools.Editors
         /// (events can't travel as values); the subscription follows the panel lifecycle so a closed surface leaks
         /// nothing and a re-parented one keeps mirroring.
         /// </summary>
-        public static void SyncFromSettings<TControl, TValue>(
+        internal static void SyncFromSettings<TControl, TValue>(
             TControl control,
             Func<TValue> read,
             Action<Action> subscribe,

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Settings/AspidSettingsUI.cs
@@ -33,7 +33,12 @@ namespace Aspid.FastTools.Editors
         // dotted canvas): the host fills the page, the background gives the dots their black base.
         public const string CanvasClass = "aspid-fasttools-settings-canvas";
         public const string CanvasBackgroundClass = "aspid-fasttools-settings-canvas__background";
+        public const string HeaderClass = "aspid-fasttools-settings__header";
+        public const string HeaderTitleClass = "aspid-fasttools-settings__header-title";
+        public const string HeaderDescriptionClass = "aspid-fasttools-settings__header-description";
+        public const string SectionClass = "aspid-fasttools-settings__section";
         public const string SectionTitleClass = "aspid-fasttools-settings__section-title";
+        public const string SectionDividerClass = "aspid-fasttools-settings__section-divider";
         public const string SectionContentClass = "aspid-fasttools-settings__section-content";
         public const string LegendClass = "aspid-fasttools-settings__legend";
         public const string LegendItemClass = "aspid-fasttools-settings__legend-item";
@@ -45,10 +50,21 @@ namespace Aspid.FastTools.Editors
         public const string SharedScopeClass = "aspid-fasttools-settings-scope--shared";
         public const string UserScopeClass = "aspid-fasttools-settings-scope--user";
 
+        // The stripe element a scoped row mounts on its left edge, and the backplate that carries the row's
+        // hover/keyboard-focus fill clear of the stripe (see WithScopeStripe).
+        public const string ScopeStripeClass = "aspid-fasttools-settings__scope-stripe";
+        public const string RowBackplateClass = "aspid-fasttools-settings__row-backplate";
+
+        // Keyboard ring markers (the other tabs' nav idiom): the window's Settings tab walks a flat focus ring over
+        // the actionable elements; the focused class mirrors each element's hover treatment in USS.
+        public const string NavTargetClass = "aspid-fasttools-settings__nav-target";
+        public const string NavTargetFocusedClass = "aspid-fasttools-settings__nav-target--focused";
+
         // Row primitives for non-BaseField settings rows (e.g. action rows of buttons), styled to match the field
         // rows. Danger = red hover family for destructive actions; info = blue for per-user-scope actions.
         public const string RowClass = "aspid-fasttools-settings__row";
         public const string RowCaptionClass = "aspid-fasttools-settings__row-caption";
+        public const string RowNoteClass = "aspid-fasttools-settings__row-note";
         public const string ActionClass = "aspid-fasttools-settings__action";
         public const string ActionDangerClass = "aspid-fasttools-settings__action--danger";
         public const string ActionInfoClass = "aspid-fasttools-settings__action--info";
@@ -59,6 +75,32 @@ namespace Aspid.FastTools.Editors
         /// </summary>
         public static T AsSurface<T>(this T element) where T : VisualElement =>
             element.AddStyleSheetsFromResource(StyleSheetPath).AddClass(RootClass);
+
+        /// <summary>
+        /// Marks a settings row with its storage scope: applies <paramref name="scopeClass"/> and mounts two absolute
+        /// children — the stripe on the row's left edge (a separate element, not a border-left, so it stays a straight
+        /// line whatever the row's corner radius) and, behind the content, the backplate that carries the row's
+        /// hover / keyboard-focus fill. The fill lives on the backplate — inset past the stripe — rather than on the
+        /// row itself, so a lit row never touches its stripe. (The stripe also cannot hang outside the row's box in a
+        /// margin gutter: some field types, e.g. AspidSwitch and EnumField, clip children to their bounds.)
+        /// </summary>
+        public static T WithScopeStripe<T>(this T element, string scopeClass) where T : VisualElement
+        {
+            element.AddClass(scopeClass);
+
+            // hierarchy, not Add: a BaseField routes Add through its (closed) contentContainer, but both mounts
+            // belong on the row element itself — they position absolutely against the row's box. The backplate goes
+            // in at index 0 so it paints behind the row's content; the stripe appends last, over everything.
+            element.hierarchy.Insert(0, new VisualElement()
+                .AddClass(RowBackplateClass)
+                .SetPickingMode(PickingMode.Ignore));
+
+            element.hierarchy.Add(new VisualElement()
+                .AddClass(ScopeStripeClass)
+                .AddClass(scopeClass)
+                .SetPickingMode(PickingMode.Ignore));
+            return element;
+        }
 
         /// <summary>
         /// Composes a whole Unity settings page (Preferences or Project Settings) hosting the branded surface for
@@ -102,7 +144,8 @@ namespace Aspid.FastTools.Editors
         /// </summary>
         public static void BuildSurfaceContent(VisualElement container, AspidSettingsScope scope = AspidSettingsScope.All)
         {
-            container.Add(BuildScopeLegend(scope));
+            container.Add(BuildSurfaceHeader(scope));
+
             AddSection(container, "References", content => SerializeReferenceSettingsUI.BuildControls(content, scope));
 
             // The remaining areas are per-user through and through, so a shared-only surface simply has no sections
@@ -118,23 +161,62 @@ namespace Aspid.FastTools.Editors
         }
 
         /// <summary>
-        /// Appends a titled settings section: a header label over a content container that
-        /// <paramref name="buildContent"/> fills. Each package area (References, Type Selector, Appearance, Welcome)
-        /// gets its own section so a surface reads as one grouped composition from a single definition per area.
+        /// The surface's header — the audit tabs' results-header idiom: an underlined heading over the bare canvas
+        /// (no card), a one-line dim description and, right where the reader starts, the scope legend decoding the
+        /// row stripes below. Only the scopes the surface renders get a legend item, so a single-scope page never
+        /// explains a stripe it doesn't show.
         /// </summary>
-        public static void AddSection(VisualElement container, string title, Action<VisualElement> buildContent)
+        private static VisualElement BuildSurfaceHeader(AspidSettingsScope scope)
         {
-            container.Add(new Label(title).AddClass(SectionTitleClass));
+            var title = new AspidLabel("Settings", AspidLabelPreset.Default
+                    .SetLabelTheme(ThemeStyle.Type.Lightness)
+                    .SetLabelSize(AspidLabelSizeStyle.Type.H4)
+                    .SetLineTheme(ThemeStyle.Type.Dark))
+                .AddClass(HeaderTitleClass);
 
-            var content = new VisualElement().AddClass(SectionContentClass);
-            buildContent(content);
-            container.Add(content);
+            var description = new Label(
+                    "Every FastTools setting in one place. The stripe on each row shows where the value is stored.")
+                .AddClass(HeaderDescriptionClass);
+
+            return new VisualElement().AddClass(HeaderClass)
+                .AddChild(title)
+                .AddChild(description)
+                .AddChild(BuildScopeLegend(scope));
         }
 
         /// <summary>
-        /// The one-line key to the rows' scope stripes: each item pairs a swatch painted by the same scope class the
-        /// rows wear with a caption naming what that colour means for persistence. Only the scopes the surface renders
-        /// get an item, so a single-scope page never explains a stripe it doesn't show.
+        /// Appends a titled settings section: a glass group card — the window's card idiom (the Project References
+        /// group cards, the Welcome sample cards) — with the section title as its static header row, the shared dim
+        /// header divider under it, and a content container that <paramref name="buildContent"/> fills with flat
+        /// settings rows. Each package area (References, Type Selector, Appearance, Welcome) gets its own card so a
+        /// surface reads as one grouped composition from a single definition per area.
+        /// </summary>
+        public static void AddSection(VisualElement container, string title, Action<VisualElement> buildContent)
+        {
+            var card = new VisualElement().AddClass(SectionClass)
+                .AddChild(new Label(title).AddClass(SectionTitleClass))
+                .AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
+                        .SetTheme(ThemeStyle.Type.Light)
+                        .SetSize(AspidDividingLineSizeStyle.Type.Thin))
+                    .AddClass(SectionDividerClass));
+
+            var content = new VisualElement().AddClass(SectionContentClass);
+            buildContent(content);
+            container.Add(card.AddChild(content));
+        }
+
+        /// <summary>
+        /// One dim line under a settings row surfacing what its tooltip would otherwise hide — the meaning of a
+        /// row's values or a team-wide toggle's real effect. For the few rows whose caption alone doesn't carry the
+        /// stakes; self-explanatory rows stay bare so the notes keep their weight.
+        /// </summary>
+        public static Label CreateRowNote(string text) => new Label(text).AddClass(RowNoteClass);
+
+        /// <summary>
+        /// The one-line key to the rows' scope stripes: each item pairs a dot painted by the same scope class the
+        /// rows wear with a caption naming what that colour means for persistence. Lives in the surface header, so
+        /// the reader meets the key before the first striped row. Only the scopes the surface renders get an item,
+        /// so a single-scope page never explains a stripe it doesn't show.
         /// </summary>
         public static VisualElement BuildScopeLegend(AspidSettingsScope scope = AspidSettingsScope.All)
         {
@@ -192,7 +274,9 @@ namespace Aspid.FastTools.Editors
                 row.AddChild(user.AddClass(ActionClass).AddClass(ActionInfoClass).AddClass(UserScopeClass));
             }
 
-            return new VisualElement().AddClass(FooterClass).AddChild(row);
+            // The scope legend lives in the surface header (BuildSurfaceHeader); the footer is just the reset row.
+            return new VisualElement().AddClass(FooterClass)
+                .AddChild(row);
         }
 
         private static void ResetSharedToDefaults()

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/Settings/TypeSelectorSettingsView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/Settings/TypeSelectorSettingsView.cs
@@ -20,7 +20,7 @@ namespace Aspid.FastTools.Types.Editors
                     + "Per-user setting — stored locally, never committed.",
             };
 
-            showFavorites.AddClass(AspidSettingsUI.UserScopeClass);
+            showFavorites.WithScopeStripe(AspidSettingsUI.UserScopeClass);
             showFavorites.RegisterValueChangedCallback(evt => TypeSelectorSettings.ShowFavorites = evt.newValue);
             SyncFromSettings(showFavorites, () => TypeSelectorSettings.ShowFavorites);
             container.Add(showFavorites);
@@ -34,7 +34,7 @@ namespace Aspid.FastTools.Types.Editors
                     + "Per-user setting — stored locally, never committed.",
             };
 
-            capacity.AddClass(AspidSettingsUI.UserScopeClass);
+            capacity.WithScopeStripe(AspidSettingsUI.UserScopeClass);
             capacity.RegisterValueChangedCallback(evt => TypeSelectorSettings.RecentsCapacity = evt.newValue);
             SyncFromSettings(capacity, () => TypeSelectorSettings.RecentsCapacity);
             container.Add(capacity);
@@ -44,7 +44,7 @@ namespace Aspid.FastTools.Types.Editors
 
         private static VisualElement BuildClearRow()
         {
-            var row = new VisualElement().AddClass(AspidSettingsUI.RowClass).AddClass(AspidSettingsUI.UserScopeClass);
+            var row = new VisualElement().AddClass(AspidSettingsUI.RowClass).WithScopeStripe(AspidSettingsUI.UserScopeClass);
             row.tooltip = "The Favorites / Recent lists are saved per user and per project.\n"
                 + "Clearing removes every stored entry, including ones kept for types that don't currently resolve.";
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeSelectorView.Rows.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Selectors/TypeSelectorView.Rows.cs
@@ -21,6 +21,8 @@ namespace Aspid.FastTools.Types.Editors
         private const string ItemCheckClass = BlockClass + "__item-check";
         private const string ItemCountClass = BlockClass + "__item-count";
         private const string ItemArrowClass = BlockClass + "__item-arrow";
+        private const string ItemDividerClass = BlockClass + "__item-divider";
+        private const string ItemContentClass = BlockClass + "__item-content";
         private const string RowAfterPinnedModifier = BlockClass + "__item--after-pinned";
         private const string SectionTitleClass = BlockClass + "__section-title";
         private const string FavoriteToggleClass = BlockClass + "__favorite-toggle";
@@ -38,6 +40,14 @@ namespace Aspid.FastTools.Types.Editors
 
         private VisualElement CreateListItem()
         {
+            // The pinned-block divider rides inside the row shell (absolutely positioned in its extra top zone,
+            // shown only via --after-pinned) rather than as a border: a border-top would curve along the content's
+            // rounded corners. All visuals live on the content wrapper pinned to the shell's bottom — see the
+            // stylesheet's Item section for why the shell itself must stay bare.
+            var divider = new VisualElement()
+                .AddClass(ItemDividerClass)
+                .SetPickingMode(PickingMode.Ignore);
+
             var icon = new Image()
                 .AddClass(ItemIconClass)
                 .SetPickingMode(PickingMode.Ignore);
@@ -64,8 +74,8 @@ namespace Aspid.FastTools.Types.Editors
             var arrow = new Label("›")
                 .AddClass(ItemArrowClass);
 
-            var row = new VisualElement()
-                .AddClass(ItemClass)
+            var content = new VisualElement()
+                .AddClass(ItemContentClass)
                 .AddChild(icon)
                 .AddChild(glyph)
                 .AddChild(label)
@@ -73,6 +83,11 @@ namespace Aspid.FastTools.Types.Editors
                 .AddChild(count)
                 .AddChild(favorite)
                 .AddChild(arrow);
+
+            var row = new VisualElement()
+                .AddClass(ItemClass)
+                .AddChild(divider)
+                .AddChild(content);
 
             row.RegisterCallback<ClickEvent>(OnRowClicked);
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/AspidGradientButton.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidGradientButton/AspidGradientButton.cs
@@ -25,6 +25,23 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         private readonly AspidGradientButtonColorsStyle _colors;
 
         private Texture2D _gradientTexture;
+        private bool _highlighted;
+        private bool _hovered;
+
+        /// <summary>
+        /// Shows the hover visual (accent overlay + accent-tinted labels) programmatically, for host-driven states
+        /// like a keyboard focus ring.
+        /// </summary>
+        /// <remarks>Mouse hover and this flag compose: the visual stays on while either is active.</remarks>
+        internal bool Highlighted
+        {
+            get => _highlighted;
+            set
+            {
+                _highlighted = value;
+                ApplyHoverVisual(_highlighted || _hovered);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the button label text.
@@ -189,16 +206,22 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
 
         private void OnMouseEnter(MouseEnterEvent _)
         {
-            _overlay.SetTarget(1f);
-            _label.style.color = _colors.Accent;
-            _trailingLabel.style.color = _colors.Accent;
+            _hovered = true;
+            ApplyHoverVisual(true);
         }
 
         private void OnMouseLeave(MouseLeaveEvent _)
         {
-            _overlay.SetTarget(0f);
-            _label.style.color = StyleKeyword.Null;
-            _trailingLabel.style.color = StyleKeyword.Null;
+            _hovered = false;
+            ApplyHoverVisual(_highlighted);
+        }
+
+        private void ApplyHoverVisual(bool on)
+        {
+            _overlay.SetTarget(on ? 1f : 0f);
+            var labelColor = on ? new StyleColor(_colors.Accent) : new StyleColor(StyleKeyword.Null);
+            _label.style.color = labelColor;
+            _trailingLabel.style.color = labelColor;
         }
 
         private void OnAttachToPanel(AttachToPanelEvent _)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidWindowFooters/AspidWindowFooter.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidWindowFooters/AspidWindowFooter.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
+using Aspid.FastTools.UIElements;
 using System.Text.RegularExpressions;
 using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 
@@ -28,6 +29,7 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         private const string RootClass = "aspid-fasttools-window-footer";
         private const string RowClass = RootClass + "__row";
         private const string VersionClass = RootClass + "__version";
+        private const string KeysClass = RootClass + "__keys";
         private const string LinkClass = RootClass + "__link";
 
         /// <summary>
@@ -51,8 +53,15 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
             var githubLabel = new Label("GitHub").AddClass(LinkClass);
             githubLabel.AddManipulator(new Clickable(() => Application.OpenURL(GitHubUrl)));
 
+            // The keyboard-ring key: every hosting window drives its tabs with the same ring, and the ring is
+            // otherwise invisible until the first arrow press. Absolutely centred over the row (see the USS) and
+            // click-transparent, so the version / GitHub links keep their edges and their hits.
+            var keysHint = new Label("↑↓ navigate   ⏎ activate   esc dismiss")
+                .AddClass(KeysClass)
+                .SetPickingMode(PickingMode.Ignore);
+
             var row = new VisualElement().AddClass(RowClass);
-            row.AddChild(versionLabel).AddChild(githubLabel);
+            row.AddChild(versionLabel).AddChild(keysHint).AddChild(githubLabel);
 
             this.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default.SetTheme(ThemeStyle.Type.Darkness)))
                 .AddChild(row);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidWindowFooters/AspidWindowFooter.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/Components/AspidWindowFooters/AspidWindowFooter.cs
@@ -35,7 +35,11 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
         /// <summary>
         /// Builds the footer, reads the package version, and wires the version and GitHub links.
         /// </summary>
-        public AspidWindowFooter()
+        public AspidWindowFooter() : this(showKeysHint: true) { }
+
+        /// <param name="showKeysHint">Whether to show the centred keyboard-ring key. Hosts without the ring
+        /// (the Unity-native settings pages) pass <c>false</c> so the footer never promises keys that do nothing.</param>
+        public AspidWindowFooter(bool showKeysHint)
         {
             this.AddAspidThemeStyleSheets()
                 .AddStyleSheetsFromResource(StyleSheetPath)
@@ -53,15 +57,18 @@ namespace Aspid.FastTools.UIElements.Editors.Internal
             var githubLabel = new Label("GitHub").AddClass(LinkClass);
             githubLabel.AddManipulator(new Clickable(() => Application.OpenURL(GitHubUrl)));
 
+            var row = new VisualElement().AddClass(RowClass);
+            row.AddChild(versionLabel);
+
             // The keyboard-ring key: every hosting window drives its tabs with the same ring, and the ring is
             // otherwise invisible until the first arrow press. Absolutely centred over the row (see the USS) and
             // click-transparent, so the version / GitHub links keep their edges and their hits.
-            var keysHint = new Label("↑↓ navigate   ⏎ activate   esc dismiss")
-                .AddClass(KeysClass)
-                .SetPickingMode(PickingMode.Ignore);
+            if (showKeysHint)
+                row.AddChild(new Label("↑↓ navigate   ⏎ activate   esc dismiss")
+                    .AddClass(KeysClass)
+                    .SetPickingMode(PickingMode.Ignore));
 
-            var row = new VisualElement().AddClass(RowClass);
-            row.AddChild(versionLabel).AddChild(keysHint).AddChild(githubLabel);
+            row.AddChild(githubLabel);
 
             this.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default.SetTheme(ThemeStyle.Type.Darkness)))
                 .AddChild(row);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/HoverSweep.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/HoverSweep.cs
@@ -1,0 +1,38 @@
+using System;
+using UnityEngine.UIElements;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.UIElements.Editors.Internal
+{
+    /// <summary>
+    /// Wires the window cards' hover-sweep idiom: a flat header button whose accent underline sweep is a sibling (so
+    /// USS <c>:hover</c> can't reach it) mirrors its hover onto an ancestor card modifier class the sweep rule
+    /// listens to. Composed with <see cref="NavRing"/> — while the button is the nav-focused ring member the sweep
+    /// stays lit after the mouse leaves, matching the programmatic hover the ring paints — so keyboard focus and mouse
+    /// hover render identically. Shared by the Welcome sample cards and both References audit tabs so the composition
+    /// (which ancestor carries the modifier, and the keep-lit-while-focused guard) can't drift between them.
+    /// </summary>
+    internal static class HoverSweep
+    {
+        /// <summary>
+        /// Mirrors <paramref name="button"/>'s mouse hover onto the modifier <paramref name="hoverClass"/> on the card
+        /// resolved by <paramref name="resolveCard"/> — resolved at event time, so it works whether the card is a
+        /// captured local or the button's live parent. The modifier is kept lit while <paramref name="isNavFocused"/>
+        /// reports the button as the focus-ring member, so a mouse pass over a keyboard-focused card never
+        /// half-extinguishes its sweep.
+        /// </summary>
+        public static void MirrorHover(
+            VisualElement button,
+            Func<VisualElement> resolveCard,
+            string hoverClass,
+            Func<bool> isNavFocused)
+        {
+            button.RegisterCallback<MouseEnterEvent>(_ => resolveCard()?.AddToClassList(hoverClass));
+            button.RegisterCallback<MouseLeaveEvent>(_ =>
+            {
+                if (isNavFocused()) return;
+                resolveCard()?.RemoveFromClassList(hoverClass);
+            });
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/HoverSweep.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/HoverSweep.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7679e58536d5e4178af27c895d1ae38f

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/NavRing.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/NavRing.cs
@@ -1,0 +1,231 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.FastTools.UIElements.Editors.Internal
+{
+    /// <summary>
+    /// The window's shared keyboard focus ring: one flat list of actionable elements walked with ↑/↓, activated with
+    /// Enter and dropped with Escape; sliders take ←/→ (Adjust) and removable rows take Delete/Backspace (Remove). The
+    /// window views (Welcome, Asset / Project References, Settings) all drive from this one ring so their keyboard
+    /// behaviour stays identical — each supplies only how a focused member is painted, how to scroll it into view,
+    /// and (optionally) when the ring is suspended because its own picker owns the keyboard.
+    /// </summary>
+    /// <remarks>
+    /// The ring never moves real keyboard focus onto its members — the host element keeps focus and the ring only
+    /// paints a highlight — so a member hidden by a collapsed container is skipped while walking and never activated,
+    /// keeping an off-screen member out of keyboard reach.
+    /// </remarks>
+    internal sealed class NavRing
+    {
+        /// <summary>
+        /// One ring member: the element plus what Enter (<see cref="Activate"/>), ←/→ (<see cref="Adjust"/>, sliders)
+        /// and Delete/Backspace (<see cref="Remove"/>, removable rows) do to it. <see cref="Adjust"/> / <see cref="Remove"/>
+        /// are <see langword="null"/> for members that don't take them.
+        /// </summary>
+        internal readonly struct Target
+        {
+            public readonly VisualElement Element;
+            public readonly Action Activate;
+            public readonly Action<int> Adjust;
+            public readonly Action Remove;
+
+            public Target(VisualElement element, Action activate, Action<int> adjust, Action remove)
+            {
+                Element = element;
+                Activate = activate;
+                Adjust = adjust;
+                Remove = remove;
+            }
+        }
+
+        private readonly List<Target> _targets = new();
+        private int _index = -1;
+
+        private readonly VisualElement _host;
+        private readonly string _navTargetClass;
+        private readonly Action<VisualElement, bool> _paint;
+        private readonly Action<VisualElement> _scrollTo;
+        private readonly Func<bool> _isSuspended;
+
+        /// <summary>
+        /// Wires the ring onto <paramref name="host"/>: the host grabs keyboard focus on attach (so keys reach the ring
+        /// before anything is highlighted) and every <see cref="KeyDownEvent"/> bubbling to it is handled here.
+        /// </summary>
+        /// <param name="host">The element that holds keyboard focus and receives the ring's key events.</param>
+        /// <param name="navTargetClass">USS class applied to every registered member (the view's <c>__nav-target</c>).</param>
+        /// <param name="paint">Lights (<see langword="true"/>) or clears (<see langword="false"/>) a member's focus treatment.</param>
+        /// <param name="scrollTo">Scrolls a member into view when focus lands on it; may be <see langword="null"/>.</param>
+        /// <param name="isSuspended">When it returns <see langword="true"/> the ring ignores all keys (e.g. an open picker owns them); may be <see langword="null"/>.</param>
+        public NavRing(
+            VisualElement host,
+            string navTargetClass,
+            Action<VisualElement, bool> paint,
+            Action<VisualElement> scrollTo = null,
+            Func<bool> isSuspended = null)
+        {
+            _host = host;
+            _navTargetClass = navTargetClass;
+            _paint = paint;
+            _scrollTo = scrollTo;
+            _isSuspended = isSuspended;
+
+            host.focusable = true;
+            host.RegisterCallback<KeyDownEvent>(OnKeyDown);
+            host.RegisterCallback<AttachToPanelEvent>(_ => host.schedule.Execute(() => host.Focus()));
+        }
+
+        /// <summary>The highlighted member's index, or -1 when nothing is highlighted.</summary>
+        public int Index => _index;
+
+        /// <summary>The number of registered members.</summary>
+        public int Count => _targets.Count;
+
+        /// <summary>Whether <paramref name="element"/> is the currently highlighted member.</summary>
+        public bool IsFocused(VisualElement element) =>
+            _index >= 0 && _index < _targets.Count && _targets[_index].Element == element;
+
+        /// <summary>
+        /// Appends a member in visual order. <paramref name="adjust"/> handles ←/→ (sliders); <paramref name="remove"/>
+        /// handles Delete/Backspace (removable rows). EnableInClassList (not Add), so a member re-registered on a ring
+        /// rebuild never stacks the class twice.
+        /// </summary>
+        public void Register(VisualElement element, Action activate, Action<int> adjust = null, Action remove = null)
+        {
+            element.EnableInClassList(_navTargetClass, true);
+            _targets.Add(new Target(element, activate, adjust, remove));
+        }
+
+        /// <summary>Clears the highlight and drops every member — a full ring rebuild follows with fresh <see cref="Register"/> calls.</summary>
+        public void Clear()
+        {
+            ClearFocus();
+            _targets.Clear();
+        }
+
+        /// <summary>Drops the highlight without touching the member list.</summary>
+        public void ClearFocus()
+        {
+            if (_index >= 0 && _index < _targets.Count)
+                _paint(_targets[_index].Element, false);
+
+            _index = -1;
+        }
+
+        /// <summary>
+        /// Highlights the member at <paramref name="index"/>, scrolling it into view unless <paramref name="scrollTo"/>
+        /// is <see langword="false"/> — used when restoring a highlight after a rebuild, where a scroll would be jarring.
+        /// </summary>
+        public void Focus(int index, bool scrollTo = true)
+        {
+            if (_index == index) return;
+
+            ClearFocus();
+            _index = index;
+
+            var element = _targets[index].Element;
+            _paint(element, true);
+            if (scrollTo) _scrollTo?.Invoke(element);
+        }
+
+        private void OnKeyDown(KeyDownEvent evt)
+        {
+            // A view whose own picker (or any modal child) owns the keyboard suspends the ring entirely.
+            if (_isSuspended is not null && _isSuspended()) return;
+
+            // A control being edited owns the keyboard: arrows/Enter inside a slider or text field adjust and commit
+            // there. Escape still clears below — an editing control never keeps focus past Escape.
+            if (IsEditingControlFocused()) return;
+
+            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
+            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
+
+            switch (evt.keyCode)
+            {
+                case KeyCode.DownArrow:
+                    Move(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.UpArrow:
+                    Move(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.LeftArrow when _index >= 0 && _targets[_index].Adjust is { } decrease:
+                    decrease(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.RightArrow when _index >= 0 && _targets[_index].Adjust is { } increase:
+                    increase(+1);
+                    evt.StopPropagation();
+                    break;
+
+                // Guarded on visibility too: a member hidden inside a collapsed container must not be activatable even
+                // if the highlight was left on it (e.g. the card was collapsed by mouse after the keyboard focused it).
+                case KeyCode.Return or KeyCode.KeypadEnter
+                    when _index >= 0 && _targets[_index].Activate is { } activate && IsVisible(_targets[_index].Element):
+                    activate();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Delete or KeyCode.Backspace when _index >= 0 && _targets[_index].Remove is { } remove:
+                    remove();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Escape when _index >= 0:
+                    ClearFocus();
+                    evt.StopPropagation();
+                    break;
+            }
+        }
+
+        // First press (nothing highlighted) lands on the first visible member whichever arrow is hit; after that the
+        // ring steps to the next visible member in the arrow's direction, skipping members hidden inside a collapsed
+        // container, and clamps (does not wrap) when no visible member remains that way.
+        private void Move(int delta)
+        {
+            if (_targets.Count == 0) return;
+
+            var start = _index < 0 ? 0 : _index + delta;
+            var step = _index < 0 ? +1 : delta;
+
+            for (var i = start; i >= 0 && i < _targets.Count; i += step)
+            {
+                if (!IsVisible(_targets[i].Element)) continue;
+                Focus(i);
+                return;
+            }
+        }
+
+        private bool IsEditingControlFocused()
+        {
+            if (_host.focusController?.focusedElement is not VisualElement focused) return false;
+
+            for (var element = focused; element is not null; element = element.parent)
+            {
+                if (element is ITextEdition or SliderInt) return true;
+                // Button derives from TextElement, so a focused ring button (e.g. a Settings reset button) must not be
+                // mistaken for a text-editing control — that would silently kill the ring while the button holds focus.
+                if (element is TextElement and not Button) return true;
+            }
+
+            return false;
+        }
+
+        // A member is navigable only while it is actually on screen: a collapsed document band sets its body's
+        // display to None, so its descendant members fail this ancestor walk and drop out of the ring.
+        private static bool IsVisible(VisualElement element)
+        {
+            for (var e = element; e is not null; e = e.parent)
+                if (e.resolvedStyle.display == DisplayStyle.None)
+                    return false;
+
+            return true;
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/NavRing.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/VisualElements/Internal/NavRing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81628a8c04e124485b29a1df1587f10a

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeSettingsUI.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeSettingsUI.cs
@@ -24,7 +24,7 @@ namespace Aspid.FastTools.Editors
                     + "Turning it off suppresses every future auto-show; Tools → Aspid 🐍 → FastTools → Welcome keeps working.\n"
                     + "Per-user setting — stored locally, never committed.",
             };
-            autoShow.AddClass(AspidSettingsUI.UserScopeClass);
+            autoShow.WithScopeStripe(AspidSettingsUI.UserScopeClass);
             autoShow.RegisterValueChangedCallback(evt => WelcomeSettings.AutoShowEnabled = evt.newValue);
             SyncFromSettings(autoShow, () => WelcomeSettings.AutoShowEnabled);
             container.Add(autoShow);

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
@@ -37,11 +37,14 @@ namespace Aspid.FastTools.Editors
         private const string ToastVisibleClass = "aspid-fasttools-welcome__toast--visible";
 
         private const string SampleCardClass = "aspid-fasttools-welcome__sample";
-        private const string SampleBodyClass = "aspid-fasttools-welcome__sample-body";
+        private const string SampleHeaderHoverClass = "aspid-fasttools-welcome__sample--header-hover";
+        private const string SampleHeaderRowClass = "aspid-fasttools-welcome__sample-header-row";
         private const string SampleHeaderClass = "aspid-fasttools-welcome__sample-header";
+        private const string SampleHeaderRemoveClass = "aspid-fasttools-welcome__sample-header--remove";
         private const string SampleTitleClass = "aspid-fasttools-welcome__sample-title";
-        private const string SampleActionClass = "aspid-fasttools-welcome__sample-action";
         private const string SampleDividerClass = "aspid-fasttools-welcome__sample-divider";
+        private const string SampleSweepClass = "aspid-fasttools-welcome__sample-sweep";
+        private const string SampleSweepRemoveClass = "aspid-fasttools-welcome__sample-sweep--remove";
         private const string SampleDescriptionClass = "aspid-fasttools-welcome__sample-description";
 
         private Label _toast;
@@ -61,10 +64,6 @@ namespace Aspid.FastTools.Editors
             }
 
             tree.CloneTree(this);
-
-            // The host window already paints one shared dotted canvas behind every tab; drop the Welcome UXML's
-            // own background so the tabs read over a single continuous canvas instead of a doubled-up layer.
-            this.Q<AspidAnimatedDotsBackground>()?.RemoveFromHierarchy();
 
             _toast = this.Q<Label>(ToastName);
             if (_toast != null)
@@ -170,10 +169,10 @@ namespace Aspid.FastTools.Editors
         private void AddUpmSamples(PackageInfo package)
         {
             foreach (var sample in Sample.FindByPackage(package.name, package.version))
-                _samplesList.Add(CreateUpmSampleButton(sample));
+                _samplesList.Add(CreateUpmSampleCard(sample));
         }
 
-        private AspidGradientButton CreateUpmSampleButton(Sample sample)
+        private VisualElement CreateUpmSampleCard(Sample sample)
         {
             var displayName = sample.displayName;
             var description = sample.description;
@@ -181,31 +180,11 @@ namespace Aspid.FastTools.Editors
 
             if (sample.isImported)
             {
-                // The sample already lives under Assets — re-importing overwrites it, so mirror the Package
-                // Manager and confirm before clobbering any local edits the user may have made to the copy.
-                return CreateSampleCard(displayName, description, "Reimport  ▼", evt =>
-                {
-                    var pointer = GetMousePosition(evt);
-                    var target = ToProjectRelativePath(captured.importPath);
-
-                    var confirmed = EditorUtility.DisplayDialog(
-                        $"Reimport “{displayName}”",
-                        $"This overwrites “{target}”, discarding any local changes to the sample. Continue?",
-                        "Reimport",
-                        "Cancel");
-
-                    if (!confirmed) return;
-
-                    if (!captured.Import(Sample.ImportOptions.OverridePreviousImports | Sample.ImportOptions.HideImportWindow))
-                    {
-                        ShowToast($"Failed to reimport “{displayName}”", pointer);
-                        return;
-                    }
-
-                    AssetDatabase.Refresh();
-                    ShowToast($"“{displayName}” reimported into Assets/Samples", pointer);
-                    RebuildSamplesList();
-                });
+                // An imported sample's one action is taking the copy back out — deletion is confirmed and the
+                // sample stays reimportable right after, so the direct verb replaces a Reimport/Remove menu.
+                return CreateSampleCard(displayName, description, "Remove",
+                    evt => RemoveSample(captured, displayName, GetMousePosition(evt)),
+                    SampleHeaderRemoveClass);
             }
 
             return CreateSampleCard(displayName, description, "Import  ▼", evt =>
@@ -225,70 +204,81 @@ namespace Aspid.FastTools.Editors
         }
 
         /// <summary>
-        /// Builds a two-line sample row: the display name on the first line, the package.json description (when
-        /// present) wrapping below it, and the <paramref name="trailingText"/> action pinned to the right edge.
-        /// The name + description live in a flex-grow leading column so the trailing action stays right-aligned;
-        /// the <see cref="SampleCardClass"/> USS rule relaxes the gradient button's fixed single-line height.
+        /// Builds a sample card in the References group-card idiom: a glass box whose whole header row is one flat
+        /// clickable button (the display name on the left, the <paramref name="actionText"/> verb pinned to the
+        /// right, an accent glow on hover), with the package.json description (when present) wrapping below.
         /// </summary>
-        private AspidGradientButton CreateSampleCard(string displayName, string description, string actionText, Action<EventBase> onClick)
+        private static VisualElement CreateSampleCard(
+            string displayName,
+            string description,
+            string actionText,
+            Action<EventBase> onClick,
+            string headerModifierClass = null)
         {
-            var card = new AspidGradientButton(string.Empty, onClick)
+            var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(SampleCardClass);
 
-            var body = new VisualElement()
-                .AddClass(SampleBodyClass)
-                .SetPickingMode(PickingMode.Ignore);
+            var action = new AspidGradientButton(actionText, onClick)
+                .AddClass(SampleHeaderClass);
+            if (!string.IsNullOrEmpty(headerModifierClass))
+                action.AddClass(headerModifierClass);
+
+            // The sweep sits outside the button (riding the divider below), so USS :hover can't reach it —
+            // the button mirrors its hover onto a card modifier the sweep rule listens to instead.
+            action.RegisterCallback<MouseEnterEvent>(_ => card.AddToClassList(SampleHeaderHoverClass));
+            action.RegisterCallback<MouseLeaveEvent>(_ => card.RemoveFromClassList(SampleHeaderHoverClass));
+            action.AddLeadingContent(new Label(displayName)
+                .AddClass(SampleTitleClass)
+                .SetPickingMode(PickingMode.Ignore));
 
             var header = new VisualElement()
-                .AddClass(SampleHeaderClass)
-                .SetPickingMode(PickingMode.Ignore);
+                .AddClass(SampleHeaderRowClass)
+                .AddChild(action);
 
-            var title = new Label(displayName)
-                .AddClass(SampleTitleClass)
-                .SetPickingMode(PickingMode.Ignore);
-            header.Add(title);
-
-            Label action = null;
-            if (!string.IsNullOrEmpty(actionText))
-            {
-                action = new Label(actionText)
-                    .AddClass(SampleActionClass)
-                    .SetPickingMode(PickingMode.Ignore);
-                header.Add(action);
-            }
-
-            body.Add(header);
+            card.AddChild(header);
 
             if (!string.IsNullOrEmpty(description))
             {
-                body.Add(new AspidDividingLine(AspidDividingLinePreset.Default
+                card.AddChild(new AspidDividingLine(AspidDividingLinePreset.Default
                         .SetTheme(ThemeStyle.Type.Light)
                         .SetSize(AspidDividingLineSizeStyle.Type.Thin))
-                    .AddClass(SampleDividerClass)
-                    .SetPickingMode(PickingMode.Ignore));
+                    .AddClass(SampleDividerClass));
 
-                body.Add(new Label(description)
-                    .AddClass(SampleDescriptionClass)
-                    .SetPickingMode(PickingMode.Ignore));
+                // The accent sweep riding the divider: a hairline that scales in from the left while the card
+                // is hovered (pure USS :hover, see __sample-sweep). Red on a Remove card, brand green otherwise.
+                var sweep = new VisualElement().AddClass(SampleSweepClass);
+                if (headerModifierClass == SampleHeaderRemoveClass)
+                    sweep.AddClass(SampleSweepRemoveClass);
+                card.AddChild(sweep);
+
+                card.AddChild(new Label(description)
+                    .AddClass(SampleDescriptionClass));
             }
 
-            card.AddLeadingContent(body);
-            card.FillWithLeadingContent();
-
-            // The action/title now live in the leading content instead of the button's own labels, so the
-            // button's built-in hover recolor no longer reaches them — mirror it here against the accent color.
-            card.RegisterCallback<MouseEnterEvent>(_ =>
-            {
-                title.style.color = card.Accent;
-                if (action is not null) action.style.color = card.Accent;
-            });
-            card.RegisterCallback<MouseLeaveEvent>(_ =>
-            {
-                title.style.color = StyleKeyword.Null;
-                if (action is not null) action.style.color = StyleKeyword.Null;
-            });
-
             return card;
+        }
+
+        private void RemoveSample(Sample sample, string displayName, Vector2 pointer)
+        {
+            var target = ToProjectRelativePath(sample.importPath);
+
+            var confirmed = EditorUtility.DisplayDialog(
+                $"Remove “{displayName}”",
+                $"This deletes “{target}” from the project, discarding any local changes to the copy. Continue?",
+                "Remove",
+                "Cancel");
+
+            if (!confirmed) return;
+
+            if (!AssetDatabase.DeleteAsset(target))
+            {
+                ShowToast($"Failed to remove “{displayName}”", pointer);
+                return;
+            }
+
+            AssetDatabase.Refresh();
+            ShowToast($"“{displayName}” removed from Assets/Samples", pointer);
+            RebuildSamplesList();
         }
 
         private void AddLocalSamples()
@@ -298,7 +288,7 @@ namespace Aspid.FastTools.Editors
                 var fileName = Path.GetFileName(subfolder);
                 if (string.IsNullOrEmpty(fileName)) continue;
 
-                _samplesList.Add(CreateSampleCard(fileName, null, string.Empty, evt =>
+                _samplesList.Add(CreateSampleCard(fileName, null, "Show", evt =>
                 {
                     PingAsset(subfolder);
                     ShowToast($"“{fileName}” selected in the Project window", GetMousePosition(evt));

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
@@ -67,9 +67,8 @@ namespace Aspid.FastTools.Editors
         private IVisualElementScheduledItem _toastHide;
 
         // Keyboard navigation: one flat focus ring over the sample cards' header buttons in list order (hero
-        // links stay mouse-only). -1 means nothing is highlighted.
-        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
-        private int _navIndex = -1;
+        // links stay mouse-only), shared with the other window tabs.
+        private readonly NavRing _ring;
 
         public WelcomeView()
         {
@@ -96,83 +95,29 @@ namespace Aspid.FastTools.Editors
 
             _scroll = this.Q<ScrollView>(ScrollName);
 
+            // The shared keyboard ring: the view holds focus (grabbed on attach) so keys reach it before anything is
+            // highlighted. Built before PopulateSamples, which registers the sample cards onto it.
+            _ring = new NavRing(
+                host: this,
+                navTargetClass: NavTargetClass,
+                paint: PaintNavFocus,
+                scrollTo: element => _scroll?.ScrollTo(element));
+
             PopulateSamples(this);
             SetUpLogoLink(this);
             SetUpHeroLinks(this);
-
-            // Arrow-key navigation: the view holds keyboard focus (grabbed on attach) so key events reach
-            // OnNavKeyDown even before anything is highlighted; events from focused descendants bubble here too.
-            focusable = true;
-            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
-            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
         }
 
         // ---------------------------------------------------------------------------------------------------------
         // Keyboard navigation
         // ---------------------------------------------------------------------------------------------------------
 
-        private void OnNavKeyDown(KeyDownEvent evt)
+        // Sample headers paint their hover in code (accent overlay + tinted labels + divider sweep), so keyboard focus
+        // drives that same programmatic hover instead of a USS focused class.
+        private static void PaintNavFocus(VisualElement element, bool on)
         {
-            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
-            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
-
-            switch (evt.keyCode)
-            {
-                case KeyCode.DownArrow:
-                    MoveNavFocus(+1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.UpArrow:
-                    MoveNavFocus(-1);
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
-                    _navTargets[_navIndex].Activate();
-                    evt.StopPropagation();
-                    break;
-
-                case KeyCode.Escape when _navIndex >= 0:
-                    ClearNavFocus();
-                    evt.StopPropagation();
-                    break;
-            }
-        }
-
-        // First press (nothing highlighted) lands on the first sample whichever arrow is hit; after that the
-        // ring clamps at both ends instead of wrapping.
-        private void MoveNavFocus(int delta)
-        {
-            if (_navTargets.Count == 0) return;
-            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
-        }
-
-        private void SetNavFocus(int index, bool scrollTo = true)
-        {
-            if (_navIndex == index) return;
-
-            ClearNavFocus();
-            _navIndex = index;
-
-            var element = _navTargets[index].Element;
-            // Sample headers paint their hover in code (accent overlay + tinted labels), so keyboard focus
-            // drives that same programmatic hover instead of a USS focused class.
-            if (element is AspidGradientButton button) button.Highlighted = true;
-            SetHeaderSweep(element, on: true);
-            if (scrollTo) _scroll?.ScrollTo(element);
-        }
-
-        private void ClearNavFocus()
-        {
-            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
-            {
-                var element = _navTargets[_navIndex].Element;
-                if (element is AspidGradientButton button) button.Highlighted = false;
-                SetHeaderSweep(element, on: false);
-            }
-
-            _navIndex = -1;
+            if (element is AspidGradientButton button) button.Highlighted = on;
+            SetHeaderSweep(element, on);
         }
 
         // A focused sample header also lights its card's divider sweep — the same card-level hover mirror the
@@ -187,20 +132,6 @@ namespace Aspid.FastTools.Editors
                 ancestor.EnableInClassList(SampleHeaderHoverClass, on);
                 return;
             }
-        }
-
-        // The samples list is rebuilt after every Import/Remove, so the ring is rebuilt with it: sample headers
-        // in list order. Hero links are deliberately not in the ring — they are mouse-only decoration.
-        private void ResetNavTargets()
-        {
-            ClearNavFocus();
-            _navTargets.Clear();
-        }
-
-        private void RegisterNavTarget(VisualElement element, Action activate)
-        {
-            element.AddToClassList(NavTargetClass);
-            _navTargets.Add((element, activate));
         }
 
         private static void SetUpLogoLink(VisualElement root)
@@ -294,17 +225,17 @@ namespace Aspid.FastTools.Editors
             // An Import/Remove triggered from the keyboard rebuilds the very ring it came from — put the
             // highlight back on the same slot (clamped: Remove may shrink nothing, but stay safe) so the
             // keyboard flow continues from where it acted.
-            var keepIndex = _navIndex;
+            var keepIndex = _ring.Index;
 
             _samplesList.Clear();
-            ResetNavTargets();
+            _ring.Clear();
 
             var package = PackageInfo.FindForPackageName(PackageName);
             if (package is not null) AddUpmSamples(package);
             else if (AssetDatabase.IsValidFolder(SamplesPath)) AddLocalSamples();
 
-            if (keepIndex >= 0 && _navTargets.Count > 0)
-                SetNavFocus(Mathf.Min(keepIndex, _navTargets.Count - 1), scrollTo: false);
+            if (keepIndex >= 0 && _ring.Count > 0)
+                _ring.Focus(Mathf.Min(keepIndex, _ring.Count - 1), scrollTo: false);
         }
 
         private void AddUpmSamples(PackageInfo package)
@@ -364,14 +295,14 @@ namespace Aspid.FastTools.Editors
 
             var action = new AspidGradientButton(actionText, evt => onClick(GetMousePosition(evt)))
                 .AddClass(SampleHeaderClass);
-            RegisterNavTarget(action, () => onClick(action.worldBound.center));
+            _ring.Register(action, () => onClick(action.worldBound.center));
             if (imported == true)
                 action.AddClass(SampleHeaderRemoveClass);
 
-            // The sweep sits outside the button (riding the divider below), so USS :hover can't reach it —
-            // the button mirrors its hover onto a card modifier the sweep rule listens to instead.
-            action.RegisterCallback<MouseEnterEvent>(_ => card.AddToClassList(SampleHeaderHoverClass));
-            action.RegisterCallback<MouseLeaveEvent>(_ => card.RemoveFromClassList(SampleHeaderHoverClass));
+            // The sweep sits outside the button (riding the divider below), so USS :hover can't reach it — the button
+            // mirrors its hover onto a card modifier the sweep rule listens to, staying lit while the card is the
+            // nav-focused ring member (else a mouse pass over a keyboard-focused card would half-extinguish it).
+            HoverSweep.MirrorHover(action, () => card, SampleHeaderHoverClass, () => _ring.IsFocused(action));
 
             var info = new VisualElement()
                 .AddClass(SampleInfoClass)

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
@@ -49,7 +49,8 @@ namespace Aspid.FastTools.Editors
         private const string SampleHeaderRemoveClass = "aspid-fasttools-welcome__sample-header--remove";
         private const string SampleInfoClass = "aspid-fasttools-welcome__sample-info";
         private const string SampleTitleClass = "aspid-fasttools-welcome__sample-title";
-        private const string SampleImportDotClass = "aspid-fasttools-welcome__sample-import-dot";
+        private const string SampleStateDotClass = "aspid-fasttools-welcome__sample-state-dot";
+        private const string SampleStateDotImportedClass = "aspid-fasttools-welcome__sample-state-dot--imported";
         private const string SampleDividerClass = "aspid-fasttools-welcome__sample-divider";
         private const string SampleSweepClass = "aspid-fasttools-welcome__sample-sweep";
         private const string SampleSweepRemoveClass = "aspid-fasttools-welcome__sample-sweep--remove";
@@ -229,9 +230,9 @@ namespace Aspid.FastTools.Editors
         /// Builds a sample card in the References group-card idiom: a glass box whose whole header row is one flat
         /// clickable button (the display name on the left, the <paramref name="actionText"/> verb pinned to the
         /// right, an accent glow on hover), with the package.json description (when present) wrapping below.
-        /// A not-yet-imported sample (<paramref name="imported"/> is <see langword="false"/>) is flagged by a
-        /// small brand-blue dot ahead of the title — the unread-marker idiom; an imported one drops the dot and
-        /// its destructive verb hovers in the error tone. <see langword="null"/> means the state doesn't apply
+        /// A state dot ahead of the title carries <paramref name="imported"/>: brand-blue while the sample is
+        /// not imported yet (the unread-marker idiom), green once it is; an imported card's destructive verb
+        /// also hovers in the error tone. <see langword="null"/> drops the dot — the state doesn't apply
         /// (local, non-UPM samples).
         /// </summary>
         private static VisualElement CreateSampleCard(
@@ -258,12 +259,16 @@ namespace Aspid.FastTools.Editors
                 .AddClass(SampleInfoClass)
                 .SetPickingMode(PickingMode.Ignore);
 
-            if (imported == false)
+            if (imported.HasValue)
             {
                 // Kept pickable (no click handler — presses bubble through to the header button) so its
                 // tooltip can explain the state.
-                var dot = new VisualElement().AddClass(SampleImportDotClass);
-                dot.tooltip = "Not imported yet";
+                var dot = new VisualElement().AddClass(SampleStateDotClass);
+
+                if (imported.Value)
+                    dot.AddClass(SampleStateDotImportedClass);
+
+                dot.tooltip = imported.Value ? "Imported" : "Not imported yet";
                 info.AddChild(dot);
             }
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
+using System.Collections.Generic;
 using UnityEngine.UIElements;
 using Aspid.FastTools.UIElements;
 using UnityEditor.PackageManager.UI;
@@ -39,8 +40,11 @@ namespace Aspid.FastTools.Editors
 
         private const string LogoName = "welcome-logo";
         private const string ToastName = "welcome-toast";
+        private const string ScrollName = "welcome-scroll";
         private const string SamplesListName = "welcome-samples-list";
         private const string ToastVisibleClass = "aspid-fasttools-welcome__toast--visible";
+
+        private const string NavTargetClass = "aspid-fasttools-welcome__nav-target";
 
         private const string SampleCardClass = "aspid-fasttools-welcome__sample";
         private const string SampleHeaderHoverClass = "aspid-fasttools-welcome__sample--header-hover";
@@ -57,9 +61,15 @@ namespace Aspid.FastTools.Editors
         private const string SampleDescriptionClass = "aspid-fasttools-welcome__sample-description";
 
         private Label _toast;
+        private ScrollView _scroll;
         private VisualElement _samplesList;
         private IVisualElementScheduledItem _toastShow;
         private IVisualElementScheduledItem _toastHide;
+
+        // Keyboard navigation: one flat focus ring over the sample cards' header buttons in list order (hero
+        // links stay mouse-only). -1 means nothing is highlighted.
+        private readonly List<(VisualElement Element, Action Activate)> _navTargets = new();
+        private int _navIndex = -1;
 
         public WelcomeView()
         {
@@ -84,9 +94,113 @@ namespace Aspid.FastTools.Editors
                 _toast.SetPickingMode(PickingMode.Ignore);
             }
 
+            _scroll = this.Q<ScrollView>(ScrollName);
+
             PopulateSamples(this);
             SetUpLogoLink(this);
             SetUpHeroLinks(this);
+
+            // Arrow-key navigation: the view holds keyboard focus (grabbed on attach) so key events reach
+            // OnNavKeyDown even before anything is highlighted; events from focused descendants bubble here too.
+            focusable = true;
+            RegisterCallback<KeyDownEvent>(OnNavKeyDown);
+            RegisterCallback<AttachToPanelEvent>(_ => schedule.Execute(() => Focus()));
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+        // Keyboard navigation
+        // ---------------------------------------------------------------------------------------------------------
+
+        private void OnNavKeyDown(KeyDownEvent evt)
+        {
+            // FunctionKey rides along with arrows on some platforms; any real modifier means the key is not ours.
+            if ((evt.modifiers & ~EventModifiers.FunctionKey) != 0) return;
+
+            switch (evt.keyCode)
+            {
+                case KeyCode.DownArrow:
+                    MoveNavFocus(+1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.UpArrow:
+                    MoveNavFocus(-1);
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Return or KeyCode.KeypadEnter when _navIndex >= 0:
+                    _navTargets[_navIndex].Activate();
+                    evt.StopPropagation();
+                    break;
+
+                case KeyCode.Escape when _navIndex >= 0:
+                    ClearNavFocus();
+                    evt.StopPropagation();
+                    break;
+            }
+        }
+
+        // First press (nothing highlighted) lands on the first sample whichever arrow is hit; after that the
+        // ring clamps at both ends instead of wrapping.
+        private void MoveNavFocus(int delta)
+        {
+            if (_navTargets.Count == 0) return;
+            SetNavFocus(_navIndex < 0 ? 0 : Mathf.Clamp(_navIndex + delta, 0, _navTargets.Count - 1));
+        }
+
+        private void SetNavFocus(int index, bool scrollTo = true)
+        {
+            if (_navIndex == index) return;
+
+            ClearNavFocus();
+            _navIndex = index;
+
+            var element = _navTargets[index].Element;
+            // Sample headers paint their hover in code (accent overlay + tinted labels), so keyboard focus
+            // drives that same programmatic hover instead of a USS focused class.
+            if (element is AspidGradientButton button) button.Highlighted = true;
+            SetHeaderSweep(element, on: true);
+            if (scrollTo) _scroll?.ScrollTo(element);
+        }
+
+        private void ClearNavFocus()
+        {
+            if (_navIndex >= 0 && _navIndex < _navTargets.Count)
+            {
+                var element = _navTargets[_navIndex].Element;
+                if (element is AspidGradientButton button) button.Highlighted = false;
+                SetHeaderSweep(element, on: false);
+            }
+
+            _navIndex = -1;
+        }
+
+        // A focused sample header also lights its card's divider sweep — the same card-level hover mirror the
+        // mouse path drives in CreateSampleCard — so keyboard focus and mouse hover render identically.
+        private static void SetHeaderSweep(VisualElement element, bool on)
+        {
+            if (!element.ClassListContains(SampleHeaderClass)) return;
+
+            for (var ancestor = element.parent; ancestor is not null; ancestor = ancestor.parent)
+            {
+                if (!ancestor.ClassListContains(SampleCardClass)) continue;
+                ancestor.EnableInClassList(SampleHeaderHoverClass, on);
+                return;
+            }
+        }
+
+        // The samples list is rebuilt after every Import/Remove, so the ring is rebuilt with it: sample headers
+        // in list order. Hero links are deliberately not in the ring — they are mouse-only decoration.
+        private void ResetNavTargets()
+        {
+            ClearNavFocus();
+            _navTargets.Clear();
+        }
+
+        private void RegisterNavTarget(VisualElement element, Action activate)
+        {
+            element.AddToClassList(NavTargetClass);
+            _navTargets.Add((element, activate));
         }
 
         private static void SetUpLogoLink(VisualElement root)
@@ -176,17 +290,21 @@ namespace Aspid.FastTools.Editors
         private void RebuildSamplesList()
         {
             if (_samplesList is null) return;
+
+            // An Import/Remove triggered from the keyboard rebuilds the very ring it came from — put the
+            // highlight back on the same slot (clamped: Remove may shrink nothing, but stay safe) so the
+            // keyboard flow continues from where it acted.
+            var keepIndex = _navIndex;
+
             _samplesList.Clear();
+            ResetNavTargets();
 
             var package = PackageInfo.FindForPackageName(PackageName);
-            if (package is not null)
-            {
-                AddUpmSamples(package);
-                return;
-            }
+            if (package is not null) AddUpmSamples(package);
+            else if (AssetDatabase.IsValidFolder(SamplesPath)) AddLocalSamples();
 
-            if (AssetDatabase.IsValidFolder(SamplesPath))
-                AddLocalSamples();
+            if (keepIndex >= 0 && _navTargets.Count > 0)
+                SetNavFocus(Mathf.Min(keepIndex, _navTargets.Count - 1), scrollTo: false);
         }
 
         private void AddUpmSamples(PackageInfo package)
@@ -206,14 +324,12 @@ namespace Aspid.FastTools.Editors
                 // An imported sample's one action is taking the copy back out — deletion is confirmed and the
                 // sample stays reimportable right after, so the direct verb replaces a Reimport/Remove menu.
                 return CreateSampleCard(displayName, description, "Remove",
-                    evt => RemoveSample(captured, displayName, GetMousePosition(evt)),
+                    pointer => RemoveSample(captured, displayName, pointer),
                     imported: true);
             }
 
-            return CreateSampleCard(displayName, description, "Import", imported: false, onClick: evt =>
+            return CreateSampleCard(displayName, description, "Import", imported: false, onClick: pointer =>
             {
-                var pointer = GetMousePosition(evt);
-
                 if (!captured.Import(Sample.ImportOptions.HideImportWindow))
                 {
                     ShowToast($"Failed to import “{displayName}”", pointer);
@@ -233,20 +349,22 @@ namespace Aspid.FastTools.Editors
         /// A state dot ahead of the title carries <paramref name="imported"/>: brand-blue while the sample is
         /// not imported yet (the unread-marker idiom), green once it is; an imported card's destructive verb
         /// also hovers in the error tone. <see langword="null"/> drops the dot — the state doesn't apply
-        /// (local, non-UPM samples).
+        /// (local, non-UPM samples). <paramref name="onClick"/> receives the panel-space anchor for the result
+        /// toast: the cursor on a mouse click, the header's center on a keyboard Enter.
         /// </summary>
-        private static VisualElement CreateSampleCard(
+        private VisualElement CreateSampleCard(
             string displayName,
             string description,
             string actionText,
-            Action<EventBase> onClick,
+            Action<Vector2> onClick,
             bool? imported = null)
         {
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(SampleCardClass);
 
-            var action = new AspidGradientButton(actionText, onClick)
+            var action = new AspidGradientButton(actionText, evt => onClick(GetMousePosition(evt)))
                 .AddClass(SampleHeaderClass);
+            RegisterNavTarget(action, () => onClick(action.worldBound.center));
             if (imported == true)
                 action.AddClass(SampleHeaderRemoveClass);
 
@@ -336,10 +454,10 @@ namespace Aspid.FastTools.Editors
                 var fileName = Path.GetFileName(subfolder);
                 if (string.IsNullOrEmpty(fileName)) continue;
 
-                _samplesList.Add(CreateSampleCard(fileName, null, "Show", evt =>
+                _samplesList.Add(CreateSampleCard(fileName, null, "Show", pointer =>
                 {
                     PingAsset(subfolder);
-                    ShowToast($"“{fileName}” selected in the Project window", GetMousePosition(evt));
+                    ShowToast($"“{fileName}” selected in the Project window", pointer);
                 }));
             }
         }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Welcome/WelcomeView.cs
@@ -28,6 +28,12 @@ namespace Aspid.FastTools.Editors
 
         private const string SamplesPath = PackageRootPath + "/Samples";
         private const string AssetStoreUrl = "https://assetstore.unity.com/packages/slug/365584";
+        private const string GitHubUrl = "https://github.com/VPDPersonal/Aspid.FastTools";
+        private const string DocumentationUrl = GitHubUrl + "/blob/main/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md";
+
+        private const string DocsLinkName = "welcome-link-docs";
+        private const string GitHubLinkName = "welcome-link-github";
+        private const string StoreLinkName = "welcome-link-store";
 
         private const string UxmlResourcePath = "UI/Windows/Welcome/Aspid-FastTools-Welcome";
 
@@ -41,7 +47,9 @@ namespace Aspid.FastTools.Editors
         private const string SampleHeaderRowClass = "aspid-fasttools-welcome__sample-header-row";
         private const string SampleHeaderClass = "aspid-fasttools-welcome__sample-header";
         private const string SampleHeaderRemoveClass = "aspid-fasttools-welcome__sample-header--remove";
+        private const string SampleInfoClass = "aspid-fasttools-welcome__sample-info";
         private const string SampleTitleClass = "aspid-fasttools-welcome__sample-title";
+        private const string SampleImportDotClass = "aspid-fasttools-welcome__sample-import-dot";
         private const string SampleDividerClass = "aspid-fasttools-welcome__sample-divider";
         private const string SampleSweepClass = "aspid-fasttools-welcome__sample-sweep";
         private const string SampleSweepRemoveClass = "aspid-fasttools-welcome__sample-sweep--remove";
@@ -77,12 +85,26 @@ namespace Aspid.FastTools.Editors
 
             PopulateSamples(this);
             SetUpLogoLink(this);
+            SetUpHeroLinks(this);
         }
 
         private static void SetUpLogoLink(VisualElement root)
         {
             var logo = root.Q<AspidAnimatedLogo>(LogoName);
             logo?.AddManipulator(new Clickable(() => Application.OpenURL(AssetStoreUrl)));
+        }
+
+        private static void SetUpHeroLinks(VisualElement root)
+        {
+            SetUpLink(root, DocsLinkName, DocumentationUrl);
+            SetUpLink(root, GitHubLinkName, GitHubUrl);
+            SetUpLink(root, StoreLinkName, AssetStoreUrl);
+        }
+
+        private static void SetUpLink(VisualElement root, string name, string url)
+        {
+            var link = root.Q<Label>(name);
+            link?.AddManipulator(new Clickable(() => Application.OpenURL(url)));
         }
 
         private void ShowToast(string message, Vector2 mousePosition)
@@ -184,10 +206,10 @@ namespace Aspid.FastTools.Editors
                 // sample stays reimportable right after, so the direct verb replaces a Reimport/Remove menu.
                 return CreateSampleCard(displayName, description, "Remove",
                     evt => RemoveSample(captured, displayName, GetMousePosition(evt)),
-                    SampleHeaderRemoveClass);
+                    imported: true);
             }
 
-            return CreateSampleCard(displayName, description, "Import  ▼", evt =>
+            return CreateSampleCard(displayName, description, "Import", imported: false, onClick: evt =>
             {
                 var pointer = GetMousePosition(evt);
 
@@ -207,29 +229,49 @@ namespace Aspid.FastTools.Editors
         /// Builds a sample card in the References group-card idiom: a glass box whose whole header row is one flat
         /// clickable button (the display name on the left, the <paramref name="actionText"/> verb pinned to the
         /// right, an accent glow on hover), with the package.json description (when present) wrapping below.
+        /// A not-yet-imported sample (<paramref name="imported"/> is <see langword="false"/>) is flagged by a
+        /// small brand-blue dot ahead of the title — the unread-marker idiom; an imported one drops the dot and
+        /// its destructive verb hovers in the error tone. <see langword="null"/> means the state doesn't apply
+        /// (local, non-UPM samples).
         /// </summary>
         private static VisualElement CreateSampleCard(
             string displayName,
             string description,
             string actionText,
             Action<EventBase> onClick,
-            string headerModifierClass = null)
+            bool? imported = null)
         {
             var card = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Darkness))
                 .AddClass(SampleCardClass);
 
             var action = new AspidGradientButton(actionText, onClick)
                 .AddClass(SampleHeaderClass);
-            if (!string.IsNullOrEmpty(headerModifierClass))
-                action.AddClass(headerModifierClass);
+            if (imported == true)
+                action.AddClass(SampleHeaderRemoveClass);
 
             // The sweep sits outside the button (riding the divider below), so USS :hover can't reach it —
             // the button mirrors its hover onto a card modifier the sweep rule listens to instead.
             action.RegisterCallback<MouseEnterEvent>(_ => card.AddToClassList(SampleHeaderHoverClass));
             action.RegisterCallback<MouseLeaveEvent>(_ => card.RemoveFromClassList(SampleHeaderHoverClass));
-            action.AddLeadingContent(new Label(displayName)
+
+            var info = new VisualElement()
+                .AddClass(SampleInfoClass)
+                .SetPickingMode(PickingMode.Ignore);
+
+            if (imported == false)
+            {
+                // Kept pickable (no click handler — presses bubble through to the header button) so its
+                // tooltip can explain the state.
+                var dot = new VisualElement().AddClass(SampleImportDotClass);
+                dot.tooltip = "Not imported yet";
+                info.AddChild(dot);
+            }
+
+            info.AddChild(new Label(displayName)
                 .AddClass(SampleTitleClass)
                 .SetPickingMode(PickingMode.Ignore));
+
+            action.AddLeadingContent(info);
 
             var header = new VisualElement()
                 .AddClass(SampleHeaderRowClass)
@@ -244,10 +286,11 @@ namespace Aspid.FastTools.Editors
                         .SetSize(AspidDividingLineSizeStyle.Type.Thin))
                     .AddClass(SampleDividerClass));
 
-                // The accent sweep riding the divider: a hairline that scales in from the left while the card
-                // is hovered (pure USS :hover, see __sample-sweep). Red on a Remove card, brand green otherwise.
+                // The accent sweep riding the divider: a hairline that scales in from the left while the header
+                // button is hovered (via the --header-hover card modifier). Red on an imported (Remove) card,
+                // brand green otherwise.
                 var sweep = new VisualElement().AddClass(SampleSweepClass);
-                if (headerModifierClass == SampleHeaderRemoveClass)
+                if (imported == true)
                     sweep.AddClass(SampleSweepRemoveClass);
                 card.AddChild(sweep);
 

--- a/Aspid.FastTools/ProjectSettings/SerializeReferenceSharedSettings.asset
+++ b/Aspid.FastTools/ProjectSettings/SerializeReferenceSharedSettings.asset
@@ -14,4 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: Aspid.FastTools.Unity.Editor::Aspid.FastTools.SerializeReferences.Editors.SerializeReferenceGateSettings
   _buildSeverity: 1
   _autoDeAlias: 1
-  _excludedFolders: []
+  _excludedFolders:
+  - Assets/DevTests

--- a/docs/QA-CHECKLIST.md
+++ b/docs/QA-CHECKLIST.md
@@ -76,13 +76,16 @@
 - [ ] **Project References — Required violations**: a separate card lists every unset `[TypeSelector(Required = true)]` field found by the same gate scan (asset path + component + field path), skipped entirely when the build/CI gate is Off, respects `Excluded Folders`; clicking a row pings/opens the asset like a broken-reference row (no bulk fix — nothing sensible to auto-assign); only (re)scanned on an explicit Scan/Rescan click, not on a tab switch.
 - [ ] **Settings**: see section 6.
 - [ ] Ctrl+Tab / Ctrl+Shift+Tab switch tabs.
+- [ ] **Keyboard navigation**: ↑/↓ move the focus ring over rows/cards on every tab (Welcome samples, both audits, Settings), Enter activates, Esc drops focus; Welcome hero links stay outside the ring; the Settings Excluded Folders list also takes Enter (add) and Del (remove); the window footer shows the key hints.
+- [ ] **Audit entry affordances**: entry text is selectable/copyable; the row context menu offers Open in Asset References / Open in Prefab Mode / Select in Project; long asset paths elide at the start (the file name stays visible).
+- [ ] **Audit legend & counts**: both audit tabs decode entry colours in the header legend (amber = missing, blue = pending migration) and the headline splits missing / migration / required counts.
 
 ## 6. Settings — three mirrors
 
-> Verify on **each** of the three surfaces: the window's Settings tab, `Preferences → Aspid FastTools`, `Project Settings → Aspid FastTools → SerializeReference` (the last one — References only, native look).
+> Verify on **each** of the three surfaces: the window's Settings tab, `Preferences → Aspid.FastTools` (aggregate page + SerializeReference / Type Selector / Welcome subpages), `Project Settings → Aspid.FastTools → SerializeReference` (the last one — References only, native look).
 
 - [ ] The mirrors sync live (a change on one surface shows on the others), survive dock moves and switch clicks.
-- [ ] Scope stripes (green = ProjectSettings, blue = EditorPrefs) + legend; per-scope Reset to defaults behind a confirm naming the exact defaults; Favorites/Recent survive a reset.
+- [ ] Scope stripes (green = ProjectSettings, blue = EditorPrefs) + the legend in the surface header; per-scope Reset to defaults behind a confirm naming the exact defaults; Favorites/Recent survive a reset.
 - [ ] References: auto de-alias, breakage detection (per-user), gate severity Off/Warn/Fail (shared asset), excluded folders (list + selector).
 - [ ] Type Selector: hide Favorites, Recent capacity, Saved lists maintenance (confirm with counts).
 - [ ] Appearance: theme override StyleSheet (live, per-project), Create template…; Welcome: auto-show.

--- a/docs/QA-CHECKLIST_RU.md
+++ b/docs/QA-CHECKLIST_RU.md
@@ -76,13 +76,16 @@
 - [ ] **Project References — Required violations**: отдельная карточка со всеми незаполненными `[TypeSelector(Required = true)]`-полями из того же gate-скана (путь ассета + компонент + field path), полностью пропускается при выключенном (Off) build/CI gate, учитывает `Excluded Folders`; клик по строке пингует/открывает ассет как строка broken-reference (без bulk-fix — нечего осмысленно назначить автоматически); (пере)сканируется только по явному клику Scan/Rescan, не при переключении вкладки.
 - [ ] **Settings**: см. раздел 6.
 - [ ] Ctrl+Tab / Ctrl+Shift+Tab — переключение вкладок.
+- [ ] **Клавиатурная навигация**: ↑/↓ двигают фокус-кольцо по строкам/карточкам на каждой вкладке (сэмплы Welcome, оба аудита, Settings), Enter активирует, Esc сбрасывает фокус; hero-ссылки Welcome вне кольца; список Excluded Folders в Settings дополнительно принимает Enter (добавить) и Del (удалить); подсказки клавиш — в футере окна.
+- [ ] **Аффордансы записей аудита**: текст записи выделяется/копируется; контекст-меню строки — Open in Asset References / Open in Prefab Mode / Select in Project; длинные пути ассетов элидируются с начала (имя файла остаётся видно).
+- [ ] **Легенда и счётчики аудита**: обе вкладки аудита расшифровывают цвета записей легендой в шапке (янтарный = missing, синий = pending migration), headline раздельно считает missing / migration / required.
 
 ## 6. Settings — три зеркала
 
-> Проверить на **каждой** из трёх поверхностей: вкладка Settings окна, `Preferences → Aspid FastTools`, `Project Settings → Aspid FastTools → SerializeReference` (последняя — только References, нативный вид).
+> Проверить на **каждой** из трёх поверхностей: вкладка Settings окна, `Preferences → Aspid.FastTools` (сводная страница + подстраницы SerializeReference / Type Selector / Welcome), `Project Settings → Aspid.FastTools → SerializeReference` (последняя — только References, нативный вид).
 
 - [ ] Зеркала синхронны live (изменение на одной поверхности видно на другой), переживают dock-move и клики по свитчу.
-- [ ] Scope-полоски (зелёная = ProjectSettings, синяя = EditorPrefs) + легенда; Reset to defaults раздельно per-scope с confirm, называющим дефолты; Favorites/Recent переживают reset.
+- [ ] Scope-полоски (зелёная = ProjectSettings, синяя = EditorPrefs) + легенда в шапке поверхности; Reset to defaults раздельно per-scope с confirm, называющим дефолты; Favorites/Recent переживают reset.
 - [ ] References: auto de-alias, breakage detection (per-user), gate severity Off/Warn/Fail (shared asset), excluded folders (список + селектор).
 - [ ] Type Selector: hide Favorites, Recent capacity, Saved lists maintenance (confirm с количеством).
 - [ ] Appearance: theme override StyleSheet (live, per-project), Create template…; Welcome: auto-show.


### PR DESCRIPTION
**Summary**

- ✨ **Welcome** rebuilt on the glass-card idiom: hero links, sample cards with two-state install markers, unified hover transitions.
- ✨ **Project References / Asset References** brought to one audit design: flat entry rows with absolute dividers, composite headers splitting missing / migration / required counts, a colour legend (amber = missing, blue = pending migration).
- ✨ **Keyboard navigation on every tab**: ↑/↓ move a focus ring over rows/cards, Enter activates, Esc drops focus; the Excluded Folders list also takes Enter/Del; key hints live in the window footer.
- ✨ Audit entries got real affordances: selectable/copyable text, a context menu (Open in Asset References / Open in Prefab Mode / Select in Project), start-elided asset paths so the file name stays visible.
- ♻️ **Settings** tab rebuilt on the window design system (static card headers, flat rows, custom scrollbar, notes); the Unity-native pages restructured under `Preferences → Aspid.FastTools` with SerializeReference / Type Selector / Welcome subpages.
- 🎨 **TypeSelector picker** chrome tied to the card accents: hover/selection fills, row dividers, search-border accent.
- 📝 QA checklists (EN + RU) extended with the new behaviours; settings paths updated.

**Notes for review**

- ⚠️ Editor-only UI throughout — no runtime assemblies touched (the lone `SerializeReferenceSharedSettings.asset` diff is a serialized-field touch).
- ♻️ One merge from `main` mid-branch (pipeline tooling update) — its noise is not part of the redesign.

<details>
<summary>🇷🇺 Описание на русском</summary>

**Summary**

- ✨ **Welcome** пересобрана на glass-card-идиоме: hero-ссылки, карточки сэмплов с двухфазным маркером установки, единые hover-переходы.
- ✨ **Project References / Asset References** приведены к единому дизайну аудита: плоские строки с абсолютными разделителями, составные шапки с раздельными счётчиками missing / migration / required, цветовая легенда (янтарный = missing, синий = pending migration).
- ✨ **Клавиатурная навигация на каждой вкладке**: ↑/↓ двигают фокус-кольцо по строкам/карточкам, Enter активирует, Esc сбрасывает фокус; список Excluded Folders также принимает Enter/Del; подсказки клавиш — в футере окна.
- ✨ Записи аудита получили нормальные аффордансы: выделяемый/копируемый текст, контекст-меню (Open in Asset References / Open in Prefab Mode / Select in Project), элизия путей с начала — имя файла всегда видно.
- ♻️ Вкладка **Settings** пересобрана на дизайн-системе окна (статические шапки карточек, плоские строки, кастомный скроллбар, заметки); нативные страницы Unity реструктурированы под `Preferences → Aspid.FastTools` с подстраницами SerializeReference / Type Selector / Welcome.
- 🎨 Хром **TypeSelector-пикера** привязан к акцентам карточек: заливки hover/selection, разделители строк, акцент рамки поиска.
- 📝 QA-чеклисты (EN + RU) дополнены новыми поведениями; пути настроек обновлены.

**Notes for review**

- ⚠️ Только editor-UI — runtime-сборки не тронуты (единственный дифф `SerializeReferenceSharedSettings.asset` — сериализованное поле).
- ♻️ Один merge из `main` посреди ветки (обновление pipeline-тулинга) — его шум не относится к редизайну.

</details>
