### PR TITLE
build(package): fix UPM hygiene gaps from the release audit

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/LICENSE.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vladislav Panin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/LICENSE.md.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7d3ffe7c22994763862585c82540d016
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Documentation/TUTORIAL.md.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Documentation/TUTORIAL.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7928e6bc002645c4be6c4953ec37a449
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Documentation/TUTORIAL_RU.md.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Samples~/Types/Documentation/TUTORIAL_RU.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bfb64cd3a4404de1b21aae769977ef4e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
@@ -5,6 +5,9 @@
   "description": "Unity tools to cut boilerplate \u2014 source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",
   "unity": "6000.0",
   "license": "MIT",
+  "dependencies": {
+    "com.unity.modules.uielements": "1.0.0"
+  },
   "licensesUrl": "https://github.com/VPDPersonal/Aspid.FastTools/blob/main/LICENSE",
   "documentationUrl": "https://github.com/VPDPersonal/Aspid.FastTools/blob/main/README.md",
   "changelogUrl": "https://github.com/VPDPersonal/Aspid.FastTools/blob/main/CHANGELOG.md",


### PR DESCRIPTION
Release-readiness audit fixes for the UPM package itself — nothing here changes code behavior.

## Summary

- 📄 Ship the MIT license text inside the package (`LICENSE.md` + `.meta`): publish branches distribute the package without the repo root `LICENSE`, while MIT requires the license text to accompany every copy.
- 🔧 Add the missing `.meta` files for the Types sample's `TUTORIAL.md` / `TUTORIAL_RU.md` — the only meta-coverage gap in the package (the other five samples already have them).
- 📦 Declare built-in module dependencies in `package.json`: `com.unity.modules.uielements` (runtime code is built on `UnityEngine.UIElements`).

## Notes for review

- The module audit covered both runtime assemblies: `Source/` is `noEngineReferences: true`, and `Unity/Runtime/` uses no module-hosted API besides UIElements (`Unity.Profiling`, `Unity.Properties` and `UnsafeUtility` live in core; `Unity.Mathematics` remains an optional `versionDefines` satellite, so it must not be a hard dependency).
- `CHANGELOG.md` for the package is intentionally out of scope — a separate branch owns it.

<details>
<summary>🇷🇺 Описание на русском</summary>

Фиксы аудита релизной готовности самого UPM-пакета — поведение кода не меняется.

## Summary

- 📄 Текст лицензии MIT теперь внутри пакета (`LICENSE.md` + `.meta`): publish-ветки раздают пакет без корневого `LICENSE` репозитория, а MIT требует включать текст лицензии в каждую копию.
- 🔧 Добавлены недостающие `.meta` для `TUTORIAL.md` / `TUTORIAL_RU.md` сэмпла Types — единственный пробел meta-покрытия пакета (у остальных пяти сэмплов они уже есть).
- 📦 В `package.json` объявлены зависимости от встроенных модулей: `com.unity.modules.uielements` (runtime-код целиком построен на `UnityEngine.UIElements`).

## Notes for review

- Аудит модулей покрыл обе runtime-сборки: `Source/` — `noEngineReferences: true`, а `Unity/Runtime/` не использует модульных API кроме UIElements (`Unity.Profiling`, `Unity.Properties` и `UnsafeUtility` живут в core; `Unity.Mathematics` остаётся опциональным сателлитом через `versionDefines`, поэтому жёсткой зависимостью быть не должен).
- `CHANGELOG.md` пакета намеренно вне скоупа — им занимается отдельная ветка.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsVLAxv4eia9yv4TjSaP3G
