### PR TITLE
ci: pin the .NET SDK and harden the release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ env:
   PACKAGE_PATH: Aspid.FastTools/Packages/tech.aspid.fasttools
   CHANGELOG_PATH: CHANGELOG.md
   GENERATORS_SOLUTION_DIR: Aspid.FastTools.Generators
+  ANALYZERS_SOLUTION_DIR: Aspid.FastTools.Analyzers
 
 jobs:
   release:
@@ -110,24 +111,54 @@ jobs:
 
           echo "CHANGELOG section for $VERSION extracted ($(echo "$NOTES" | wc -l) lines)."
 
+      - name: Verify package CHANGELOG is in sync
+        run: |
+          set -euo pipefail
+          PKG_CHANGELOG="$PACKAGE_PATH/CHANGELOG.md"
+          if [[ ! -f "$PKG_CHANGELOG" ]]; then
+            echo "Package CHANGELOG.md does not exist yet; skipping sync check."
+            exit 0
+          fi
+          if ! diff -u "$CHANGELOG_PATH" "$PKG_CHANGELOG"; then
+            echo "::error file=$PKG_CHANGELOG::Package CHANGELOG.md is out of sync with the root $CHANGELOG_PATH. Sync them before releasing."
+            exit 1
+          fi
+          echo "Package CHANGELOG.md matches the root $CHANGELOG_PATH."
+
+      # The test projects target net6.0; the SDK pinned in global.json builds them,
+      # the 6.0 runtime (installed via the 6.0.x SDK) runs them.
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          global-json-file: global.json
+          dotnet-version: '6.0.x'
 
-      - name: Build generators
-        run: dotnet build -c Release
+      # Tests run in Debug on purpose: the Directory.Build.targets deploy of the Roslyn
+      # DLLs into the Unity package is Release-only, so a Debug test run can never
+      # interfere with the DLL freshness verification below.
+      - name: Run generator tests
+        run: dotnet test --nologo
         working-directory: ${{ env.GENERATORS_SOLUTION_DIR }}
 
-      - name: Verify deployed generator DLL is present
+      - name: Run analyzer tests
+        run: dotnet test --nologo
+        working-directory: ${{ env.ANALYZERS_SOLUTION_DIR }}
+
+      # Rebuilding in Release re-deploys both DLLs into the package checkout
+      # (Directory.Build.targets); a clean `git diff` then proves the committed
+      # DLLs were built from the sources being released.
+      - name: Verify committed Roslyn DLLs match sources
         run: |
           set -euo pipefail
-          DEPLOYED="$PACKAGE_PATH/Aspid.FastTools.Generators.dll"
-          if [[ ! -s "$DEPLOYED" ]]; then
-            echo "::error file=$DEPLOYED::Generator DLL is missing from the package. Run 'dotnet build -c Release' in $GENERATORS_SOLUTION_DIR and commit the updated DLL before releasing."
+          dotnet build "$GENERATORS_SOLUTION_DIR/Aspid.FastTools.Generators" -c Release --nologo
+          dotnet build "$ANALYZERS_SOLUTION_DIR/Aspid.FastTools.Analyzers/Aspid.FastTools.Analyzers" -c Release --nologo
+          GENERATORS_DLL="$PACKAGE_PATH/Aspid.FastTools.Generators.dll"
+          ANALYZERS_DLL="$PACKAGE_PATH/Aspid.FastTools.Analyzers.dll"
+          if ! git diff --exit-code -- "$GENERATORS_DLL" "$ANALYZERS_DLL"; then
+            echo "::error::Committed Roslyn DLLs do not match a fresh Release build of the sources. Rebuild with the SDK pinned in global.json ('dotnet build -c Release' in $GENERATORS_SOLUTION_DIR and $ANALYZERS_SOLUTION_DIR) and commit the updated DLLs before releasing."
             exit 1
           fi
-          echo "Deployed generator DLL: $(stat -c '%s bytes' "$DEPLOYED")"
+          echo "Committed Roslyn DLLs match a fresh Release build."
 
       - name: Create and push release tag
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The test projects target net6.0; the 8.0 SDK builds them, the 6.0 runtime runs them.
+      # The test projects target net6.0; the SDK pinned in global.json builds them,
+      # the 6.0 runtime (installed via the 6.0.x SDK) runs them.
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            6.0.x
-            8.0.x
+          global-json-file: global.json
+          dotnet-version: 6.0.x
 
       - name: Run ${{ matrix.name }} tests
         run: dotnet test "${{ matrix.path }}" --nologo

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "disable"
+  }
+}


### PR DESCRIPTION
## Summary

- 🔧 Add a root `global.json` pinning the .NET SDK to **10.0.300** (`rollForward: disable`) so CI and the local machine build the Roslyn DLLs with the identical toolchain; both workflows now install it via setup-dotnet `global-json-file` (6.0.x kept alongside for the net6.0 test runtime).
- ✅ `release.yml` now runs the Generators and Analyzers test suites before tagging — Debug on purpose, so a test run can never touch the shipped Release DLLs.
- 🛡️ Replace the "generator DLL is non-empty" check with a real freshness gate: rebuild both Roslyn projects in Release (`Directory.Build.targets` re-deploys the DLLs into the package) and fail on `git diff --exit-code` over both DLLs. This also finally covers `Aspid.FastTools.Analyzers.dll`, which the release workflow never verified after the analyzer merge (#152).
- 📝 Guard that the package `CHANGELOG.md`, once it exists, is byte-identical to the root `CHANGELOG.md`; the step skips while the package copy doesn't exist.

## Notes for review

- ⚠️ **Merge order: after `build/release-gate-deterministic-dlls`.** Without `<Deterministic>` + `<ContinuousIntegrationBuild>` a rebuild is not byte-reproducible, so the freshness gate would fail on every release (verified locally: today's rebuild produces binary-different DLLs of identical size). After that branch lands, the DLLs need one rebuild + commit with the pinned SDK.
- 📝 The CHANGELOG sync guard stays dormant until `docs/changelog-catchup` adds the package `CHANGELOG.md`, then activates automatically.
- 🔧 Why `rollForward: disable`: setup-dotnet installs exactly the version from `global.json`, while a silent local patch roll-forward (e.g. 10.0.301) would produce byte-different DLLs and a confusing gate failure at release time — better to fail fast at `dotnet` startup.
- ✅ Step order matters: on current `main` the generator deploy is not yet Release-only, so a Debug test run overwrites the package DLL — the subsequent Release rebuild overwrites it again before the diff, keeping the gate correct either way.
- 🧪 `tests.yml` is intentionally still not triggered by tags: `release.yml` now runs both suites itself.

<details>
<summary>🇷🇺 Описание на русском</summary>

### Кратко

- 🔧 Корневой `global.json` пинит .NET SDK **10.0.300** (`rollForward: disable`) — CI и локальная машина собирают Roslyn-DLL одним тулчейном; оба workflow ставят его через setup-dotnet `global-json-file` (6.0.x остаётся для net6.0-рантайма тестов).
- ✅ `release.yml` теперь гоняет тесты Generators и Analyzers до тегирования — намеренно в Debug, чтобы прогон тестов не мог затронуть поставляемые Release-DLL.
- 🛡️ Проверка «DLL генератора непустая» заменена настоящим гейтом свежести: Release-пересборка обоих Roslyn-проектов (`Directory.Build.targets` сам разворачивает DLL в пакет) и `git diff --exit-code` по обеим DLL. Заодно впервые проверяется `Aspid.FastTools.Analyzers.dll`, который релизный workflow не верифицировал после вливания анализаторов (#152).
- 📝 Guard синхронности: `CHANGELOG.md` пакета, как только появится, обязан быть байт-в-байт равен корневому; пока файла нет — шаг пропускается.

### Заметки для ревью

- ⚠️ **Порядок merge: после `build/release-gate-deterministic-dlls`.** Без `<Deterministic>` + `<ContinuousIntegrationBuild>` пересборка не воспроизводима байт-в-байт, и гейт свежести падал бы на каждом релизе (проверено локально: сегодняшняя пересборка даёт бинарно другие DLL того же размера). После merge той ветки DLL нужно один раз пересобрать и закоммитить пиненым SDK.
- 📝 Guard changelog «спит», пока `docs/changelog-catchup` не добавит `CHANGELOG.md` в пакет, затем включается сам.
- 🔧 Почему `rollForward: disable`: setup-dotnet ставит ровно версию из `global.json`, а тихий локальный roll-forward патча дал бы байт-различие DLL и невнятное падение гейта на релизе — лучше падать сразу при запуске `dotnet`.
- ✅ Порядок шагов важен: на текущем `main` деплой генератора ещё не Release-only, и Debug-тесты затирают DLL пакета — последующая Release-пересборка перезаписывает её снова до diff, так что гейт корректен в обоих случаях.
- 🧪 `tests.yml` по-прежнему намеренно не триггерится тегами: `release.yml` теперь сам гоняет оба набора тестов.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsVLAxv4eia9yv4TjSaP3G
