### PR TITLE
fix(types): keep TypeSelector member constraints live in UIToolkit

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeTests.cs
@@ -1,0 +1,32 @@
+using System;
+using NUnit.Framework;
+
+namespace Aspid.FastTools.Types.Editors.Tests
+{
+    /// <summary>
+    /// Guards the implicit <c>SerializableType → Type</c> conversions: a <see langword="null"/> wrapper
+    /// converts to <see langword="null"/> instead of throwing, matching the <c>Type</c> property's
+    /// "resolved type or null" contract.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SerializableTypeTests
+    {
+        [Test]
+        public void ImplicitConversion_NullWrapper_YieldsNull()
+        {
+            SerializableType wrapper = null;
+            Type type = wrapper;
+
+            Assert.IsNull(type);
+        }
+
+        [Test]
+        public void ImplicitConversion_NullGenericWrapper_YieldsNull()
+        {
+            SerializableType<IComparable> wrapper = null;
+            Type type = wrapper;
+
+            Assert.IsNull(type);
+        }
+    }
+}

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeTests.cs.meta
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/SerializableTypeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf27c2ef9a5949efa8936d1cec435fdf

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorConstraintResolverTests.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Tests/Editor/Types/TypeSelectorConstraintResolverTests.cs
@@ -176,5 +176,26 @@ namespace Aspid.FastTools.Types.Editors.Tests
             CollectionAssert.AreEquivalent(new[] { typeof(int), typeof(short) }, result.Types);
             Assert.AreEqual(0, result.Warnings.Count);
         }
+
+        // The live-constraint contract the drawers depend on: Resolve holds no state between calls, so
+        // each call reads the member's CURRENT value — that is what lets the pickers re-resolve while
+        // the inspector is open.
+        [Test]
+        public void MemberValueChange_IsReflectedByTheNextResolve()
+        {
+            var host = new MutableHost { Constraint = typeof(int) };
+            var before = Resolve(nameof(MutableHost.Constraint), host);
+
+            host.Constraint = typeof(long);
+            var after = Resolve(nameof(MutableHost.Constraint), host);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(int) }, before.Types);
+            CollectionAssert.AreEquivalent(new[] { typeof(long) }, after.Types);
+        }
+
+        private sealed class MutableHost
+        {
+            public Type Constraint { get; set; }
+        }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceListAddBehavior.cs
@@ -23,7 +23,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         /// for non-list elements, multi-object selections (handled by the de-alias guard), or when an override is
         /// already present.
         /// </summary>
-        public static void TryInstall(VisualElement elementField, SerializedProperty elementProperty, Type elementType, Type[] baseTypes)
+        /// <remarks>
+        /// The base types come through a provider consulted when the picker opens — a member-referenced
+        /// <c>[TypeSelector]</c> constraint can re-resolve long after the "+" override is installed.
+        /// </remarks>
+        public static void TryInstall(VisualElement elementField, SerializedProperty elementProperty, Type elementType, Func<Type[]> baseTypesProvider)
         {
             if (elementField is null || elementProperty is null) return;
 
@@ -49,7 +53,7 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 if (listView.overridingAddButtonBehavior != null) return;
 
                 listView.overridingAddButtonBehavior = (_, button) =>
-                    OpenAppendPicker(target, arrayPath, elementType, baseTypes, button);
+                    OpenAppendPicker(target, arrayPath, elementType, baseTypesProvider(), button);
             });
         }
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceUIToolkitPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/Drawers/SerializeReferenceUIToolkitPropertyDrawer.cs
@@ -8,9 +8,15 @@ namespace Aspid.FastTools.SerializeReferences.Editors
     internal static class SerializeReferenceUIToolkitPropertyDrawer
     {
         public static VisualElement Draw(string label, SerializedProperty property, params Type[] baseTypes)
+            => Draw(label, property, baseTypes, out _);
+
+        // The out overload hands the created field to callers that keep updating its base types after
+        // creation (live member-referenced constraints — see TypeSelectorPropertyDrawer).
+        internal static VisualElement Draw(string label, SerializedProperty property, Type[] baseTypes, out SerializeReferenceField field)
         {
             label = string.IsNullOrWhiteSpace(label) ? null : label;
-            return new SerializeReferenceField(label, property, baseTypes);
+            field = new SerializeReferenceField(label, property, baseTypes);
+            return field;
         }
     }
 }

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/SerializeReferences/VisualElements/SerializeReferenceField.cs
@@ -89,8 +89,11 @@ namespace Aspid.FastTools.SerializeReferences.Editors
         private readonly VisualElement _notices;
         private readonly SerializedProperty _property;
         private readonly Type _fieldType;
-        private readonly Type[] _baseTypes;
-        private readonly Func<Type, bool> _filter;
+
+        // Mutable on purpose: a [TypeSelector] member-referenced constraint re-resolves while the
+        // inspector is open and replaces both through SetBaseTypes.
+        private Type[] _baseTypes;
+        private Func<Type, bool> _filter;
 
         private SerializeReferenceNotice _missingNotice;
         private SerializeReferenceNotice _sharedNotice;
@@ -189,9 +192,10 @@ namespace Aspid.FastTools.SerializeReferences.Editors
             RegisterDragAndDrop(toggle);
 
             // When this field is a list element, replace the list's "+" with a picker-backed add (kills duplicate-last
-            // rid aliasing at the source). Installed on attach, once per ListView.
+            // rid aliasing at the source). Installed on attach, once per ListView; the provider is consulted when the
+            // picker opens, so the append picker honours a constraint re-resolved after installation.
             RegisterCallback<AttachToPanelEvent>(_ =>
-                SerializeReferenceListAddBehavior.TryInstall(this, _property, _fieldType, _baseTypes));
+                SerializeReferenceListAddBehavior.TryInstall(this, _property, _fieldType, () => _baseTypes));
 
             this.AddChild(_foldout);
 
@@ -220,6 +224,16 @@ namespace Aspid.FastTools.SerializeReferences.Editors
                 Undo.undoRedoPerformed -= OnUndoRedo;
                 LiveFields.Remove(this);
             });
+        }
+
+        /// <summary>
+        /// Replaces the base-type constraint after construction, so a re-resolved <c>[TypeSelector]</c>
+        /// member reference narrows every picker this field spawns from now on.
+        /// </summary>
+        internal void SetBaseTypes(Type[] baseTypes)
+        {
+            _baseTypes = baseTypes;
+            _filter = SerializeReferenceHelpers.BuildAssignableFilter(baseTypes);
         }
 
         // The arrow sits in-flow before the aligned label, so the dropdown overshoots the value column by the

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeSelectorPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeSelectorPropertyDrawer.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEditor;
 using UnityEngine;
+using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 using System.Collections.Generic;
 using Aspid.FastTools.UIElements;
@@ -35,20 +36,48 @@ namespace Aspid.FastTools.Types.Editors
 
         public override VisualElement CreatePropertyGUI(SerializedProperty property)
         {
-            var field = CreateField(property);
+            var field = CreateField(property, out var applyResolvedTypes);
 
-            var warnings = GetConstraintWarnings(property);
-            if (warnings.Count == 0) return field;
+            // Without string arguments the constraint is static — nothing to re-resolve, no warnings possible.
+            var typeSelectorAttribute = (TypeSelectorAttribute)attribute;
+            if (typeSelectorAttribute.AssemblyQualifiedNames.Length is 0) return field;
 
             var container = new VisualElement().AddChild(field);
             var notice = new SerializeReferenceNotice();
-            notice.Set(
-                message: GetNoticeMessage(warnings),
-                actionText: string.Empty,
-                detail: GetNoticeDetail(warnings),
-                onAction: null);
 
-            return container.AddChild(notice);
+            // A string argument may reference a member of the target object whose value changes while the
+            // inspector is open; every change to the object re-resolves the constraint and pushes the fresh
+            // base types and warnings into the field (the IMGUI path re-resolves per OnGUI instead).
+            container.TrackSerializedObjectValue(property.serializedObject, OnSerializedObjectChanged);
+            UpdateNotice();
+
+            return container;
+
+            void OnSerializedObjectChanged(SerializedObject serializedObject)
+            {
+                if (serializedObject.targetObject == null) return;
+
+                applyResolvedTypes();
+                UpdateNotice();
+            }
+
+            void UpdateNotice()
+            {
+                var warnings = _constraintWarnings;
+                if (warnings.Count == 0)
+                {
+                    notice.RemoveFromHierarchy();
+                    return;
+                }
+
+                notice.Set(
+                    message: GetNoticeMessage(warnings),
+                    actionText: string.Empty,
+                    detail: GetNoticeDetail(warnings),
+                    onAction: null);
+
+                if (notice.parent is null) container.AddChild(notice);
+            }
         }
 
         private void DrawField(Rect position, SerializedProperty property, GUIContent label)
@@ -84,32 +113,46 @@ namespace Aspid.FastTools.Types.Editors
                 types: GetTypesFromAttribute(property));
         }
 
-        private VisualElement CreateField(SerializedProperty property)
+        // applyResolvedTypes re-resolves the constraint and pushes the result into the created field,
+        // so member-referenced base types stay live while the inspector is open (see CreatePropertyGUI).
+        private VisualElement CreateField(SerializedProperty property, out Action applyResolvedTypes)
         {
             if (TryGetSerializableTypeContainer(property, out var nameProperty, out var genericBaseType))
             {
-                return TypeUIToolkitPropertyDrawer.Draw(
+                var element = TypeUIToolkitPropertyDrawer.Draw(
                     label: preferredLabel,
                     property: nameProperty,
                     allow: GetTypeAllow(),
-                    types: GetSerializableTypeBaseTypes(property, genericBaseType));
+                    types: GetSerializableTypeBaseTypes(property, genericBaseType),
+                    field: out var containerTypeField);
+
+                applyResolvedTypes = () => containerTypeField.Types = GetSerializableTypeBaseTypes(property, genericBaseType);
+                return element;
             }
 
             ThrowExceptionIfInvalidProperty(property);
 
             if (property.propertyType == SerializedPropertyType.ManagedReference)
             {
-                return SerializeReferenceUIToolkitPropertyDrawer.Draw(
+                var element = SerializeReferenceUIToolkitPropertyDrawer.Draw(
                     label: preferredLabel,
                     property: property,
-                    baseTypes: GetTypesFromAttribute(property));
+                    baseTypes: GetTypesFromAttribute(property),
+                    field: out var referenceField);
+
+                applyResolvedTypes = () => referenceField.SetBaseTypes(GetTypesFromAttribute(property));
+                return element;
             }
 
-            return TypeUIToolkitPropertyDrawer.Draw(
+            var stringElement = TypeUIToolkitPropertyDrawer.Draw(
                 label: preferredLabel,
                 property: property,
                 allow: GetTypeAllow(),
-                types: GetTypesFromAttribute(property));
+                types: GetTypesFromAttribute(property),
+                field: out var stringTypeField);
+
+            applyResolvedTypes = () => stringTypeField.Types = GetTypesFromAttribute(property);
+            return stringElement;
         }
 
         private float GetFieldHeight(SerializedProperty property)
@@ -171,14 +214,16 @@ namespace Aspid.FastTools.Types.Editors
 
             if (typeSelectorAttribute.AssemblyQualifiedNames.Length is 0)
             {
-                _constraintWarnings ??= Array.Empty<string>();
+                _constraintWarnings = Array.Empty<string>();
                 return Array.Empty<Type>();
             }
 
             var resolution = TypeSelectorConstraintResolver.Resolve(
                 property.serializedObject.targetObject, typeSelectorAttribute.AssemblyQualifiedNames);
 
-            _constraintWarnings ??= resolution.Warnings;
+            // Overwrite (never ??=): a member-referenced constraint re-resolves while the inspector is
+            // open, and the warnings must follow the latest resolution rather than freeze on the first.
+            _constraintWarnings = resolution.Warnings;
             return resolution.Types;
         }
 

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeUIToolkitPropertyDrawer.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Editor/Scripts/Types/Drawers/TypeUIToolkitPropertyDrawer.cs
@@ -16,10 +16,20 @@ namespace Aspid.FastTools.Types.Editors
             SerializedProperty property,
             TypeAllow allow = TypeAllow.All,
             params Type[] types)
+            => Draw(label, property, allow, types, out _);
+
+        // The out overload hands the created field to callers that keep updating its Types after
+        // creation (live member-referenced constraints — see TypeSelectorPropertyDrawer).
+        internal static VisualElement Draw(
+            string label,
+            SerializedProperty property,
+            TypeAllow allow,
+            Type[] types,
+            out InspectorTypeField field)
         {
             label = string.IsNullOrWhiteSpace(label) ? null : label;
 
-            var field = new InspectorTypeField(label, property)
+            field = new InspectorTypeField(label, property)
             {
                 Allow = allow,
                 Types = types,

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Unity/Runtime/Types/SerializableType.cs
@@ -53,8 +53,9 @@ namespace Aspid.FastTools.Types
 
         /// <summary>
         /// Resolves and returns the wrapped type; equivalent to <see cref="Type"/>.
+        /// A <see langword="null"/> wrapper converts to <see langword="null"/>.
         /// </summary>
-        public static implicit operator Type?(SerializableType type) => type.Type;
+        public static implicit operator Type?(SerializableType? type) => type?.Type;
 
         void ISerializationCallbackReceiver.OnAfterDeserialize() =>
             _type = null;
@@ -118,8 +119,9 @@ namespace Aspid.FastTools.Types
 
         /// <summary>
         /// Resolves and returns the wrapped type; equivalent to <see cref="Type"/>.
+        /// A <see langword="null"/> wrapper converts to <see langword="null"/>.
         /// </summary>
-        public static implicit operator Type?(SerializableType<T> type) => type.Type;
+        public static implicit operator Type?(SerializableType<T>? type) => type?.Type;
 
         void ISerializationCallbackReceiver.OnAfterDeserialize() =>
             _type = null;


### PR DESCRIPTION
Member-referenced `[TypeSelector]` constraints promise to narrow another field's picker **live in the Inspector** (`Documentation/EN/Types.md`, QA checklist item "editing the member updates the constraint *(2×UI)*"). The UIToolkit drawer — Unity's **default** inspector — resolved the constraint once in `CreatePropertyGUI` and baked the result into the created field, so edits of the referenced member never reached the picker until the inspector was rebuilt. The IMGUI path re-resolved every `OnGUI`, but froze its inline warnings with `??=` after the first resolve.

**Fix design:** `TypeSelectorPropertyDrawer` becomes the liveness orchestrator — it registers `TrackSerializedObjectValue` on the inspected object and, on every change, re-resolves the constraint and pushes the fresh base types into the concrete field, while the inline warnings notice updates, appears, or disappears with the latest resolution.

- 🐛 UIToolkit: `InspectorTypeField.Types` is refreshed on every object change (the picker reads it at open); `SerializeReferenceField` gains an internal `SetBaseTypes` refreshing both the constraint and its assignable filter
- 🐛 The list "+" append picker reads the constraint through a provider at open time instead of the array captured when the override was installed
- 🐛 IMGUI: inline warnings re-evaluate on every resolve (`??=` → `=`) instead of freezing on the first
- 🐛 Runtime: implicit `SerializableType` / `SerializableType<T>` → `Type` conversions no longer throw NRE on a `null` wrapper (`type?.Type`, honouring the `Type` property's "or null" contract)
- ✅ Tests: resolver statelessness contract the fix rests on (a member value change is reflected by the next resolve) + null-wrapper conversion tests

**Notes for review**

- ⚠️ Authored in an isolated worktree without a Unity Library — **EditMode tests will be run in the live editor before merge**.
- ♻️ Cost: re-resolution runs per *change* of the serialized object (reflection member lookup), cheaper than the IMGUI path's per-`OnGUI` resolve that was already the accepted norm.
- A constraint member that is a non-serialized C# property still refreshes only on the next serialized change in UIToolkit; IMGUI keeps its per-frame resolve.

<details>
<summary>🇷🇺 Описание на русском</summary>

Member-reference констрейнты `[TypeSelector]` обещают сужать пикер другого поля **живьём в инспекторе** (`Documentation/EN/Types.md`, пункт QA-чек-листа «editing the member updates the constraint *(2×UI)*»). UIToolkit-дровер — **дефолтный** инспектор Unity — резолвил констрейнт один раз в `CreatePropertyGUI` и запекал результат в созданное поле: правки члена-источника не доходили до пикера до пересоздания инспектора. IMGUI-путь резолвил на каждый `OnGUI`, но замораживал inline-предупреждения через `??=` после первого резолва.

**Дизайн фикса:** `TypeSelectorPropertyDrawer` становится оркестратором живости — вешает `TrackSerializedObjectValue` на инспектируемый объект и при каждом изменении пере-резолвит констрейнт, проталкивая свежие базовые типы в конкретное поле; inline-предупреждение обновляется, появляется и исчезает по последнему резолву.

- 🐛 UIToolkit: `InspectorTypeField.Types` обновляется при каждом изменении объекта (пикер читает его при открытии); у `SerializeReferenceField` появился internal `SetBaseTypes`, обновляющий и констрейнт, и фильтр совместимости
- 🐛 «+»-пикер списка читает констрейнт через провайдер в момент открытия, а не массив, захваченный при установке оверрайда
- 🐛 IMGUI: inline-предупреждения переоцениваются при каждом резолве (`??=` → `=`) вместо заморозки на первом
- 🐛 Runtime: implicit-конверсии `SerializableType` / `SerializableType<T>` → `Type` больше не кидают NRE на `null`-обёртке (`type?.Type` — по контракту свойства `Type` «or null»)
- ✅ Тесты: контракт незамороженности резолвера, на котором держится фикс, + тесты конверсии null-обёртки

**Заметки для ревью**

- ⚠️ Ветка написана в изолированном worktree без Unity Library — **EditMode-тесты будут прогнаны в живом редакторе перед merge**.
- ♻️ Цена: пере-резолв выполняется на *изменение* сериализованного объекта (reflection-поиск члена) — дешевле принятой нормы IMGUI-пути (резолв на каждый `OnGUI`).
- Член-источник, являющийся несериализуемым C#-свойством, в UIToolkit обновляется только при следующем сериализованном изменении; IMGUI сохраняет по-кадровый резолв.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsVLAxv4eia9yv4TjSaP3G
