### PR TITLE
chore: release 1.0.0-rc.6

### DIFF
--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/CHANGELOG.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.6] — 2026-08-06
+
 This release is centred on the **SerializeReference toolchain**: `[TypeSelector]` now drives managed-reference and `SerializableType` fields, a repair/diagnostics workbench finds and fixes missing managed references project-wide, and a build/CI gate keeps them out of builds.
 
 > Unless noted otherwise, every inspector feature below works in **both IMGUI and UIToolkit** inspectors.
@@ -283,7 +285,8 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 [#147]: https://github.com/VPDPersonal/Aspid.FastTools/pull/147
 [#148]: https://github.com/VPDPersonal/Aspid.FastTools/pull/148
 [#150]: https://github.com/VPDPersonal/Aspid.FastTools/pull/150
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.6...HEAD
+[1.0.0-rc.6]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...v1.0.0-rc.3

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/EN/README.md
@@ -63,7 +63,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Specific preview versions use the same per-release tag scheme:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.6
 ```
 
 </details>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/Documentation/RU/README.md
@@ -63,7 +63,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Конкретные preview-версии используют ту же схему per-release тегов:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.6
 ```
 
 </details>

--- a/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
+++ b/Aspid.FastTools/Packages/tech.aspid.fasttools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tech.aspid.fasttools",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "displayName": "Aspid.FastTools",
   "description": "Unity tools to cut boilerplate \u2014 source-generated ProfilerMarkers, serializable type/enum/ID systems, and a fluent UIToolkit API.",
   "unity": "6000.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.6] — 2026-08-06
+
 This release is centred on the **SerializeReference toolchain**: `[TypeSelector]` now drives managed-reference and `SerializableType` fields, a repair/diagnostics workbench finds and fixes missing managed references project-wide, and a build/CI gate keeps them out of builds.
 
 > Unless noted otherwise, every inspector feature below works in **both IMGUI and UIToolkit** inspectors.
@@ -283,7 +285,8 @@ Five installable samples shipped under `Samples~/` (UPM convention, imported via
 [#147]: https://github.com/VPDPersonal/Aspid.FastTools/pull/147
 [#148]: https://github.com/VPDPersonal/Aspid.FastTools/pull/148
 [#150]: https://github.com/VPDPersonal/Aspid.FastTools/pull/150
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.6...HEAD
+[1.0.0-rc.6]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...v1.0.0-rc.3

--- a/CHANGELOG_RU.md
+++ b/CHANGELOG_RU.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.6] — 2026-08-06
+
 Этот релиз сосредоточен на **инструментарии SerializeReference**: `[TypeSelector]` теперь работает с managed-reference-полями и `SerializableType`, workbench диагностики и починки находит и исправляет потерянные managed-ссылки по всему проекту, а build/CI-гейт не пропускает их в сборки.
 
 > Если не указано иное, каждая инспекторная фича ниже работает **и в IMGUI-, и в UIToolkit-инспекторе**.
@@ -283,7 +285,8 @@
 [#147]: https://github.com/VPDPersonal/Aspid.FastTools/pull/147
 [#148]: https://github.com/VPDPersonal/Aspid.FastTools/pull/148
 [#150]: https://github.com/VPDPersonal/Aspid.FastTools/pull/150
-[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...HEAD
+[Unreleased]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.6...HEAD
+[1.0.0-rc.6]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/VPDPersonal/Aspid.FastTools/compare/v1.0.0-rc.2...v1.0.0-rc.3

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Specific preview versions use the same per-release tag scheme:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.6
 ```
 
 </details>

--- a/README_RU.md
+++ b/README_RU.md
@@ -68,7 +68,7 @@ https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview
 Конкретные preview-версии используют ту же схему per-release тегов:
 
 ```
-https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.5
+https://github.com/VPDPersonal/Aspid.FastTools.git#upm-preview/1.0.0-rc.6
 ```
 
 </details>


### PR DESCRIPTION
## Summary

Release commit for **1.0.0-rc.6** — этап rc.6 из двухэтапного плана выпуска (`docs/RELEASE-CHECKLIST.md`): пре-релиз со всеми фиксами релизного аудита (#163, #164, #165, #166, #167, #168, #169) перед полным ручным QA-прогоном и стабильной 1.0.0.

- `package.json`: `1.0.0-rc.5` → `1.0.0-rc.6`
- CHANGELOG (EN/RU): секция `[Unreleased]` → `[1.0.0-rc.6] — 2026-08-06`, compare-ссылки обновлены, копия внутри пакета синхронизирована побайтово
- 4 README: закреплённый install-URL → `#upm-preview/1.0.0-rc.6`

После merge: тег `v1.0.0-rc.6` → `release.yml` публикует GitHub Release и обновляет `upm-preview` (первый прогон нового гейта свежести DLL из #167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsVLAxv4eia9yv4TjSaP3G